### PR TITLE
ASF: implement RPC V2 CBOR parser and serializer

### DIFF
--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -1203,7 +1203,7 @@ class CBORRequestParser(BaseCBORRequestParser, JSONRequestParser):
     it for now.
     """
 
-    # timestamp format is different from traditional CBOR
+    # timestamp format is different from traditional CBOR, and is encoded as a milliseconds integer
     TIMESTAMP_FORMAT = "unixtimestampmillis"
 
     def _do_parse(

--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -1252,18 +1252,13 @@ class BaseRpcV2RequestParser(RequestParser):
     The body decoding is done in the respective subclasses.
     """
 
-    def __init__(self, service: ServiceModel) -> None:
-        super().__init__(service)
-        # self.ignore_get_body_errors = False
-        self._operation_router = RestServiceOperationRouter(service)
-
     @_handle_exceptions
     def parse(self, request: Request) -> tuple[OperationModel, Any]:
         # see https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html
         headers = request.headers
         if "X-Amz-Target" in headers or "X-Amzn-Target" in headers:
             raise ProtocolParserError(
-                "RPC v2 CBOR does not accept 'X-Amz-Target' or 'X-Amzn-Target'. "
+                "RPC v2 does not accept 'X-Amz-Target' or 'X-Amzn-Target'. "
                 "Such requests are rejected for security reasons."
             )
         # TODO: add this special path handling to the ServiceNameParser to allow RPC v2 service to be properly extracted

--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -1257,6 +1257,9 @@ class BaseRpcV2RequestParser(RequestParser):
     @_handle_exceptions
     def parse(self, request: Request) -> tuple[OperationModel, Any]:
         # see https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html
