### PR TITLE
KMS: AWS-compliant validation for multi-region key replication

### DIFF
--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -85,6 +85,7 @@ from localstack.aws.api.kms import (
     MacAlgorithmSpec,
     MarkerType,
     MultiRegionKey,
+    MultiRegionKeyType,
     NotFoundException,
     NullableBooleanType,
     OriginType,
@@ -503,7 +504,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         # Ensure it's a primary key (covers cases where MultiRegionKeyType might be missing or have other values)
         if (
             source_key.metadata.get("MultiRegionConfiguration", {}).get("MultiRegionKeyType")
-            != "PRIMARY"
+            != MultiRegionKeyType.PRIMARY
         ):
             raise UnsupportedOperationException(
                 "You can only replicate a multi-Region primary key."

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -505,8 +505,8 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             source_key.metadata.get("MultiRegionConfiguration", {}).get("MultiRegionKeyType")
             != "PRIMARY"
         ):
-            raise ValidationException(
-                "The key cannot be replicated because it is not a multi-region primary key."
+            raise UnsupportedOperationException(
+                "You can only replicate a multi-Region primary key."
             )
 
         if key_id in replicate_to_store.keys:

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -500,8 +500,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         replica_region = request.get("ReplicaRegion")
         replicate_to_store = kms_stores[account_id][replica_region]
 
-        # replica keys cannot be replicated.
-        # Ensure it's a primary key (covers cases where MultiRegionKeyType might be missing or have other values)
         if (
             source_key.metadata.get("MultiRegionConfiguration", {}).get("MultiRegionKeyType")
             != MultiRegionKeyType.PRIMARY

--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -493,6 +493,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         account_id = context.account_id
         source_key = self._get_kms_key(account_id, context.region, request.get("KeyId"))
         key_id = source_key.metadata.get("KeyId")
+        key_arn = source_key.metadata.get("Arn")
         if not source_key.metadata.get("MultiRegion"):
             raise UnsupportedOperationException(
                 f"Unable to replicate a non-MultiRegion key {key_id}"
@@ -504,9 +505,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             source_key.metadata.get("MultiRegionConfiguration", {}).get("MultiRegionKeyType")
             != MultiRegionKeyType.PRIMARY
         ):
-            raise UnsupportedOperationException(
-                "You can only replicate a multi-Region primary key."
-            )
+            raise UnsupportedOperationException(f"{key_arn} is not a multi-region primary key.")
 
         if key_id in replicate_to_store.keys:
             raise AlreadyExistsException(

--- a/localstack-core/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack-core/localstack/testing/snapshots/transformer_utility.py
@@ -45,6 +45,10 @@ PATTERN_KEY_ARN = re.compile(
     r"arn:(aws[a-zA-Z-]*)?:([a-zA-Z0-9-_.]+)?:([^:]+)?:(\d{12})?:key/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 )
 
+PATTERN_MRK_KEY_ARN = re.compile(
+    r"arn:(aws[a-zA-Z-]*)?:([a-zA-Z0-9-_.]+)?:([^:]+)?:(\d{12})?:key/mrk-[a-fA-F0-9]{32}"
+)
+
 
 # TODO: split into generic/aws and put into lib
 class TransformerUtility:
@@ -573,6 +577,7 @@ class TransformerUtility:
             TransformerUtility.key_value("CiphertextBlob", reference_replacement=False),
             TransformerUtility.key_value("Plaintext", reference_replacement=False),
             RegexTransformer(PATTERN_KEY_ARN, replacement="<key-arn>"),
+            RegexTransformer(PATTERN_MRK_KEY_ARN, replacement="<mrk-key-arn>"),
         ]
 
     @staticmethod

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2490,6 +2490,7 @@ class TestKMSGenerateKeys:
         kms_replicate_key,
         region_name,
         secondary_region_name,
+        snapshot,
     ):
         """Tes that attempting to replicate a replica key should raise ValidationException"""
         primary_key_id = kms_create_key(
@@ -2509,7 +2510,5 @@ class TestKMSGenerateKeys:
                 KeyId=primary_key_id, ReplicaRegion=secondary_region_name
             )
 
-        # TODO: add validation against AWS snapshot.
-        error = exc_info.value.response["Error"]
-        assert error["Code"] == "ValidationException"
-        assert "not a multi-region primary key" in error["Message"]
+        error = exc_info.value.response
+        snapshot.match("fail-replicate-non-primary-key", error)

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2222,10 +2222,6 @@ class TestKMS:
         snapshot,
     ):
         """Tes that attempting to replicate a replica key should raise ValidationException"""
-        snapshot.add_transformer(
-            snapshot.transform.regex(secondary_region_name, "<secondary-region>")
-        )
-
         primary_key_id = kms_create_key(
             region_name=region_name, MultiRegion=True, Description="test primary key"
         )["KeyId"]
@@ -2234,8 +2230,6 @@ class TestKMS:
             region_from=region_name, KeyId=primary_key_id, ReplicaRegion=secondary_region_name
         )
         replica_key_id = replica_response["ReplicaKeyMetadata"]["KeyId"]
-
-        snapshot.add_transformer(snapshot.transform.regex(replica_key_id, "<key-id:1>"))
 
         # attempt to replicate the replica key from the secondary region
         # This should fail because we're trying to replicate a replica

--- a/tests/aws/services/kms/test_kms.py
+++ b/tests/aws/services/kms/test_kms.py
@@ -2490,7 +2490,7 @@ class TestKMSGenerateKeys:
         kms_replicate_key,
         region_name,
         secondary_region_name,
-        snapshot,
+        # snapshot,  # TODO: needs fixing iam:CreateServiceLinkedRole permission
     ):
         """Tes that attempting to replicate a replica key should raise ValidationException"""
         primary_key_id = kms_create_key(
@@ -2511,4 +2511,8 @@ class TestKMSGenerateKeys:
             )
 
         error = exc_info.value.response
