### PR TITLE
CFNV2: fix community issues after attempted pro fixes

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -273,6 +273,7 @@ jobs:
             events-v1:
                - 'tests/aws/services/events/**'
             cloudformation-v2:
+               - 'localstack-core/localstack/services/cloudformation/**'
                - 'tests/aws/services/cloudformation/**'
             sns-v2:
                - 'tests/aws/services/sns/**' # todo: potentially add more locations (lambda/sqs tests?)

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -60,7 +60,7 @@ from localstack.utils.run import to_str
 from localstack.utils.strings import to_bytes
 from localstack.utils.urls import localstack_host
 
-_AWS_URL_SUFFIX = localstack_host().host_and_port()  # The value in AWS is "amazonaws.com"
+_AWS_URL_SUFFIX = localstack_host().host  # The value in AWS is "amazonaws.com"
 
 _PSEUDO_PARAMETERS: Final[set[str]] = {
     "AWS::Partition",

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -450,7 +450,8 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             prefix = api_match[1]
             host = api_match[2]
             path = api_match[3]
-            value = f"{prefix}{host}/{path}"
+            port = localstack_host().port
+            value = f"{prefix}{host}:{port}/{path}"
             return value
 
         return value

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -563,7 +563,7 @@ class ResourceProviderExecutor:
     @staticmethod
     def try_load_resource_provider(resource_type: str) -> ResourceProvider | None:
         # TODO: unify namespace of plugins
-        if resource_type.startswith("Custom"):
+        if resource_type and resource_type.startswith("Custom"):
             resource_type = "AWS::CloudFormation::CustomResource"
 
         # 1. try to load pro resource provider


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While performing the last minute fixes for the Pro resources in #13045 we found that the v2 community tests were not being run. This meant that some bugs slipped in to the new provider undetected. This was only picked up in #13098.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Correct the test changes determination to include the service code as well as the tests
* Undo a couple of fixes from #13045 that are no longer needed
* Handle the case where during modelling `try_load_resource_provider` is called with a `Nothing` value

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
