### PR TITLE
APIGW: fix UpdateResource on root method

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -697,6 +697,9 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     f"Invalid patch path  '{path}' specified for op '{op}'. Please choose supported operations"
                 )
 
+            if moto_resource.parent_id is None:
+                raise BadRequestException(f"Root resource cannot update its {path.strip('/')}.")
+
             if path == "/parentId":
                 value = patch_operation.get("value")
                 future_parent_resource = moto_rest_api.resources.get(value)
@@ -733,7 +736,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     api_resources.pop(current_parent_id)
 
         # add it to the new parent children
-        future_sibling_resources = api_resources[moto_resource.parent_id]
+        future_sibling_resources = api_resources.setdefault(moto_resource.parent_id, [])
         future_sibling_resources.append(resource_id)
 
         response = moto_resource.to_dict()

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -4834,5 +4834,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_update_resource_on_root": {
+    "recorded-date": "03-09-2025, 15:58:00",
+    "recorded-content": {
+      "update-root-path-part": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Root resource cannot update its pathPart."
+        },
+        "message": "Root resource cannot update its pathPart.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-root-parent": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Root resource cannot update its parentId."
+        },
+        "message": "Root resource cannot update its parentId.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -104,6 +104,15 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_update_resource_behaviour": {
     "last_validated_date": "2024-04-15T17:29:08+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiResource::test_update_resource_on_root": {
+    "last_validated_date": "2025-09-03T15:58:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.82,
+      "call": 0.86,
+      "teardown": 0.3,
+      "total": 1.98
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiRestApi::test_create_rest_api_private_type": {
     "last_validated_date": "2025-07-04T16:09:35+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Looking at error logs, I've spotted the following:

```python
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/apigateway/legacy/provider.py", line 796, in update_resource
    future_sibling_resources = api_resources[moto_resource.parent_id]
                               ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '1gynbbaktd'
```

I couldn't really reproduce the issue directly, because we check for the `moto_resource.parent_id` existence a bit higher, but not via the `api_resources`. I've hardened it to use `setdefault` instead, in case of concurrent access/removal, this should be more solid.

When thinking of cases when this could happened, I realized the root method don't have a parent id, and it would fail, so I added a validated test for that and fixed it. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix validation when calling `UpdateResource` on the root resource
- add validated test
- harden `api_resources` access


completes FLC-33

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