+        if request.method != "POST":
+            raise ProtocolParserError("RPC v2 only accepts POST requests.")
+
         headers = request.headers
         if "X-Amz-Target" in headers or "X-Amzn-Target" in headers:
             raise ProtocolParserError(

--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -19,19 +19,18 @@ The class hierarchy looks as follows:
                           │RequestParser│
                           └─────────────┘
                              ▲   ▲   ▲
-           ┌─────────────────┘   │   └────────────────────┬───────────────────────┐
-  ┌────────┴─────────┐ ┌─────────┴───────────┐ ┌──────────┴──────────┐ ┌──────────┴──────────┐
-  │QueryRequestParser│ │BaseRestRequestParser│ │BaseJSONRequestParser│ │BaseCBORRequestParser│
-  └──────────────────┘ └─────────────────────┘ └─────────────────────┘ └─────────────────────┘
-          ▲                    ▲            ▲   ▲           ▲             ▲
-  ┌───────┴────────┐ ┌─────────┴──────────┐ │   │  ┌────────┴────────┐    │
-  │EC2RequestParser│ │RestXMLRequestParser│ │   │  │JSONRequestParser│    │
-  └────────────────┘ └────────────────────┘ │   │  └─────────────────┘    │
+           ┌─────────────────┘   │   └────────────────────┬───────────────────────┬───────────────────────┐
+  ┌────────┴─────────┐ ┌─────────┴───────────┐ ┌──────────┴──────────┐ ┌──────────┴──────────┐ ┌──────────┴───────────┐
+  │QueryRequestParser│ │BaseRestRequestParser│ │BaseJSONRequestParser│ │BaseCBORRequestParser│ │BaseRpcV2RequestParser│
+  └──────────────────┘ └─────────────────────┘ └─────────────────────┘ └─────────────────────┘ └──────────────────────┘
+          ▲                    ▲            ▲   ▲           ▲             ▲             ▲             ▲
+  ┌───────┴────────┐ ┌─────────┴──────────┐ │   │  ┌────────┴────────┐    │         ┌───┴─────────────┴────┐
+  │EC2RequestParser│ │RestXMLRequestParser│ │   │  │JSONRequestParser│    │         │RpcV2CBORRequestParser│
+  └────────────────┘ └────────────────────┘ │   │  └─────────────────┘    │         └──────────────────────┘
                            ┌────────────────┴───┴┐                 ▲      │
                            │RestJSONRequestParser│             ┌───┴──────┴──────┐
                            └─────────────────────┘             │CBORRequestParser│
                                                                └─────────────────┘
-
 ::
 
 The ``RequestParser`` contains the logic that is used among all the
@@ -46,6 +45,8 @@ The classes are structured as follows:
   which is shared among all different protocols.
 * The ``BaseRestRequestParser`` contains the logic for the REST
   protocol specifics (i.e. specific HTTP metadata parsing).
+* The ``BaseRpcV2RequestParser`` contains the logic for the RPC v2
+  protocol specifics (special path routing, no logic about body decoding)
 * The ``BaseJSONRequestParser`` contains the logic for the JSON body
   parsing.
 * The ``BaseCBORRequestParser`` contains the logic for the CBOR body
@@ -56,8 +57,9 @@ The classes are structured as follows:
 * The ``CBORRequestParser`` inherits the ``json``-protocol specific
   logic from the ``JSONRequestParser`` and the CBOR body parsing
   from the ``BaseCBORRequestParser``.
-* The ``QueryRequestParser``, ``RestXMLRequestParser`` and
-``JSONRequestParser`` have a conventional inheritance structure.
+* The ``QueryRequestParser``, ``RestXMLRequestParser``,
+  ``RpcV2CBORRequestParser`` and ``JSONRequestParser`` have a
+  conventional inheritance structure.
 
 The services and their protocols are defined by using AWS's Smithy
 (a language to define services in a - somewhat - protocol-agnostic

--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -2263,8 +2263,9 @@ def create_serializer(
         #  CBOR handling from JSONResponseParser
         # this is not an "official" protocol defined from the spec, but is derived from ``json``
     }
-    # TODO: do we want to add a check if the user-defined protocol is part of the available ones in the ServiceModel?
-    #  or should it be checked once
+    # TODO: even though our Service Name Parser will only use a protocol that is available for the service, we might
+    #  want to verify if the given protocol here is available for that service, in case we are manually calling
+    #  this factory. Revisit once we implement multi-protocol support
     service_protocol = protocol or service.protocol
 
     # Try to select a service- and protocol-specific serializer implementation

--- a/localstack-core/localstack/aws/spec.py
+++ b/localstack-core/localstack/aws/spec.py
@@ -21,7 +21,7 @@ from localstack.utils.objects import singleton_factory
 LOG = logging.getLogger(__name__)
 
 ServiceName = str
-ProtocolName = Literal["query", "json", "rest-json", "rest-xml", "ec2", "smithy-rpc-v2"]
+ProtocolName = Literal["query", "json", "rest-json", "rest-xml", "ec2", "smithy-rpc-v2-cbor"]
 
 
 class ServiceModelIdentifier(NamedTuple):

--- a/localstack-core/localstack/aws/spec.py
+++ b/localstack-core/localstack/aws/spec.py
@@ -21,7 +21,7 @@ from localstack.utils.objects import singleton_factory
 LOG = logging.getLogger(__name__)
 
 ServiceName = str
-ProtocolName = Literal["query", "json", "rest-json", "rest-xml", "ec2"]
+ProtocolName = Literal["query", "json", "rest-json", "rest-xml", "ec2", "smithy-rpc-v2"]
 
 
 class ServiceModelIdentifier(NamedTuple):

--- a/tests/aws/services/kinesis/test_kinesis.validation.json
+++ b/tests/aws/services/kinesis/test_kinesis.validation.json
@@ -6,12 +6,12 @@
     "last_validated_date": "2024-07-31T11:17:28+00:00"
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_cbor_exceptions": {
-    "last_validated_date": "2025-09-04T16:59:26+00:00",
+    "last_validated_date": "2025-09-16T15:31:43+00:00",
     "durations_in_seconds": {
-      "setup": 0.5,
-      "call": 0.47,
+      "setup": 0.57,
+      "call": 0.48,
       "teardown": 0.0,
-      "total": 0.97
+      "total": 1.05
     }
   },
   "tests/aws/services/kinesis/test_kinesis.py::TestKinesis::test_create_stream_without_shard_count": {

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1522,7 +1522,3 @@ def test_smithy_rpc_v2_cbor():
         primaryRegion="string",
         tags={"string": "string"},
     )
-
-
-# arc-region-switch supports both `json` and `smithy-rpc-v2`. Testing that we can support both
-# @pytest.mark.parametrize("protocol", ["json", "smithy-rpc-v2"])

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1537,3 +1537,21 @@ def test_protocol_selection(protocol):
         arn="string",
         tags={"string": "string"},
     )
+
+
+def test_rpcv2_operation_detection_with_prefix():
+    """
+    Every request for the rpcv2Cbor protocol MUST be sent to a URL with the following form:
+    {prefix?}/service/{serviceName}/operation/{operationName}
+    The Smithy RPCv2 CBOR protocol will only use the last four segments of the URL when routing requests.
+    For example, a service could use a v1 prefix in the URL path, which would not affect the operation a request
+    is routed to: `v1/service/FooService/operation/BarOperation`
+    """
+    request = HttpRequest(
+        method="POST",
+        path="/v1/service/ArcRegionSwitch/operation/TagResource",
+        body=b"\xa2carnfstringdtags\xa1fstringfstring",
+    )
+    parser = create_parser(load_service("arc-region-switch"))
+    parsed_operation_model, parsed_request = parser.parse(request)
+    assert parsed_operation_model.name == "TagResource"

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1452,6 +1452,7 @@ def test_restxml_ignores_get_body():
 def test_smithy_rpc_v2_cbor():
     # we are using a service that LocalStack does not implement yet because it implements `smithy-rpc-v2-cbor`
     # we can replace this service by CloudWatch once it has support in Botocore
