### PR TITLE
fix: add IDE_SESSION_ID to track sessions from extensions in IDEs

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -36,6 +36,7 @@ TRACKED_ENV_VAR = [
     "ES_ENDPOINT_STRATEGY",  # deprecated in 0.14.0, removed in 3.0.0
     "EVENT_RULE_ENGINE",
     "IAM_SOFT_MODE",
+    "IDE_SESSION_ID",
     "KINESIS_PROVIDER",  # Not functional; deprecated in 2.0.0, removed in 3.0.0
     "KINESIS_ERROR_PROBABILITY",
     "KMS_PROVIDER",  # defunct since 1.4.0


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
Localstack has released a [new extension](https://marketplace.visualstudio.com/items?itemName=localstack.localstack). 

This will enable telemetry for sessions in the IDEs, which can also be disabled.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--


What's left to do:

- [ ] ...
- [ ] ...
-->
