### PR TITLE
fix stack update with transformation included

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -704,7 +704,7 @@ class ChangeSetModel:
                     "Invalid: Fn::Transforms cannot be nested inside another Fn::Transform"
                 )
 
-            path = "$" + ".".join(scope.split("/")[:-1])
+            path = scope.parent.jsonpath
             before_siblings = extract_jsonpath(self._before_template, path)
             after_siblings = extract_jsonpath(self._after_template, path)
 

--- a/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.snapshot.json
@@ -725,5 +725,34 @@
       },
       "array-value": "[\"a\",\"b\",\"c\"]"
     }
+  },
+  "tests/aws/services/cloudformation/api/test_transformers.py::test_redeployment_with_fn_include": {
+    "recorded-date": "09-09-2025, 16:00:50",
+    "recorded-content": {
+      "api-details": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "ipAddressType": "ipv4",
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "rootResourceId": "<root-resource-id:1>",
+        "tags": {
+          "aws:cloudformation:logical-id": "RestApi",
+          "aws:cloudformation:stack-id": "<aws:cloudformation:stack-id:1>",
+          "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+        },
+        "version": "1.2.3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_transformers.validation.json
+++ b/tests/aws/services/cloudformation/api/test_transformers.validation.json
@@ -62,6 +62,15 @@
       "total": 24.63
     }
   },
+  "tests/aws/services/cloudformation/api/test_transformers.py::test_redeployment_with_fn_include": {
+    "last_validated_date": "2025-09-09T16:00:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.7,
+      "call": 27.5,
+      "teardown": 5.29,
+      "total": 33.49
+    }
+  },
   "tests/aws/services/cloudformation/api/test_transformers.py::test_transformer_individual_resource_level": {
     "last_validated_date": "2024-06-13T06:43:21+00:00"
   },

--- a/tests/aws/templates/cfn_apigw_with_include_fn.yml
+++ b/tests/aws/templates/cfn_apigw_with_include_fn.yml
@@ -1,0 +1,18 @@
+  Parameters:
+    ApiName:
+      Type: String
+    BucketName:
+      Type: String
+  Resources:
+    RestApi:
+      Type: AWS::ApiGateway::RestApi
+      Properties:
+        Name: !Ref ApiName
+        Body:
+          'Fn::Transform':
+            Name: 'AWS::Include'
+            Parameters:
+              Location: !Sub "s3://${BucketName}/api.yaml"
+  Outputs:
+    RestApiId:
+      Value: !Ref RestApi


### PR DESCRIPTION
## Motivation
This PR fixes an issue occurred during the update of a stack that includes a Fn::Transform.

## Changes
- Use the correct method for building the JsonPath.
- Catch Waiter ChangeSet errors. This is an improvement in the developer experience when writing CFn tests.

## Testing
- New AWS validated test.

## Notes
Thanks to @simonrw for doing the initial investigation.
