### PR TITLE
Support Additional Parameters for S3 UploadPartCopy

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -2477,7 +2477,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # TODO: RequestCharged: Optional[RequestCharged]
         return response
 
-    # AIDEN
     @handler("UploadPartCopy", expand=False)
     def upload_part_copy(
         self,

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -430,15 +430,16 @@ def get_failed_upload_part_copy_source_preconditions(
         # CopySourceIfMatch is unaffected by CopySourceIfUnmodifiedSince so return early
         if if_unmodified_since:
             return None
-        
+
     if if_unmodified_since and if_unmodified_since < last_modified:
         return "x-amz-copy-source-If-Unmodified-Since"
-    
+
     if if_none_match and if_none_match == f'"{etag}"':
         return "x-amz-copy-source-If-None-Match"
 
     if if_modified_since and if_modified_since > last_modified:
         return "x-amz-copy-source-If-Modified-Since"
+
 
 def get_full_default_bucket_location(bucket_name: BucketName) -> str:
     host_definition = localstack_host()

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -410,7 +410,7 @@ def get_failed_upload_part_copy_source_preconditions(
 ) -> str | None:
     """
     Utility which parses the conditions from a S3 UploadPartCopy request.
-    
+
     Few things to note:
     1. Certain conditions are checked first, and take the order of:
         - CopySourceIfMatch -> CopySourceIfUnmodifiedSince -> CopySourceIfNoneMatch
@@ -432,10 +432,10 @@ def get_failed_upload_part_copy_source_preconditions(
         # CopySourceIfMatch is unaffected by CopySourceIfUnmodifiedSince
         if if_unmodified_since:
             return None
-        
+
     if if_unmodified_since and if_unmodified_since < last_modified:
         return "x-amz-copy-source-If-Unmodified-Since"
-    
+
     if if_none_match and if_none_match == f'"{etag}"':
         return "x-amz-copy-source-If-None-Match"
 

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -423,7 +423,7 @@ def get_failed_upload_part_copy_source_preconditions(
     if_modified_since = request.get("CopySourceIfModifiedSince")
 
     if if_match:
-        if if_match != f'"{etag}"':
+        if if_match.strip('"') != etag.strip('"'):
             return "x-amz-copy-source-If-Match"
         if if_modified_since and if_modified_since > last_modified:
             return "x-amz-copy-source-If-Modified-Since"
@@ -434,7 +434,7 @@ def get_failed_upload_part_copy_source_preconditions(
     if if_unmodified_since and if_unmodified_since < last_modified:
         return "x-amz-copy-source-If-Unmodified-Since"
 
-    if if_none_match and if_none_match == f'"{etag}"':
+    if if_none_match and if_none_match.strip('"') == etag.strip('"'):
         return "x-amz-copy-source-If-None-Match"
 
     if if_modified_since and if_modified_since > last_modified:

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -437,7 +437,9 @@ def get_failed_upload_part_copy_source_preconditions(
     if if_none_match and if_none_match.strip('"') == etag.strip('"'):
         return "x-amz-copy-source-If-None-Match"
 
-    if if_modified_since and if_modified_since > last_modified:
+    if if_modified_since and last_modified < if_modified_since < datetime.datetime.now(
+        tz=datetime.UTC
+    ):
         return "x-amz-copy-source-If-Modified-Since"
 
 

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -438,7 +438,7 @@ def get_failed_upload_part_copy_source_preconditions(
         return "x-amz-copy-source-If-None-Match"
 
     if if_modified_since and last_modified < if_modified_since < datetime.datetime.now(
-        tz=datetime.UTC
+        tz=_gmt_zone_info
     ):
         return "x-amz-copy-source-If-Modified-Since"
 

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -404,7 +404,6 @@ def parse_copy_source_range_header(copy_source_range: str, object_size: int) -> 
     )
 
 
-# AIDEN
 def get_failed_upload_part_copy_source_preconditions(
     request: UploadPartCopyRequest, last_modified: datetime.datetime, etag: ETag
 ) -> str | None:

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -424,7 +424,7 @@ def get_failed_upload_part_copy_source_preconditions(
 
     if if_match and if_match != f'"{etag}"':
         # CopySourceIfMatch is unaffected by CopySourceIfModified and CopySourceIfUnmodified.
-        preconditions += "x-amz-copy-source-If-Match"
+        return "x-amz-copy-source-If-Match"
     elif if_none_match:
         # If both CopySourceIfNoneMatch and CopySourceIfUnmodifiedSince, the CopySourceIfUnmodifiedSince condition takes priority.
         if if_unmodified_since and if_unmodified_since < last_modified:

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -660,9 +660,50 @@ class TestS3Multipart:
         )
         snapshot.match("list-parts", list_parts)
 
-    @markers.aws.unknown
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Owner.DisplayName"],
+    )
     def test_upload_part_copy_with_copy_source_if_match_none_success(self, aws_client, s3_bucket, snapshot):
-        pass
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Bucket", reference_replacement=False),
+                snapshot.transform.key_value("Location"),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value("ID", reference_replacement=False),
+                snapshot.transform.key_value("ETag"),
+            ]
+        )
+
+        # Set up the source object.
+        source_key = "source_file.txt"
+        content = "0123456789"
+        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+
+        # Set up the multi-part upload.
+        multi_part_upload_key = "destination_file.txt"
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
+        upload_id = create_multipart_upload["UploadId"]
+
+        # Uploading shouldn't raise an exception
+        upload_part_copy = aws_client.s3.upload_part_copy(
+            Bucket=s3_bucket,
+            UploadId=upload_id,
+            Key=multi_part_upload_key,
+            PartNumber=1,
+            CopySource=f"{s3_bucket}/{source_key}",
+            CopySourceIfNoneMatch="none-match",
+        )
+        snapshot.match("upload-part-copy-if-none-match", upload_part_copy)
+
+        # Check parts were uploaded successfully
+        list_parts = aws_client.s3.list_parts(
+            Bucket=s3_bucket, Key=multi_part_upload_key, UploadId=upload_id
+        )
+        snapshot.match("list-parts", list_parts)
 
     @markers.aws.unknown
     def test_upload_part_copy_with_copy_source_if_unmodified_since_success(self, aws_client, s3_bucket, snapshot):

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -790,7 +790,7 @@ class TestS3Multipart:
             Key=multi_part_upload_key,
             PartNumber=1,
             CopySource=f"{s3_bucket}/{source_key}",
-            CopySourceIfMatch=put_source_object["ETag"], 
+            CopySourceIfMatch=put_source_object["ETag"],
             CopySourceIfUnmodifiedSince=earlier_datetime,
         )
         snapshot.match("upload-part-copy", upload_part_copy)

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -755,7 +755,7 @@ class TestS3Multipart:
         pass
 
     @markers.aws.unknown
-    def test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match(
+    def test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed(
         self, aws_client, s3_bucket, snapshot
     ):
         """

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -13,6 +13,7 @@ from localstack.testing.pytest import markers
 from localstack.utils.strings import long_uid, short_uid
 from tests.aws.services.s3.conftest import TEST_S3_IMAGE
 
+
 class TestS3BucketCRUD:
     @markers.aws.validated
     def test_delete_bucket_with_objects(self, s3_bucket, aws_client, snapshot):
@@ -612,8 +613,11 @@ class TestS3Multipart:
         list_parts = aws_client.s3.list_parts(Bucket=s3_bucket, Key=key, UploadId=upload_id)
         snapshot.match("list-parts", list_parts)
 
+    # AIDEN
     @markers.aws.validated
-    def test_upload_part_copy_with_copy_source_if_match_failed(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_match_failed(
+        self, aws_client, s3_bucket, snapshot
+    ):
         """
         Providing CopySourceIfMatch with an ETag which doesn't match with the specified source key ETag should fail.
         """
@@ -624,7 +628,7 @@ class TestS3Multipart:
                 snapshot.transform.key_value("UploadId"),
                 snapshot.transform.key_value("DisplayName", reference_replacement=False),
                 snapshot.transform.key_value("ID", reference_replacement=False),
-                snapshot.transform.key_value("ETag")
+                snapshot.transform.key_value("ETag"),
             ]
         )
 
@@ -636,18 +640,27 @@ class TestS3Multipart:
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
-        create_multipart_upload = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=multi_part_upload_key)
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
         snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         with pytest.raises(ClientError) as error:
             aws_client.s3.upload_part_copy(
-                Bucket=s3_bucket, UploadId=upload_id, Key=multi_part_upload_key, PartNumber=1, CopySource=f"{s3_bucket}/{source_key}", CopySourceIfMatch="not-matching"
+                Bucket=s3_bucket,
+                UploadId=upload_id,
+                Key=multi_part_upload_key,
+                PartNumber=1,
+                CopySource=f"{s3_bucket}/{source_key}",
+                CopySourceIfMatch="not-matching",
             )
         snapshot.match("upload-part-copy-source-if-match", error.value.response)
 
     @markers.aws.validated
