### PR TITLE
Fix misnamed service_name attribute in stores

### DIFF
--- a/localstack-core/localstack/services/stores.py
+++ b/localstack-core/localstack/services/stores.py
@@ -238,7 +238,7 @@ class RegionBundle(dict, Generic[BaseStoreType]):
 
                 store_obj._global = self._global
                 store_obj._universal = self._universal
-                store_obj.service_name = self.service_name
+                store_obj._service_name = self.service_name
                 store_obj._account_id = self.account_id
                 store_obj._region_name = region_name
 

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -86,10 +86,12 @@ class TestStores:
         backend1_eu = sample_stores[account1][eu_region]
         assert backend1_eu._account_id == account1
         assert backend1_eu._region_name == eu_region
+        assert backend1_eu._service_name == "zzz"
 
         backend1_ap = sample_stores[account1][ap_region]
         assert backend1_ap._account_id == account1
         assert backend1_ap._region_name == ap_region
+        assert backend1_ap._service_name == "zzz"
 
         # Ensure region-specific data isolation
         backend1_eu.region_specific_attr.extend([1, 2, 3])


### PR DESCRIPTION
## Motivation

`BaseStore` annotates the service name as `_service_name`, but we are dynamically adding `service_name`.

See https://github.com/localstack/localstack-pro/pull/5186#discussion_r2318454469

## Testing

Updates unit tests