-        snapshot.match("fail-replicate-non-primary-key", error)
+        # TODO: move to snapshot when permission issue is resolved
+        assert error["Error"]["Code"] == "UnsupportedOperationException"
+        assert error["Error"]["Message"] == "You can only replicate a multi-Region primary key."
+        assert error["ResponseMetadata"]["HTTPStatusCode"] == 400
+        # snapshot.match("fail-replicate-non-primary-key", error)

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -3197,14 +3197,14 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_replica_key_should_fail": {
-    "recorded-date": "06-09-2025, 10:00:43",
+    "recorded-date": "08-09-2025, 16:34:57",
     "recorded-content": {
       "fail-replicate-non-primary-key": {
         "Error": {
           "Code": "UnsupportedOperationException",
-          "Message": "arn:<partition>:kms:<secondary-region>:111111111111:key/<key-id:1> is not a multi-region primary key."
+          "Message": "<mrk-key-arn> is not a multi-region primary key."
         },
-        "message": "arn:<partition>:kms:<secondary-region>:111111111111:key/<key-id:1> is not a multi-region primary key.",
+        "message": "<mrk-key-arn> is not a multi-region primary key.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -3195,5 +3195,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_replica_key_should_fail": {
+    "recorded-date": "06-09-2025, 10:00:43",
+    "recorded-content": {
+      "fail-replicate-non-primary-key": {
+        "Error": {
+          "Code": "UnsupportedOperationException",
+          "Message": "arn:<partition>:kms:<secondary-region>:111111111111:key/<key-id:1> is not a multi-region primary key."
+        },
+        "message": "arn:<partition>:kms:<secondary-region>:111111111111:key/<key-id:1> is not a multi-region primary key.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -263,7 +263,7 @@
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_does_not_exist": {
-    "recorded-date": "13-04-2023, 11:29:34",
+    "recorded-date": "08-09-2025, 19:02:52",
     "recorded-content": {
       "describe-nonexistent-key-with-id": {
         "Error": {
@@ -290,9 +290,9 @@
       "describe-key-with-valid-id-mrk": {
         "Error": {
           "Code": "NotFoundException",
-          "Message": "Key 'arn:<partition>:kms:<region>:111111111111:key/mrk-d3b95762d3b95762d3b95762d3b95762' does not exist"
+          "Message": "Key '<mrk-key-arn>' does not exist"
         },
-        "message": "Key 'arn:<partition>:kms:<region>:111111111111:key/mrk-d3b95762d3b95762d3b95762d3b95762' does not exist",
+        "message": "Key '<mrk-key-arn>' does not exist",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -135,7 +135,13 @@
     "last_validated_date": "2024-04-11T15:52:50+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_does_not_exist": {
-    "last_validated_date": "2024-04-11T15:52:32+00:00"
+    "last_validated_date": "2025-09-08T19:02:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.83,
+      "call": 1.5,
+      "teardown": 0.22,
+      "total": 2.55
+    }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_get_key_in_different_region": {
     "last_validated_date": "2024-06-14T13:35:20+00:00"

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -309,12 +309,12 @@
     "last_validated_date": "2024-04-11T15:53:44+00:00"
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_replica_key_should_fail": {
-    "last_validated_date": "2025-09-06T10:00:43+00:00",
+    "last_validated_date": "2025-09-08T16:34:57+00:00",
     "durations_in_seconds": {
-      "setup": 1.05,
-      "call": 2.01,
-      "teardown": 0.38,
-      "total": 3.44
+      "setup": 0.85,
+      "call": 2.29,
+      "teardown": 0.34,
+      "total": 3.48
     }
   },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_retire_grant_with_grant_token": {

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -308,6 +308,15 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_key": {
     "last_validated_date": "2024-04-11T15:53:44+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_replicate_replica_key_should_fail": {
+    "last_validated_date": "2025-09-06T10:00:43+00:00",
+    "durations_in_seconds": {
+      "setup": 1.05,
+      "call": 2.01,
+      "teardown": 0.38,
+      "total": 3.44
+    }
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_retire_grant_with_grant_token": {
     "last_validated_date": "2024-04-11T15:52:46+00:00"
   },


### PR DESCRIPTION
## Motivation

This PR addresses an issue where LocalStack's KMS service was not enforcing AWS KMS behavior regarding multi-region key replication. According to AWS documentation, only [multi-region primary keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#multi-region-concepts) can be used as sources for replication, but LocalStack was allowing both primary and replica keys to be replicated.

## Changes
- **Improved method in `replicate_key` in `KmsProvider`**: Added validation to check that the source key is a multi-region primary key before allowing replication
- **Error handling**: Localstack now returns the exact AWS error message: `UnsupportedOperationException`

### Test coverage
- Added `test_replicate_replica_key_should_fail()` test which verifies that attempting to replicate a replica key is forbidden and throws specific error.

## Testing

The changes can be tested by:
1. Creating a multi-region primary key
2. Replicating it to create a replica key
3. Attempting to replicate the replica key (should fail with `UnsupportedOperationException`)