-    def test_upload_part_copy_with_copy_source_if_none_match_failed(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_none_match_failed(
+        self, aws_client, s3_bucket, snapshot
+    ):
         """
         Providing CopySourceIfNoneMatch with an ETag which does match with the specified source key ETag should fail.
         """
@@ -658,7 +671,7 @@ class TestS3Multipart:
                 snapshot.transform.key_value("UploadId"),
                 snapshot.transform.key_value("DisplayName", reference_replacement=False),
                 snapshot.transform.key_value("ID", reference_replacement=False),
-                snapshot.transform.key_value("ETag")
+                snapshot.transform.key_value("ETag"),
             ]
         )
 
@@ -670,19 +683,31 @@ class TestS3Multipart:
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
-        create_multipart_upload = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=multi_part_upload_key)
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
         snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         with pytest.raises(ClientError) as error:
-            # Provide the correct ETag to cause a failure
+            # Provide the correct ETag to cause a failure
             aws_client.s3.upload_part_copy(
-                Bucket=s3_bucket, UploadId=upload_id, Key=multi_part_upload_key, PartNumber=1, CopySource=f"{s3_bucket}/{source_key}", CopySourceIfNoneMatch=put_source_object["ETag"]
+                Bucket=s3_bucket,
+                UploadId=upload_id,
+                Key=multi_part_upload_key,
+                PartNumber=1,
+                CopySource=f"{s3_bucket}/{source_key}",
+                CopySourceIfNoneMatch=put_source_object["ETag"],
             )
         snapshot.match("upload-part-copy-source-if-none-match", error.value.response)
 
     @markers.aws.validated
-    def test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed(
+        self, aws_client, s3_bucket, snapshot
+    ):
+        """
+        Providing CopySourceIfUnmodifiedSince with a datetime where the object has been modified since this datetime should fail.
+        """
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -690,7 +715,7 @@ class TestS3Multipart:
                 snapshot.transform.key_value("UploadId"),
                 snapshot.transform.key_value("DisplayName", reference_replacement=False),
                 snapshot.transform.key_value("ID", reference_replacement=False),
-                snapshot.transform.key_value("ETag")
+                snapshot.transform.key_value("ETag"),
             ]
         )
 
@@ -702,15 +727,22 @@ class TestS3Multipart:
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
-        create_multipart_upload = aws_client.s3.create_multipart_upload(Bucket=s3_bucket, Key=multi_part_upload_key)
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
         snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
-        earlier = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
+        earlier_datetime = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
         with pytest.raises(ClientError) as error:
             # Provide a time earler than it's last modified time which should fail.
             aws_client.s3.upload_part_copy(
-                Bucket=s3_bucket, UploadId=upload_id, Key=multi_part_upload_key, PartNumber=1, CopySource=f"{s3_bucket}/{source_key}", CopySourceIfUnmodifiedSince=earlier
+                Bucket=s3_bucket,
+                UploadId=upload_id,
+                Key=multi_part_upload_key,
+                PartNumber=1,
+                CopySource=f"{s3_bucket}/{source_key}",
+                CopySourceIfUnmodifiedSince=earlier_datetime,
             )
         snapshot.match("upload-part-copy-source-unmodified-since-match", error.value.response)
 
