### PR TITLE
fix start error code if container exists but is not running

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -1316,6 +1316,7 @@ def start_infra_in_docker_detached(console, cli_params: dict[str, Any] = None):
     try:
         prepare_docker_start()
     except ContainerRunning as e:
+        # starting in detached mode is idempotent, return if container is already running
         console.print(str(e))
         return
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -140,6 +140,7 @@ class TestCliContainerLifecycle:
         runner.invoke(cli, ["wait", "-t", "180"])
 
         # normal start
+        # - non-idempotent: non-zero exit code + error log if the container is already running
         result = runner.invoke(cli, ["start"])
         assert container_exists(container_client, config.MAIN_CONTAINER_NAME)
         assert result.exit_code == 1
@@ -147,6 +148,7 @@ class TestCliContainerLifecycle:
         assert "is already running" in result.output
 
         # detached start
+        # - idempotent - zero exit code + no error log if the container is already running
         result = runner.invoke(cli, ["start", "-d"])
         assert container_exists(container_client, config.MAIN_CONTAINER_NAME)
         assert result.exit_code == 0


### PR DESCRIPTION
## Motivation
Currently, the CLI does not behave consistently when using the `start` command if a container with the name `localstack-main` already exists:
- `localstack start` fails with a non-zero exit code and directly shows a (cryptic) error message.
- `localstack start -d` does not fail but blocks and shows error stack traces (if `DEBUG=1`)

This PR tries to fix this inconsistency. /cc @joe4dev @skyrpex 

## Changes
- `localstack start` shows a clear error message.
- `localstack start -d` explicitly fails and shows a clear error message.