+    # TODO: test timestamp parsing
     # example taken from:
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/arc-region-switch/client/create_plan.html
 
@@ -1520,5 +1521,19 @@ def test_smithy_rpc_v2_cbor():
         ],
         recoveryApproach="activeActive",
         primaryRegion="string",
+        tags={"string": "string"},
+    )
+
+
+@pytest.mark.parametrize("protocol", ("json", "smithy-rpc-v2-cbor"))
+def test_protocol_selection(protocol):
+    # we are using a service that LocalStack does not implement yet because it implements `smithy-rpc-v2-cbor`
+    # we can replace this service by CloudWatch once it has support in Botocore
+
+    _botocore_parser_integration_test(
+        service="arc-region-switch",
+        protocol=protocol,
+        action="TagResource",
+        arn="string",
         tags={"string": "string"},
     )

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1447,3 +1447,82 @@ def test_restxml_ignores_get_body():
     assert "Bucket" in parsed_request
     assert parsed_request["Bucket"] == "test-bucket"
     assert parsed_request["Key"] == "foo"
+
+
+def test_smithy_rpc_v2_cbor():
+    # we are using a service that LocalStack does not implement yet because it implements `smithy-rpc-v2-cbor`
+    # we can replace this service by CloudWatch once it has support in Botocore
+    # example taken from:
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/arc-region-switch/client/create_plan.html
+
+    _botocore_parser_integration_test(
+        service="arc-region-switch",
+        protocol="smithy-rpc-v2-cbor",
+        action="CreatePlan",
+        description="string",
+        workflows=[
+            {
+                "steps": [
+                    {
+                        "name": "string",
+                        "description": "string",
+                        "executionBlockConfiguration": {
+                            "customActionLambdaConfig": {
+                                "timeoutMinutes": 123,
+                                "lambdas": [
+                                    {
+                                        "crossAccountRole": "string",
+                                        "externalId": "string",
+                                        "arn": "string",
+                                    },
+                                ],
+                                "retryIntervalMinutes": 10.0,
+                                "regionToRun": "activatingRegion",
+                                "ungraceful": {"behavior": "skip"},
+                            },
+                        },
+                        "executionBlockType": "CustomActionLambda",
+                    },
+                ],
+                "workflowTargetAction": "activate",
+                "workflowTargetRegion": "string",
+                "workflowDescription": "string",
+            },
+        ],
+        executionRole="string",
+        recoveryTimeObjectiveMinutes=123,
+        associatedAlarms={
+            "string": {
+                "crossAccountRole": "string",
+                "externalId": "string",
+                "resourceIdentifier": "string",
+                "alarmType": "applicationHealth",
+            }
+        },
+        triggers=[
+            {
+                "description": "string",
+                "targetRegion": "string",
+                "action": "activate",
+                "conditions": [
+                    {
+                        "associatedAlarmName": "string",
+                        "condition": "red",
+                    },
+                ],
+                "minDelayMinutesBetweenExecutions": 123,
+            },
+        ],
+        name="string",
+        regions=[
+            "region1",
+            "region2",
+        ],
+        recoveryApproach="activeActive",
+        primaryRegion="string",
+        tags={"string": "string"},
+    )
+
+
+# arc-region-switch supports both `json` and `smithy-rpc-v2`. Testing that we can support both
+# @pytest.mark.parametrize("protocol", ["json", "smithy-rpc-v2"])

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -1521,7 +1521,8 @@ def test_rpc_v2_cbor_serializer_arc_region_switch_with_botocore():
                 "recoveryApproach": "activeActive",
                 "primaryRegion": "string",
                 "version": "string",
-                "updatedAt": datetime(2015, 1, 1, 23, 59, 59, tzinfo=tzlocal()),
+                # validated with AWS, it returns millisecond precision
+                "updatedAt": datetime(2015, 1, 1, 23, 59, 59, microsecond=262000, tzinfo=tzlocal()),
                 "description": "string",
                 "executionRole": "string",
                 "activePlanExecution": "string",
@@ -1536,6 +1537,48 @@ def test_rpc_v2_cbor_serializer_arc_region_switch_with_botocore():
         action="ListPlans",
         response=parameters,
         protocol="smithy-rpc-v2-cbor",
