### PR TITLE
Remove dependency of static error message in implementation coverage script

### DIFF
--- a/scripts/capture_notimplemented_responses.py
+++ b/scripts/capture_notimplemented_responses.py
@@ -190,7 +190,7 @@ def map_to_notimplemented(row: RowEntry) -> bool:
     Some simple heuristics to check the API responses and classify them into implemented/notimplemented
 
     Ideally they all should behave the same way when receiving requests for not yet implemented endpoints
-    (501 with a "not yet implemented" message)
+    (501 error code and avoids relying on static "not yet implemented" error message strings)
 
     :param row: the RowEntry
     :return: True if we assume it is not implemented, False otherwise
@@ -231,16 +231,6 @@ def map_to_notimplemented(row: RowEntry) -> bool:
         and row["status_code"] == 404
         and row.get("error_message") is not None
         and "The requested URL was not found on the server" in row.get("error_message")
-    ):
-        return True
-    if (
-        row["status_code"] == 501
-        and row.get("error_message") is not None
-        and "not yet implemented" in row.get("error_message", "")
-    ):
-        return True
-    if row.get("error_message") is not None and "not yet implemented" in row.get(
-        "error_message", ""
     ):
         return True
     if row["status_code"] == 501:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR refactors the `map_to_notimplemented` logic used in the implementation coverage script to remove dependency on static error message string `not yet implemented`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
Remove dependency of static error message in implementation coverage script. Some key observations:
- Redundant check with the `status_code == 501` exists. 
- `not yet implemented` always occurs with `501` error code. 
- Generating the `implementation_coverage_full.csv` with the updated script yields no difference in the file for both community and pro versions. 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