@@ -765,7 +797,9 @@ class TestS3Multipart:
                 CopySourceIfNoneMatch="not-matching",
                 CopySourceIfUnmodifiedSince=earlier_datetime,
             )
-        snapshot.match("upload-part-copy-source-unmodified-since-and-if-none-match", error.value.response)
+        snapshot.match(
+            "upload-part-copy-source-unmodified-since-and-if-none-match", error.value.response
+        )
 
 
 class TestS3BucketVersioning:

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -679,7 +679,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -705,9 +705,51 @@ class TestS3Multipart:
         )
         snapshot.match("list-parts", list_parts)
 
-    @markers.aws.unknown
+    @markers.aws.validated
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Owner.DisplayName"],
+    )
     def test_upload_part_copy_with_copy_source_if_unmodified_since_success(self, aws_client, s3_bucket, snapshot):
-        pass
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Bucket", reference_replacement=False),
+                snapshot.transform.key_value("Location"),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value("ID", reference_replacement=False),
+                snapshot.transform.key_value("ETag"),
+            ]
+        )
+
+        # Set up the source object.
+        source_key = "source_file.txt"
+        content = "0123456789"
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+
+        # Set up the multi-part upload.
+        multi_part_upload_key = "destination_file.txt"
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
+        upload_id = create_multipart_upload["UploadId"]
+
+        # Uploading shouldn't raise an exception
+        later_datetime = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=1)
+        upload_part_copy = aws_client.s3.upload_part_copy(
+            Bucket=s3_bucket,
+            UploadId=upload_id,
+            Key=multi_part_upload_key,
+            PartNumber=1,
+            CopySource=f"{s3_bucket}/{source_key}",
+            CopySourceIfUnmodifiedSince=later_datetime
+        )
+        snapshot.match("upload-part-copy-if-unmodified-since", upload_part_copy)
+
+        # Check parts were uploaded successfully
+        list_parts = aws_client.s3.list_parts(
+            Bucket=s3_bucket, Key=multi_part_upload_key, UploadId=upload_id
+        )
+        snapshot.match("list-parts", list_parts)
 
     @markers.aws.unknown
     def test_upload_part_copy_with_copy_source_if_modified_since_success(self, aws_client, s3_bucket, snapshot):

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -614,7 +614,6 @@ class TestS3Multipart:
         list_parts = aws_client.s3.list_parts(Bucket=s3_bucket, Key=key, UploadId=upload_id)
         snapshot.match("list-parts", list_parts)
 
-    # AIDEN
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -614,6 +614,7 @@ class TestS3Multipart:
         list_parts = aws_client.s3.list_parts(Bucket=s3_bucket, Key=key, UploadId=upload_id)
         snapshot.match("list-parts", list_parts)
 
+    # AIDEN
     @markers.aws.validated
     def test_upload_part_copy_with_copy_source_if_match_failed(
         self, aws_client, s3_bucket, snapshot
@@ -635,15 +636,13 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
-        snapshot.match("put-src-object", put_source_object)
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
         create_multipart_upload = aws_client.s3.create_multipart_upload(
             Bucket=s3_bucket, Key=multi_part_upload_key
         )
-        snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         with pytest.raises(ClientError) as error:
@@ -679,14 +678,12 @@ class TestS3Multipart:
         source_key = "source_file.txt"
         content = "0123456789"
         put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
-        snapshot.match("put-src-object", put_source_object)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
         create_multipart_upload = aws_client.s3.create_multipart_upload(
             Bucket=s3_bucket, Key=multi_part_upload_key
         )
-        snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         with pytest.raises(ClientError) as error:
@@ -722,15 +719,13 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
-        snapshot.match("put-src-object", put_source_object)
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
         create_multipart_upload = aws_client.s3.create_multipart_upload(
             Bucket=s3_bucket, Key=multi_part_upload_key
         )
-        snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         earlier_datetime = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
@@ -772,14 +767,12 @@ class TestS3Multipart:
         source_key = "source_file.txt"
         content = "0123456789"
         put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
-        snapshot.match("put-src-object", put_source_object)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
         create_multipart_upload = aws_client.s3.create_multipart_upload(
             Bucket=s3_bucket, Key=multi_part_upload_key
         )
-        snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         # Uploading shouldn't raise an exception
@@ -822,15 +815,13 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
-        snapshot.match("put-src-object", put_source_object)
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
         create_multipart_upload = aws_client.s3.create_multipart_upload(
             Bucket=s3_bucket, Key=multi_part_upload_key
         )
-        snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         earlier_datetime = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
@@ -864,15 +855,13 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
-        snapshot.match("put-src-object", put_source_object)
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
         create_multipart_upload = aws_client.s3.create_multipart_upload(
             Bucket=s3_bucket, Key=multi_part_upload_key
         )
-        snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
         # Don't do this, but required for behaviour with CopySourceIfModifiedSince which will pass if a future time is provided.

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -613,7 +613,6 @@ class TestS3Multipart:
         list_parts = aws_client.s3.list_parts(Bucket=s3_bucket, Key=key, UploadId=upload_id)
         snapshot.match("list-parts", list_parts)
 
-    # AIDEN
     @markers.aws.validated
     def test_upload_part_copy_with_copy_source_if_match_failed(
         self, aws_client, s3_bucket, snapshot

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -618,7 +618,9 @@ class TestS3Multipart:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],
     )
-    def test_upload_part_copy_with_copy_source_if_match_success(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_match_success(
+        self, aws_client, s3_bucket, snapshot
+    ):
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -663,7 +665,9 @@ class TestS3Multipart:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],
     )
