### PR TITLE
CI: fix cancellation of test runs when pushing commits on PR

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -135,7 +135,11 @@ env:
   TINYBIRD_PYTEST_ARGS: "${{ github.repository == 'localstack/localstack' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) && '--report-to-tinybird ' || '' }}"
   DOCKER_PULL_SECRET_AVAILABLE: ${{ secrets.DOCKERHUB_PULL_USERNAME != '' && secrets.DOCKERHUB_PULL_TOKEN != '' && 'true' || 'false' }}
 
-
+# Only one pull-request triggered run should be executed at a time
+# (head_ref is only set for PR events, otherwise fallback to run_id which differs for every run).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working on some PRs, I realized I got some tests results coming back positive/negative even tough I had pushed more commits. 

This is because we were not cancelling already running workflows for one PR when pushing more commits.
This should maybe free up a some runners, and also reduce the amount of minutes used. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add `cancel-in-progress` for PR based on the ref / run-id


completes FLC-37

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
