### PR TITLE
S3: fix PutBucketTagging and PutObjectTagging when `TagSet` is `None`

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -3220,12 +3220,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if "TagSet" not in tagging:
             raise MalformedXML()
 
-        validate_tag_set(tagging["TagSet"], type_set="object")
+        tag_set = tagging["TagSet"] or []
+        validate_tag_set(tag_set, type_set="object")
 
         key_id = get_unique_key_id(bucket, key, s3_object.version_id)
         # remove the previous tags before setting the new ones, it overwrites the whole TagSet
         store.TAGS.tags.pop(key_id, None)
-        store.TAGS.tag_resource(key_id, tags=tagging["TagSet"])
+        store.TAGS.tag_resource(key_id, tags=tag_set)
         response = PutObjectTaggingOutput()
         if s3_object.version_id:
             response["VersionId"] = s3_object.version_id

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -3166,11 +3166,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if "TagSet" not in tagging:
             raise MalformedXML()
 
-        validate_tag_set(tagging["TagSet"], type_set="bucket")
+        tag_set = tagging["TagSet"] or []
+        validate_tag_set(tag_set, type_set="bucket")
 
         # remove the previous tags before setting the new ones, it overwrites the whole TagSet
         store.TAGS.tags.pop(s3_bucket.bucket_arn, None)
-        store.TAGS.tag_resource(s3_bucket.bucket_arn, tags=tagging["TagSet"])
+        store.TAGS.tag_resource(s3_bucket.bucket_arn, tags=tag_set)
 
     def get_bucket_tagging(
         self,

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4708,5 +4708,33 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_bucket_tagging_none_value": {
+    "recorded-date": "02-09-2025, 22:48:59",
+    "recorded-content": {
+      "put-bucket-tags-origin": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-none-tag-set": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "no-such-tag-set": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchTagSet",
+          "Message": "The TagSet does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2167,7 +2167,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_exc": {
-    "recorded-date": "21-01-2025, 18:11:13",
+    "recorded-date": "02-09-2025, 22:43:24",
     "recorded-content": {
       "get-no-bucket-tags": {
         "Error": {
@@ -4687,6 +4687,24 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 501
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_tagging_none_value": {
+    "recorded-date": "02-09-2025, 22:43:06",
+    "recorded-content": {
+      "put-none-tag-set": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-none": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -36,13 +36,28 @@
     "last_validated_date": "2025-01-21T18:11:10+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_exc": {
-    "last_validated_date": "2025-01-21T18:11:13+00:00"
+    "last_validated_date": "2025-09-02T22:43:25+00:00",
+    "durations_in_seconds": {
+      "setup": 1.07,
+      "call": 1.36,
+      "teardown": 0.87,
+      "total": 3.3
+    }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
     "last_validated_date": "2025-01-21T18:11:16+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
     "last_validated_date": "2025-01-21T18:11:22+00:00"
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_tagging_none_value": {
+    "last_validated_date": "2025-09-02T22:43:07+00:00",
+    "durations_in_seconds": {
+      "setup": 1.05,
+      "call": 0.68,
+      "teardown": 0.96,
+      "total": 2.69
+    }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_with_tags": {
     "last_validated_date": "2025-01-21T18:11:19+00:00"

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -50,6 +50,15 @@
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
     "last_validated_date": "2025-01-21T18:11:22+00:00"
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_bucket_tagging_none_value": {
+    "last_validated_date": "2025-09-02T22:49:00+00:00",
+    "durations_in_seconds": {
+      "setup": 1.12,
+      "call": 0.8,
+      "teardown": 0.64,
+      "total": 2.56
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_tagging_none_value": {
     "last_validated_date": "2025-09-02T22:43:07+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While looking at error reports, I've spotted the following:
`exception while calling s3.PutObjectTagging: 'NoneType' object is not iterable`

This could be reproduced by passing a `None` `TagSet` value.

I've added an AWS validated test for `PutObjectTagging` and took the opportunity to also validate `PutBucketTagging`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add 2 AWS validated around `Put*Tagging`
- fix behavior to fallback to an empty list when the TagSet is `None`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