-    def test_upload_part_copy_with_copy_source_if_match_none_success(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_match_none_success(
+        self, aws_client, s3_bucket, snapshot
+    ):
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -678,7 +682,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -708,7 +712,9 @@ class TestS3Multipart:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],
     )
-    def test_upload_part_copy_with_copy_source_if_unmodified_since_success(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_unmodified_since_success(
+        self, aws_client, s3_bucket, snapshot
+    ):
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -723,7 +729,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -740,7 +746,7 @@ class TestS3Multipart:
             Key=multi_part_upload_key,
             PartNumber=1,
             CopySource=f"{s3_bucket}/{source_key}",
-            CopySourceIfUnmodifiedSince=later_datetime
+            CopySourceIfUnmodifiedSince=later_datetime,
         )
         snapshot.match("upload-part-copy-if-unmodified-since", upload_part_copy)
 
@@ -754,7 +760,9 @@ class TestS3Multipart:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],
     )
-    def test_upload_part_copy_with_copy_source_if_modified_since_success(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_modified_since_success(
+        self, aws_client, s3_bucket, snapshot
+    ):
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -769,7 +777,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -786,7 +794,7 @@ class TestS3Multipart:
             Key=multi_part_upload_key,
             PartNumber=1,
             CopySource=f"{s3_bucket}/{source_key}",
-            CopySourceIfModifiedSince=earlier_datetime
+            CopySourceIfModifiedSince=earlier_datetime,
         )
         snapshot.match("upload-part-copy-if-modified-since", upload_part_copy)
 
@@ -800,7 +808,9 @@ class TestS3Multipart:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],
     )
-    def test_upload_part_copy_with_copy_source_if_modified_since_in_future_success(self, aws_client, s3_bucket, snapshot):
+    def test_upload_part_copy_with_copy_source_if_modified_since_in_future_success(
+        self, aws_client, s3_bucket, snapshot
+    ):
         """
         Providing CopyIfModifiedSince with a datetime which is in the future will always pass (even though it evaluates to false). This is AWS defined behaviour.
         """
@@ -818,7 +828,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -835,7 +845,7 @@ class TestS3Multipart:
             Key=multi_part_upload_key,
             PartNumber=1,
             CopySource=f"{s3_bucket}/{source_key}",
-            CopySourceIfModifiedSince=later_datetime
+            CopySourceIfModifiedSince=later_datetime,
         )
         snapshot.match("upload-part-copy-if-modified-since-in-future", upload_part_copy)
 
@@ -866,7 +876,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -949,7 +959,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -1045,7 +1055,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"
@@ -1085,7 +1095,7 @@ class TestS3Multipart:
         # Set up the source object.
         source_key = "source_file.txt"
         content = "0123456789"
-        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
 
         # Set up the multi-part upload.
         multi_part_upload_key = "destination_file.txt"

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -714,6 +714,59 @@ class TestS3Multipart:
             )
         snapshot.match("upload-part-copy-source-unmodified-since-match", error.value.response)
 
+    @markers.aws.validated
+    def test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match(self):
+        """
+        If CopySourceIfMatch is provided with CopySourceIfUnmodifiedSince it should proceed even if the latter evaluates to false.
+        See documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_part_copy.html
+        """
+        pass
+
+    @markers.aws.unknown
+    def test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match(
+        self, aws_client, s3_bucket, snapshot
+    ):
+        """
+        If CopySourceIfNoneMatch evaluates to true, we should fail if CopySourceIfUnmodified evaluates to false.
+        """
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Bucket", reference_replacement=False),
+                snapshot.transform.key_value("Location"),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value("ID", reference_replacement=False),
+                snapshot.transform.key_value("ETag"),
+            ]
+        )
+
+        # Set up the source object.
+        source_key = "source_file.txt"
+        content = "0123456789"
+        put_source_object = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+        snapshot.match("put-src-object", put_source_object)
+
+        # Set up the multi-part upload.
+        multi_part_upload_key = "destination_file.txt"
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
+        snapshot.match("create-multipart", create_multipart_upload)
+        upload_id = create_multipart_upload["UploadId"]
+
+        earlier_datetime = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
+        with pytest.raises(ClientError) as error:
+            aws_client.s3.upload_part_copy(
+                Bucket=s3_bucket,
+                UploadId=upload_id,
+                Key=multi_part_upload_key,
+                PartNumber=1,
+                CopySource=f"{s3_bucket}/{source_key}",
+                CopySourceIfNoneMatch="not-matching",
+                CopySourceIfUnmodifiedSince=earlier_datetime,
+            )
+        snapshot.match("upload-part-copy-source-unmodified-since-and-if-none-match", error.value.response)
+
 
 class TestS3BucketVersioning:
     @markers.aws.validated

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -875,7 +875,7 @@ class TestS3Multipart:
         snapshot.match("create-multipart", create_multipart_upload)
         upload_id = create_multipart_upload["UploadId"]
 
-        # Don't do this, but required for behaviour with CopySourceIfModifiedSince which will pass if a future time is provided.
+        # Don't do this, but required for behaviour with CopySourceIfModifiedSince which will pass if a future time is provided.
         sleep(1)
 
         with pytest.raises(ClientError) as error:
@@ -888,6 +888,7 @@ class TestS3Multipart:
                 CopySourceIfModifiedSince=datetime.datetime.now(tz=datetime.UTC),
             )
         snapshot.match("upload-part-copy-source-modified-since-match", error.value.response)
+
 
 class TestS3BucketVersioning:
     @markers.aws.validated

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -683,7 +683,6 @@ class TestS3Multipart:
 
     @markers.aws.validated
     def test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed(self, aws_client, s3_bucket, snapshot):