+    )
+
+
+def test_rpc_v2_undefined_map_and_list_serialization():
+    # they are two types of map/list in CBOR, indefinite length types and "defined" ones:
+    # You'd use \xbf to indicate a map with indefinite length, then \xff to indicate the end of the map.
+    # You can also use \xa4 to indicate a map with exactly 4 things in it, so \xff is not required at the end.
+    # The Smithy specs are asking to follow the CBOR specs and use defined length structures, but AWS is returning
+    # undefined one with `\xbf` and `\xff`
+    service = load_service("arc-region-switch")
+    response_serializer = create_serializer(service, protocol="smithy-rpc-v2-cbor")
+    response_data = {
+        "plans": [
+            {
+                "arn": "arn:aws:arc-region-switch::671107678412:plan/TestPlan:a1b61f",
+                "owner": "671107678412",
+                "name": "TestPlan",
+                "regions": ["us-east-1", "us-east-2"],
+                "recoveryApproach": "activePassive",
+                "primaryRegion": "us-east-1",
+                "version": "1",
+                "updatedAt": datetime(2025, 9, 16, 14, 54, 5, 262000, tzinfo=tzlocal()),
+                "executionRole": "arn:aws:iam::671107678412:role/testswitch",
+            }
+        ]
+    }
+
+    result: Response = response_serializer.serialize_to_response(
+        response_data, service.operation_model("ListPlans"), {}, long_uid()
+    )
+    assert result is not None
+    assert result.content_type == "application/cbor"
+    raw_response_body = result.data
+    # this has been validated with AWS, AWS uses undefined length CBOR map and list
+    assert raw_response_body[:10] == b"\xbfeplans\x9f\xbfc"
+    assert raw_response_body[-3:] == b"\xff\xff\xff"
+    # we also validate its timestamp serialization (with double)
+    timestamp_key_index = raw_response_body.find(b"updatedAt")
+    timestamp_value_index = timestamp_key_index + len(b"updatedAt")
+    # this has been validated with AWS as well, it encodes the timestamp as a double of length 8
+    assert (
+        raw_response_body[timestamp_value_index : timestamp_value_index + 8] == b"\xc1\xfbA\xda2W{P"
     )
 
 

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -67,7 +67,7 @@ def _botocore_serializer_integration_test(
     Performs an integration test for the serializer using botocore as parser.
     It executes the following steps:
     - Load the given service (f.e. "sqs")
-    - Serialize the response with the appropriate serializer from the AWS Serivce Framework
+    - Serialize the response with the appropriate serializer from the AWS Service Framework
     - Parse the serialized response using the botocore parser
     - Checks if the metadata is correct (status code, requestID,...)
     - Checks if the parsed response content is equal to the input to the serializer
@@ -1536,6 +1536,22 @@ def test_rpc_v2_cbor_serializer_arc_region_switch_with_botocore():
         action="ListPlans",
         response=parameters,
         protocol="smithy-rpc-v2-cbor",
+    )
+
+
+@pytest.mark.parametrize("protocol", ("json", "smithy-rpc-v2-cbor"))
+def test_protocol_selection(protocol):
+    # we are using a service that LocalStack does not implement yet because it implements `smithy-rpc-v2-cbor`
+    # we can replace this service by CloudWatch once it has support in Botocore
+    parameters = {
+        "resourceTags": {"string": "string"},
+    }
+
+    _botocore_serializer_integration_test(
+        service="arc-region-switch",
+        protocol=protocol,
+        action="ListTagsForResource",
+        response=parameters,
     )
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is part of a bigger initiative to implement support for the [new Smithy Protocol](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html) `smithy-rpc-v2-cbor`, as well as the new Botocore multi-protocol support for single services (before, a service could only define one protocol).

This PR is stacked on top of #13103. 

This PR properly implements the `smithy-rpc-v2-cbor` protocol and adds support for it. 
Currently, no service that LocalStack supports implements this protocol, but we can still our unit tests to validate the serialization/deserialization works. 

The logic is based on Botocore's own serializer and parser, with some adaptations due to the client/server difference. 

One of the main feature of RPC v2-based protocol is its routing, following the `/service/<service-name>/operation/<operation-name>` format. This is implemented in our parser.

In the next steps, while implementing proper multi-protocol support, we will run integration tests with this protocol against AWS, to make sure our deserialization/serialization works end-to-end.

Because we do not support any service with `smithy-rpc-v2-cbor` yet, **I have not implemented the Service detection yet**, because we cannot test it. This will come in a follow-up when implementing the multi-protocol support (as it will also implement protocol detection, we will add `rpc-v2-cbor` service name parsing). 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- implements the `BaseRpcV2RequestParser` and `BaseRpcV2ResponseSerializer`
- implement the child `RpcV2CBORRequestParser` and `RpcV2CBORResponseSerializer` which supports `smithy-rpc-v2-cbor`
- add new unit tests to verify round trip parsing and serialization of requests/responses of service using this protocol
- add unit test to verify operation detection (service detection of RPC v2 will come in a follow up)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
