### PR TITLE
Rework S3 url handling for internal & external clients

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -577,7 +577,7 @@ class ExternalClientFactory(ClientFactory):
         if not endpoint_url:
             endpoint_url = get_service_endpoint()
             if service_name == "s3":
-                endpoint_url = f"{localstack_config.get_protocol()}://{get_s3_hostname()}"
+                endpoint_url = f"{localstack_config.get_protocol()}://{get_s3_hostname()}:{localstack_config.GATEWAY_LISTEN[0].port}"
 
         # Prevent `PartialCredentialsError` when only access key ID is provided
         # The value of secret access key is insignificant and can be set to anything


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
With #13119 we introduced a workaround for S3 presigned urls returned by Lambda.

However, this - again - showed the issues with the current URL rewriting inside internal and external clients.

The logic should not be necessary at all for internal clients (since the requests are signed and it uses path addressing), and even for external clients, it should only be necessary for the vhost s3 tests.

This PR tries removing the logic completely from internal clients, and only apply a similar logic for external clients without an explicit endpoint url override.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Remove s3 endpoint url rewrite logic for internal clients
* Only use specific s3 endpoint for external clients without overridden endpoint

## Testing

Testing this will require to run all community and pro pipelines, including optional ones, against this PR, to make sure we do not miss something.
To avoid regressions and give additional time for testing, this will not make it into 4.8.

## TODO

What's left to do:

- [ ] Revert direct boto3 client usage introduced with #13119 (once it is merged)