-        earlier = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -755,7 +755,7 @@ class TestS3Multipart:
     ):
         """
         If CopySourceIfMatch is provided with CopySourceIfUnmodifiedSince it should proceed even if the latter evaluates to false.
-        See documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_part_copy.html
+        See documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html
         """
         snapshot.add_transformer(
             [

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -797,7 +797,7 @@ class TestS3Multipart:
         )
         snapshot.match("list-parts", list_parts)
 
-    @markers.aws.unknown
+    @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Owner.DisplayName"],
     )

--- a/tests/aws/services/s3/test_s3_api.py
+++ b/tests/aws/services/s3/test_s3_api.py
@@ -780,14 +780,14 @@ class TestS3Multipart:
         upload_id = create_multipart_upload["UploadId"]
 
         # Uploading shouldn't raise an exception
-        earlier_time = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
+        earlier_datetime = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1)
         upload_part_copy = aws_client.s3.upload_part_copy(
             Bucket=s3_bucket,
             UploadId=upload_id,
             Key=multi_part_upload_key,
             PartNumber=1,
             CopySource=f"{s3_bucket}/{source_key}",
-            CopySourceIfModifiedSince=earlier_time
+            CopySourceIfModifiedSince=earlier_datetime
         )
         snapshot.match("upload-part-copy-if-modified-since", upload_part_copy)
 
@@ -798,11 +798,53 @@ class TestS3Multipart:
         snapshot.match("list-parts", list_parts)
 
     @markers.aws.unknown
+    @markers.snapshot.skip_snapshot_verify(
+        paths=["$..Owner.DisplayName"],
+    )
     def test_upload_part_copy_with_copy_source_if_modified_since_in_future_success(self, aws_client, s3_bucket, snapshot):
         """
-        Providing CopyIfModifiedSince with a datetime which is in the future will always pass. This is AWS defined behaviour.
+        Providing CopyIfModifiedSince with a datetime which is in the future will always pass (even though it evaluates to false). This is AWS defined behaviour.
         """
