### PR TITLE
CFn: fix modelling issue with AWS::NoValue

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -681,9 +681,6 @@ class ChangeSetModel:
             scope=arguments_scope, before_value=before_arguments, after_value=after_arguments
         )
 
-        if intrinsic_function == "Ref" and arguments.value == "AWS::NoValue":
-            arguments.value = Nothing
-
         if is_created(before=before_arguments, after=after_arguments):
             change_type = ChangeType.CREATED
         elif is_removed(before=before_arguments, after=after_arguments):

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -975,6 +975,10 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         return PreprocEntityDelta(before=before_parameters, after=after_parameters)
 
     def visit_node_parameter(self, node_parameter: NodeParameter) -> PreprocEntityDelta:
+        if not VALID_LOGICAL_RESOURCE_ID_RE.match(node_parameter.name):
+            raise ValidationError(
+                f"Template format error: Parameter name {node_parameter.name} is non alphanumeric."
+            )
         dynamic_value = node_parameter.dynamic_value
         dynamic_delta = self.visit(dynamic_value)
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
@@ -27,6 +27,7 @@ class ChangeSetModelValidator(ChangeSetModelPreproc):
     def visit_node_template(self, node_template: NodeTemplate):
         self.visit(node_template.mappings)
         self.visit(node_template.resources)
+        self.visit(node_template.parameters)
 
     def visit_node_intrinsic_function_fn_get_att(
         self, node_intrinsic_function: NodeIntrinsicFunction

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -1321,6 +1321,7 @@ cases = [
 ]
 
 
+@skip_if_v1_provider("Unsupported in V1 engine")
 @markers.aws.validated
 @pytest.mark.parametrize(
     "case",

--- a/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
@@ -619,5 +619,41 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_using_pseudoparameters_in_places[resource]": {
+    "recorded-date": "11-09-2025, 22:15:52",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Resource name AWS::NoValue is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_using_pseudoparameters_in_places[condition]": {
+    "recorded-date": "11-09-2025, 22:15:55",
+    "recorded-content": {}
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_using_pseudoparameters_in_places[parameter]": {
+    "recorded-date": "11-09-2025, 22:15:51",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Parameter name AWS::NoValue is non alphanumeric.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.validation.json
@@ -121,5 +121,14 @@
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::test_name_conflicts": {
     "last_validated_date": "2023-11-22T09:58:04+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_update_change_set_with_aws_novalue_repro": {
+    "last_validated_date": "2025-09-11T15:25:28+00:00",
+    "durations_in_seconds": {
+      "setup": 0.98,
+      "call": 21.48,
+      "teardown": 0.19,
+      "total": 22.65
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.validation.json
@@ -130,5 +130,32 @@
       "teardown": 0.19,
       "total": 22.65
     }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_using_pseudoparameters_in_places[condition]": {
+    "last_validated_date": "2025-09-11T22:15:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.64,
+      "teardown": 0.09,
+      "total": 3.73
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_using_pseudoparameters_in_places[parameter]": {
+    "last_validated_date": "2025-09-11T22:15:51+00:00",
+    "durations_in_seconds": {
+      "setup": 1.03,
+      "call": 0.32,
+      "teardown": 0.13,
+      "total": 1.48
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::test_using_pseudoparameters_in_places[resource]": {
+    "last_validated_date": "2025-09-11T22:15:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.16,
+      "teardown": 0.07,
+      "total": 0.23
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation


While investigating issues from the telemetry, I found that an `AWS::NoValue` was being turned into a `Nothing` which itself was being looked up as a key in a dictionary (the conditions).

```python
foo = Nothing
bar = {}
print(foo in bar)
```

This does not work because `Nothing` is not hashable, so cannot be used as a dictionary key.

The reason for this is that in #13000 I incorrectly set any `NoValue` to `Nothing` during the modelling phase, however this caused the above issue. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes


* Remove incorrect setting of `arguments.value` to `Nothing`
* Add test that exercises the bug found, specifically checking for `AWS::NoValue` in an update operation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
