### PR TITLE
CFn: add more clarity on logging for unimplemented update methods

### DIFF
--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -518,10 +518,14 @@ class ResourceProviderExecutor:
                 try:
                     return resource_provider.update(request)
                 except NotImplementedError:
+                    feature_request_url = "https://github.com/localstack/localstack/issues/new?template=feature-request.yml"
                     LOG.warning(
-                        'Unable to update resource type "%s", id "%s"',
+                        'Unable to update resource type "%s", id "%s", '
+                        "the update operation is not implemented for this resource. "
+                        "Please consider submitting a feature request at this URL: %s",
                         request.resource_type,
                         request.logical_resource_id,
+                        feature_request_url,
                     )
                     if request.previous_state is None:
                         # this is an issue with our update detection. We should never be in this state.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation


Now that we have announced/released the new CloudFormation engine with #13098, users may be inclined to try updating their stacks more often. We need to be more open and transparent about our update support, so we should tell users when they try to update their resources, but we don't support it.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Log when we don't support an update operation
* Present link for submitting a feature request

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