-        pass
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Bucket", reference_replacement=False),
+                snapshot.transform.key_value("Location"),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value("ID", reference_replacement=False),
+                snapshot.transform.key_value("ETag"),
+            ]
+        )
+
+        # Set up the source object.
+        source_key = "source_file.txt"
+        content = "0123456789"
+        _ = aws_client.s3.put_object(Bucket=s3_bucket, Key=source_key, Body=content)
+
+        # Set up the multi-part upload.
+        multi_part_upload_key = "destination_file.txt"
+        create_multipart_upload = aws_client.s3.create_multipart_upload(
+            Bucket=s3_bucket, Key=multi_part_upload_key
+        )
+        upload_id = create_multipart_upload["UploadId"]
+
+        # Uploading shouldn't raise an exception
+        later_datetime = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=1)
+        upload_part_copy = aws_client.s3.upload_part_copy(
+            Bucket=s3_bucket,
+            UploadId=upload_id,
+            Key=multi_part_upload_key,
+            PartNumber=1,
+            CopySource=f"{s3_bucket}/{source_key}",
+            CopySourceIfModifiedSince=later_datetime
+        )
+        snapshot.match("upload-part-copy-if-modified-since-in-future", upload_part_copy)
+
+        # Check parts were uploaded successfully
+        list_parts = aws_client.s3.list_parts(
+            Bucket=s3_bucket, Key=multi_part_upload_key, UploadId=upload_id
+        )
+        snapshot.match("list-parts", list_parts)
 
     @markers.aws.validated
     def test_upload_part_copy_with_copy_source_if_match_failed(

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4790,7 +4790,72 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match": {
-    "recorded-date": "03-09-2025, 22:24:46",
+    "recorded-date": "04-09-2025, 22:34:32",
+    "recorded-content": {
+      "put-src-object": {
+        "ChecksumCRC32": "poTHxg==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "<e-tag:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "destination_file.txt",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy": {
+        "CopyPartResult": {
+          "ETag": "<e-tag:1>",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "destination_file.txt",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "<e-tag:1>",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
+    "recorded-date": "04-09-2025, 22:34:53",
     "recorded-content": {
       "put-src-object": {
         "ChecksumCRC32": "poTHxg==",

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4762,7 +4762,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_bucket_tagging_none_value": {
-    "recorded-date": "02-09-2025, 22:48:59",
+    "recorded-date": "05-09-2025, 11:35:52",
     "recorded-content": {
       "put-bucket-tags-origin": {
         "ResponseMetadata": {
@@ -4784,7 +4784,7 @@
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 412
+          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4913,5 +4913,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_success": {
+    "recorded-date": "06-09-2025, 09:36:51",
+    "recorded-content": {
+      "upload-part-copy-if-match": {
+        "CopyPartResult": {
+          "ETag": "<e-tag:1>",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "destination_file.txt",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "<e-tag:1>",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4925,5 +4925,113 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
+    "recorded-date": "05-09-2025, 08:15:02",
+    "recorded-content": {
+      "put-src-object": {
+        "ChecksumCRC32": "poTHxg==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "<e-tag:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "destination_file.txt",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-source-if-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_failed": {
+    "recorded-date": "05-09-2025, 08:15:14",
+    "recorded-content": {
+      "put-src-object": {
+        "ChecksumCRC32": "poTHxg==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "<e-tag:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "destination_file.txt",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-source-if-none-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-None-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
+    "recorded-date": "05-09-2025, 08:15:32",
+    "recorded-content": {
+      "put-src-object": {
+        "ChecksumCRC32": "poTHxg==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "<e-tag:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "destination_file.txt",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-source-unmodified-since-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Unmodified-Since",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -5093,5 +5093,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_modified_since_in_future_success": {
+    "recorded-date": "06-09-2025, 10:20:23",
+    "recorded-content": {
+      "upload-part-copy-if-modified-since-in-future": {
+        "CopyPartResult": {
+          "ETag": "<e-tag:1>",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "destination_file.txt",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "<e-tag:1>",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4790,28 +4790,8 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match": {
-    "recorded-date": "04-09-2025, 22:34:32",
+    "recorded-date": "06-09-2025, 09:23:25",
     "recorded-content": {
-      "put-src-object": {
-        "ChecksumCRC32": "poTHxg==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "<e-tag:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-multipart": {
-        "Bucket": "bucket",
-        "Key": "destination_file.txt",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "upload-part-copy": {
         "CopyPartResult": {
           "ETag": "<e-tag:1>",
@@ -4855,28 +4835,8 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
-    "recorded-date": "04-09-2025, 22:34:53",
+    "recorded-date": "06-09-2025, 09:24:36",
     "recorded-content": {
-      "put-src-object": {
-        "ChecksumCRC32": "poTHxg==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "<e-tag:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-multipart": {
-        "Bucket": "bucket",
-        "Key": "destination_file.txt",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "upload-part-copy-source-unmodified-since-and-if-none-match": {
         "Error": {
           "Code": "PreconditionFailed",
@@ -4891,28 +4851,8 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_if_modified_since_failed": {
-    "recorded-date": "05-09-2025, 07:42:33",
+    "recorded-date": "06-09-2025, 09:24:51",
     "recorded-content": {
-      "put-src-object": {
-        "ChecksumCRC32": "poTHxg==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "<e-tag:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-multipart": {
-        "Bucket": "bucket",
-        "Key": "destination_file.txt",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "upload-part-copy-source-modified-since-match": {
         "Error": {
           "Code": "PreconditionFailed",
@@ -4927,28 +4867,8 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
-    "recorded-date": "05-09-2025, 08:15:02",
+    "recorded-date": "06-09-2025, 09:22:26",
     "recorded-content": {
-      "put-src-object": {
-        "ChecksumCRC32": "poTHxg==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "<e-tag:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-multipart": {
-        "Bucket": "bucket",
-        "Key": "destination_file.txt",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "upload-part-copy-source-if-match": {
         "Error": {
           "Code": "PreconditionFailed",
@@ -4963,28 +4883,8 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_failed": {
-    "recorded-date": "05-09-2025, 08:15:14",
+    "recorded-date": "06-09-2025, 09:22:50",
     "recorded-content": {
-      "put-src-object": {
-        "ChecksumCRC32": "poTHxg==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "<e-tag:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-multipart": {
-        "Bucket": "bucket",
-        "Key": "destination_file.txt",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "upload-part-copy-source-if-none-match": {
         "Error": {
           "Code": "PreconditionFailed",
@@ -4999,28 +4899,8 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
-    "recorded-date": "05-09-2025, 08:15:32",
+    "recorded-date": "06-09-2025, 09:23:12",
     "recorded-content": {
-      "put-src-object": {
-        "ChecksumCRC32": "poTHxg==",
-        "ChecksumType": "FULL_OBJECT",
-        "ETag": "<e-tag:1>",
-        "ServerSideEncryption": "AES256",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "create-multipart": {
-        "Bucket": "bucket",
-        "Key": "destination_file.txt",
-        "ServerSideEncryption": "AES256",
-        "UploadId": "<upload-id:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "upload-part-copy-source-unmodified-since-match": {
         "Error": {
           "Code": "PreconditionFailed",

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4788,5 +4788,41 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match": {
+    "recorded-date": "03-09-2025, 22:24:46",
+    "recorded-content": {
+      "put-src-object": {
+        "ChecksumCRC32": "poTHxg==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "<e-tag:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "destination_file.txt",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-source-unmodified-since-and-if-none-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Unmodified-Since",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -5003,5 +5003,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_success": {
+    "recorded-date": "06-09-2025, 09:47:30",
+    "recorded-content": {
+      "upload-part-copy-if-unmodified-since": {
+        "CopyPartResult": {
+          "ETag": "<e-tag:1>",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "destination_file.txt",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "<e-tag:1>",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -5048,5 +5048,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_modified_since_success": {
+    "recorded-date": "06-09-2025, 10:07:29",
+    "recorded-content": {
+      "upload-part-copy-if-modified-since": {
+        "CopyPartResult": {
+          "ETag": "<e-tag:1>",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "destination_file.txt",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "<e-tag:1>",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4958,5 +4958,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_none_success": {
+    "recorded-date": "06-09-2025, 09:39:55",
+    "recorded-content": {
+      "upload-part-copy-if-none-match": {
+        "CopyPartResult": {
+          "ETag": "<e-tag:1>",
+          "LastModified": "datetime"
+        },
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-parts": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "i-d"
+        },
+        "IsTruncated": false,
+        "Key": "destination_file.txt",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "ID": "i-d"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "<e-tag:1>",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 10
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4889,5 +4889,41 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_if_modified_since_failed": {
+    "recorded-date": "05-09-2025, 07:42:33",
+    "recorded-content": {
+      "put-src-object": {
+        "ChecksumCRC32": "poTHxg==",
+        "ChecksumType": "FULL_OBJECT",
+        "ETag": "<e-tag:1>",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "destination_file.txt",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part-copy-source-modified-since-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "x-amz-copy-source-If-Modified-Since",
+          "Message": "At least one of the pre-conditions you specified did not hold"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -4784,7 +4784,7 @@
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 404
+          "HTTPStatusCode": 412
         }
       }
     }

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -189,66 +189,48 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match": {
-    "last_validated_date": "2025-09-03T22:24:46+00:00",
+    "last_validated_date": "2025-09-04T22:34:32+00:00",
     "durations_in_seconds": {
-      "setup": 1.02,
-      "call": 0.15,
-      "teardown": 0.55,
-      "total": 1.72
+      "setup": 0.98,
+      "call": 0.2,
+      "teardown": 0.62,
+      "total": 1.8
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
-    "last_validated_date": "2025-09-03T19:12:58+00:00",
+    "last_validated_date": "2025-09-04T22:33:41+00:00",
     "durations_in_seconds": {
-      "setup": 1.03,
-      "call": 0.13,
-      "teardown": 0.58,
-      "total": 1.74
+      "setup": 1.0,
+      "call": 0.15,
+      "teardown": 0.56,
+      "total": 1.71
     }
   },
-  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_false": {
-    "last_validated_date": "2025-09-03T18:54:22+00:00",
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
+    "last_validated_date": "2025-09-04T22:34:54+00:00",
     "durations_in_seconds": {
-      "setup": 0.97,
+      "setup": 0.89,
       "call": 0.14,
       "teardown": 0.58,
-      "total": 1.69
-    }
-  },
-  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_false": {
-    "last_validated_date": "2025-09-03T18:30:22+00:00",
-    "durations_in_seconds": {
-      "setup": 1.06,
-      "call": 0.13,
-      "teardown": 0.54,
-      "total": 1.73
+      "total": 1.61
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_failed": {
-    "last_validated_date": "2025-09-03T19:13:15+00:00",
+    "last_validated_date": "2025-09-04T22:34:03+00:00",
     "durations_in_seconds": {
-      "setup": 0.95,
+      "setup": 0.87,
       "call": 0.14,
       "teardown": 0.57,
-      "total": 1.66
-    }
-  },
-  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_false": {
-    "last_validated_date": "2025-09-03T19:03:45+00:00",
-    "durations_in_seconds": {
-      "setup": 0.9,
-      "call": 0.14,
-      "teardown": 0.59,
-      "total": 1.63
+      "total": 1.58
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
-    "last_validated_date": "2025-09-03T19:13:31+00:00",
+    "last_validated_date": "2025-09-04T22:34:17+00:00",
     "durations_in_seconds": {
-      "setup": 1.03,
-      "call": 0.16,
+      "setup": 0.89,
+      "call": 0.14,
       "teardown": 0.55,
-      "total": 1.74
+      "total": 1.58
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_delete_object": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -251,6 +251,15 @@
       "total": 1.72
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_success": {
+    "last_validated_date": "2025-09-06T09:47:31+00:00",
+    "durations_in_seconds": {
+      "setup": 1.09,
+      "call": 0.2,
+      "teardown": 0.61,
+      "total": 1.9
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_if_modified_since_failed": {
     "last_validated_date": "2025-09-06T09:24:52+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -225,12 +225,12 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
-    "last_validated_date": "2025-09-04T22:34:17+00:00",
+    "last_validated_date": "2025-09-04T22:37:44+00:00",
     "durations_in_seconds": {
-      "setup": 0.89,
-      "call": 0.14,
-      "teardown": 0.55,
-      "total": 1.58
+      "setup": 0.98,
+      "call": 0.13,
+      "teardown": 0.59,
+      "total": 1.7
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_delete_object": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -188,6 +188,15 @@
       "total": 7.84
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match": {
+    "last_validated_date": "2025-09-03T22:24:46+00:00",
+    "durations_in_seconds": {
+      "setup": 1.02,
+      "call": 0.15,
+      "teardown": 0.55,
+      "total": 1.72
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
     "last_validated_date": "2025-09-03T19:12:58+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -69,12 +69,12 @@
     "last_validated_date": "2025-01-21T18:11:22+00:00"
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_bucket_tagging_none_value": {
-    "last_validated_date": "2025-09-02T22:49:00+00:00",
+    "last_validated_date": "2025-09-05T11:35:52+00:00",
     "durations_in_seconds": {
-      "setup": 1.12,
-      "call": 0.8,
-      "teardown": 0.64,
-      "total": 2.56
+      "setup": 0.96,
+      "call": 0.77,
+      "teardown": 0.56,
+      "total": 2.29
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_put_object_tagging_none_value": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -198,12 +198,12 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
-    "last_validated_date": "2025-09-04T22:33:41+00:00",
+    "last_validated_date": "2025-09-05T08:15:02+00:00",
     "durations_in_seconds": {
-      "setup": 1.0,
-      "call": 0.15,
-      "teardown": 0.56,
-      "total": 1.71
+      "setup": 0.95,
+      "call": 0.14,
+      "teardown": 0.57,
+      "total": 1.66
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
@@ -216,21 +216,21 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_failed": {
-    "last_validated_date": "2025-09-04T22:34:03+00:00",
+    "last_validated_date": "2025-09-05T08:15:15+00:00",
     "durations_in_seconds": {
-      "setup": 0.87,
+      "setup": 0.9,
       "call": 0.14,
       "teardown": 0.57,
-      "total": 1.58
+      "total": 1.61
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
-    "last_validated_date": "2025-09-04T22:37:44+00:00",
+    "last_validated_date": "2025-09-05T08:15:33+00:00",
     "durations_in_seconds": {
-      "setup": 0.98,
+      "setup": 0.89,
       "call": 0.13,
-      "teardown": 0.59,
-      "total": 1.7
+      "teardown": 0.58,
+      "total": 1.6
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_if_modified_since_failed": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -206,6 +206,15 @@
       "total": 1.76
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_success": {
+    "last_validated_date": "2025-09-06T09:36:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.96,
+      "call": 0.21,
+      "teardown": 0.68,
+      "total": 1.85
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
     "last_validated_date": "2025-09-06T09:24:37+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -233,6 +233,15 @@
       "total": 1.7
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_if_modified_since_failed": {
+    "last_validated_date": "2025-09-05T07:42:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.89,
+      "call": 1.14,
+      "teardown": 0.5,
+      "total": 2.53
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_delete_object": {
     "last_validated_date": "2025-01-21T18:09:31+00:00"
   },

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -188,6 +188,60 @@
       "total": 7.84
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
+    "last_validated_date": "2025-09-03T19:12:58+00:00",
+    "durations_in_seconds": {
+      "setup": 1.03,
+      "call": 0.13,
+      "teardown": 0.58,
+      "total": 1.74
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_false": {
+    "last_validated_date": "2025-09-03T18:54:22+00:00",
+    "durations_in_seconds": {
+      "setup": 0.97,
+      "call": 0.14,
+      "teardown": 0.58,
+      "total": 1.69
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_false": {
+    "last_validated_date": "2025-09-03T18:30:22+00:00",
+    "durations_in_seconds": {
+      "setup": 1.06,
+      "call": 0.13,
+      "teardown": 0.54,
+      "total": 1.73
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_failed": {
+    "last_validated_date": "2025-09-03T19:13:15+00:00",
+    "durations_in_seconds": {
+      "setup": 0.95,
+      "call": 0.14,
+      "teardown": 0.57,
+      "total": 1.66
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_false": {
+    "last_validated_date": "2025-09-03T19:03:45+00:00",
+    "durations_in_seconds": {
+      "setup": 0.9,
+      "call": 0.14,
+      "teardown": 0.59,
+      "total": 1.63
+    }
+  },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
+    "last_validated_date": "2025-09-03T19:13:31+00:00",
+    "durations_in_seconds": {
+      "setup": 1.03,
+      "call": 0.16,
+      "teardown": 0.55,
+      "total": 1.74
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_delete_object": {
     "last_validated_date": "2025-01-21T18:09:31+00:00"
   },

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -224,6 +224,15 @@
       "total": 1.85
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_modified_since_success": {
+    "last_validated_date": "2025-09-06T10:07:29+00:00",
+    "durations_in_seconds": {
+      "setup": 0.92,
+      "call": 0.29,
+      "teardown": 0.72,
+      "total": 1.93
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
     "last_validated_date": "2025-09-06T09:24:37+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -206,6 +206,15 @@
       "total": 1.76
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_none_success": {
+    "last_validated_date": "2025-09-06T09:39:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.95,
+      "call": 0.2,
+      "teardown": 0.62,
+      "total": 1.77
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_success": {
     "last_validated_date": "2025-09-06T09:36:51+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -189,57 +189,57 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_and_if_unmodified_since_match": {
-    "last_validated_date": "2025-09-04T22:34:32+00:00",
+    "last_validated_date": "2025-09-06T09:23:26+00:00",
     "durations_in_seconds": {
-      "setup": 0.98,
-      "call": 0.2,
-      "teardown": 0.62,
-      "total": 1.8
+      "setup": 0.88,
+      "call": 0.21,
+      "teardown": 0.66,
+      "total": 1.75
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_match_failed": {
-    "last_validated_date": "2025-09-05T08:15:02+00:00",
+    "last_validated_date": "2025-09-06T09:22:26+00:00",
     "durations_in_seconds": {
-      "setup": 0.95,
-      "call": 0.14,
-      "teardown": 0.57,
-      "total": 1.66
+      "setup": 1.06,
+      "call": 0.16,
+      "teardown": 0.54,
+      "total": 1.76
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_and_if_unmodified_since_match_failed": {
-    "last_validated_date": "2025-09-04T22:34:54+00:00",
+    "last_validated_date": "2025-09-06T09:24:37+00:00",
     "durations_in_seconds": {
-      "setup": 0.89,
-      "call": 0.14,
-      "teardown": 0.58,
-      "total": 1.61
+      "setup": 0.95,
+      "call": 0.15,
+      "teardown": 0.56,
+      "total": 1.66
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_none_match_failed": {
-    "last_validated_date": "2025-09-05T08:15:15+00:00",
+    "last_validated_date": "2025-09-06T09:22:51+00:00",
     "durations_in_seconds": {
-      "setup": 0.9,
+      "setup": 0.87,
       "call": 0.14,
-      "teardown": 0.57,
-      "total": 1.61
+      "teardown": 0.51,
+      "total": 1.52
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_unmodified_since_match_failed": {
-    "last_validated_date": "2025-09-05T08:15:33+00:00",
+    "last_validated_date": "2025-09-06T09:23:12+00:00",
     "durations_in_seconds": {
-      "setup": 0.89,
-      "call": 0.13,
-      "teardown": 0.58,
-      "total": 1.6
+      "setup": 1.0,
+      "call": 0.15,
+      "teardown": 0.57,
+      "total": 1.72
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_if_modified_since_failed": {
-    "last_validated_date": "2025-09-05T07:42:33+00:00",
+    "last_validated_date": "2025-09-06T09:24:52+00:00",
     "durations_in_seconds": {
-      "setup": 0.89,
-      "call": 1.14,
-      "teardown": 0.5,
-      "total": 2.53
+      "setup": 0.96,
+      "call": 1.16,
+      "teardown": 0.68,
+      "total": 2.8
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3ObjectCRUD::test_delete_object": {

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -224,6 +224,15 @@
       "total": 1.85
     }
   },
+  "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_modified_since_in_future_success": {
+    "last_validated_date": "2025-09-06T10:20:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.97,
+      "call": 0.27,
+      "teardown": 0.74,
+      "total": 1.98
+    }
+  },
   "tests/aws/services/s3/test_s3_api.py::TestS3Multipart::test_upload_part_copy_with_copy_source_if_modified_since_success": {
     "last_validated_date": "2025-09-06T10:07:29+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
## Motivation
Resolves #13106 
- Improve our parity with S3's `UploadPartCopy` functionality. This was achieved by adding support for the following conditionals: `CopySourceIfMatch`, `CopySourceIfModifiedSince`, `CopySourceIfNoneMatch` and `CopySourceIfUnmodifiedSince`

## Changes
- Updated the `S3Provider.upload_part_copy` method to handle the above mentioned conditions.
- Created a utility which handles which precondition is raised when the method fails.
- Added parity testing for the different possible failures and paths for combinations of the different conditions. 
- Note: Not every combination is accounted for, I mainly prioritised single condition usage as well as specific cases outlined in the documentation https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html

## Testing
- This was tested using parity tests for the new functionality.

## Future Changes
- Additional parity tests to test the new functionality against older functionality e.g. with `CopySource`.
- Create a multi-part upload fixture to handle repeated logic within the tests (creating a bucket -> uploading an object -> creating the multi-part upload)
- Not all the different combinations are tested for / accounted for, in the future I would like to add more test coverage for these different cases. 