### PR TITLE
opensearch: add new versions

### DIFF
--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -120,7 +120,7 @@ ELASTICSEARCH_PLUGIN_LIST = [
 ELASTICSEARCH_DELETE_MODULES = ["ingest-geoip"]
 
 # the version of opensearch which is used by default
-OPENSEARCH_DEFAULT_VERSION = "OpenSearch_2.11"
+OPENSEARCH_DEFAULT_VERSION = "OpenSearch_3.1"
 
 # See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
 OPENSEARCH_PLUGIN_LIST = [

--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -102,32 +102,6 @@ FALSE_STRINGS = ("0", "false", "False")
 # strings with valid log levels for LS_LOG
 LOG_LEVELS = ("trace-internal", "trace", "debug", "info", "warn", "error", "warning")
 
-# the version of elasticsearch that is pre-seeded into the base image (sync with Dockerfile.base)
-ELASTICSEARCH_DEFAULT_VERSION = "Elasticsearch_7.10"
-# See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
-ELASTICSEARCH_PLUGIN_LIST = [
-    "analysis-icu",
-    "ingest-attachment",
-    "analysis-kuromoji",
-    "mapper-murmur3",
-    "mapper-size",
-    "analysis-phonetic",
-    "analysis-smartcn",
-    "analysis-stempel",
-    "analysis-ukrainian",
-]
-# Default ES modules to exclude (save apprx 66MB in the final image)
-ELASTICSEARCH_DELETE_MODULES = ["ingest-geoip"]
-
-# the version of opensearch which is used by default
-OPENSEARCH_DEFAULT_VERSION = "OpenSearch_3.1"
-
-# See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
-OPENSEARCH_PLUGIN_LIST = [
-    "ingest-attachment",
-    "analysis-kuromoji",
-]
-
 # API endpoint for analytics events
 API_ENDPOINT = os.environ.get("API_ENDPOINT") or "https://api.localstack.cloud/v1"
 # new analytics API endpoint
@@ -170,9 +144,6 @@ DEFAULT_DEVELOP_PORT = 5678
 # This name should be accepted by all IaC tools, so should respect s3 bucket naming conventions
 DEFAULT_BUCKET_MARKER_LOCAL = "hot-reload"
 LEGACY_DEFAULT_BUCKET_MARKER_LOCAL = "__local__"
-
-# user that starts the opensearch process if the current user is root
-OS_USER_OPENSEARCH = "localstack"
 
 # output string that indicates that the stack is ready
 READY_MARKER_OUTPUT = "Ready."

--- a/localstack-core/localstack/services/es/provider.py
+++ b/localstack-core/localstack/services/es/provider.py
@@ -3,7 +3,6 @@ from typing import cast
 
 from botocore.exceptions import ClientError
 
-from localstack import constants
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.es import (
     ARN,
@@ -68,6 +67,7 @@ from localstack.aws.api.opensearch import (
     VersionString,
 )
 from localstack.aws.connect import connect_to
+from localstack.services.opensearch.packages import ELASTICSEARCH_DEFAULT_VERSION
 
 
 def _version_to_opensearch(
@@ -236,7 +236,7 @@ class EsProvider(EsApi):
         engine_version = (
             _version_to_opensearch(elasticsearch_version)
             if elasticsearch_version
-            else constants.ELASTICSEARCH_DEFAULT_VERSION
+            else ELASTICSEARCH_DEFAULT_VERSION
         )
         kwargs = {
             "DomainName": domain_name,

--- a/localstack-core/localstack/services/opensearch/cluster.py
+++ b/localstack-core/localstack/services/opensearch/cluster.py
@@ -18,7 +18,12 @@ from localstack.http.client import SimpleRequestsClient
 from localstack.http.proxy import ProxyHandler
 from localstack.services.edge import ROUTER
 from localstack.services.opensearch import versions
-from localstack.services.opensearch.packages import elasticsearch_package, opensearch_package
+from localstack.services.opensearch.packages import (
+    ELASTICSEARCH_DEFAULT_VERSION,
+    OPENSEARCH_DEFAULT_VERSION,
+    elasticsearch_package,
+    opensearch_package,
+)
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.common import (
     ShellCommandThread,
@@ -36,6 +41,9 @@ from localstack.utils.urls import localstack_host
 LOG = logging.getLogger(__name__)
 INTERNAL_USER_AUTH = ("localstack-internal", "localstack-internal")
 DEFAULT_BACKEND_HOST = "127.0.0.1"
+
+# user that starts the opensearch process if the current user is root
+OS_USER_OPENSEARCH = "localstack"
 
 CommandSettings = dict[str, str]
 
@@ -314,7 +322,7 @@ class OpensearchCluster(Server):
 
     @property
     def default_version(self) -> str:
-        return constants.OPENSEARCH_DEFAULT_VERSION
+        return OPENSEARCH_DEFAULT_VERSION
 
     @property
     def version(self) -> str:
@@ -336,7 +344,7 @@ class OpensearchCluster(Server):
 
     @property
     def os_user(self):
-        return constants.OS_USER_OPENSEARCH
+        return OS_USER_OPENSEARCH
 
     def health(self) -> str | None:
         return get_cluster_health_status(self.url, auth=self.auth)
@@ -580,7 +588,7 @@ class EdgeProxiedOpensearchCluster(Server):
 
     @property
     def default_version(self):
-        return constants.OPENSEARCH_DEFAULT_VERSION
+        return OPENSEARCH_DEFAULT_VERSION
 
     @property
     def url(self) -> str:
@@ -658,7 +666,7 @@ class ElasticsearchCluster(OpensearchCluster):
 
     @property
     def default_version(self) -> str:
-        return constants.ELASTICSEARCH_DEFAULT_VERSION
+        return ELASTICSEARCH_DEFAULT_VERSION
 
     @property
     def bin_name(self) -> str:
@@ -666,7 +674,7 @@ class ElasticsearchCluster(OpensearchCluster):
 
     @property
     def os_user(self):
-        return constants.OS_USER_OPENSEARCH
+        return OS_USER_OPENSEARCH
 
     def _ensure_installed(self):
         elasticsearch_package.install(self.version)
@@ -710,7 +718,7 @@ class ElasticsearchCluster(OpensearchCluster):
 class EdgeProxiedElasticsearchCluster(EdgeProxiedOpensearchCluster):
     @property
     def default_version(self):
-        return constants.ELASTICSEARCH_DEFAULT_VERSION
+        return ELASTICSEARCH_DEFAULT_VERSION
 
     def _backend_cluster(self) -> OpensearchCluster:
         return ElasticsearchCluster(

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -9,13 +9,6 @@ import threading
 import semver
 
 from localstack import config
-from localstack.constants import (
-    ELASTICSEARCH_DEFAULT_VERSION,
-    ELASTICSEARCH_DELETE_MODULES,
-    ELASTICSEARCH_PLUGIN_LIST,
-    OPENSEARCH_DEFAULT_VERSION,
-    OPENSEARCH_PLUGIN_LIST,
-)
 from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.packages.java import java_package
 from localstack.services.opensearch import versions
@@ -32,6 +25,32 @@ from localstack.utils.sync import SynchronizedDefaultDict, retry
 
 LOG = logging.getLogger(__name__)
 
+# the version of opensearch which is used by default
+OPENSEARCH_DEFAULT_VERSION = "OpenSearch_3.1"
+
+# See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
+OPENSEARCH_PLUGIN_LIST = [
+    "ingest-attachment",
+    "analysis-kuromoji",
+]
+
+# the version of elasticsearch that is pre-seeded into the base image (sync with Dockerfile.base)
+ELASTICSEARCH_DEFAULT_VERSION = "Elasticsearch_7.10"
+
+# See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
+ELASTICSEARCH_PLUGIN_LIST = [
+    "analysis-icu",
+    "ingest-attachment",
+    "analysis-kuromoji",
+    "mapper-murmur3",
+    "mapper-size",
+    "analysis-phonetic",
+    "analysis-smartcn",
+    "analysis-stempel",
+    "analysis-ukrainian",
+]
+# Default ES modules to exclude (save apprx 66MB in the final image)
+ELASTICSEARCH_DELETE_MODULES = ["ingest-geoip"]
 
 _OPENSEARCH_INSTALL_LOCKS = SynchronizedDefaultDict(threading.RLock)
 

--- a/localstack-core/localstack/services/opensearch/provider.py
+++ b/localstack-core/localstack/services/opensearch/provider.py
@@ -75,7 +75,6 @@ from localstack.aws.api.opensearch import (
     VolumeType,
     VPCDerivedInfoStatus,
 )
-from localstack.constants import OPENSEARCH_DEFAULT_VERSION
 from localstack.services.opensearch import versions
 from localstack.services.opensearch.cluster import SecurityOptions
 from localstack.services.opensearch.cluster_manager import (
@@ -84,6 +83,7 @@ from localstack.services.opensearch.cluster_manager import (
     create_cluster_manager,
 )
 from localstack.services.opensearch.models import OpenSearchStore, opensearch_stores
+from localstack.services.opensearch.packages import OPENSEARCH_DEFAULT_VERSION
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws.arns import parse_arn

--- a/localstack-core/localstack/services/opensearch/provider.py
+++ b/localstack-core/localstack/services/opensearch/provider.py
@@ -26,6 +26,7 @@ from localstack.aws.api.opensearch import (
     CognitoOptions,
     CognitoOptionsStatus,
     ColdStorageOptions,
+    CompatibleVersionsMap,
     CreateDomainRequest,
     CreateDomainResponse,
     DeleteDomainResponse,
@@ -650,6 +651,10 @@ class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
                 for comp in versions.compatible_versions
                 if comp["SourceVersion"] == version_filter
             ]
+            if not compatible_versions:
+                compatible_versions = [
+                    CompatibleVersionsMap(SourceVersion=version_filter, TargetVersions=[])
+                ]
         return GetCompatibleVersionsResponse(CompatibleVersions=compatible_versions)
 
     def describe_domain_config(

--- a/localstack-core/localstack/services/opensearch/versions.py
+++ b/localstack-core/localstack/services/opensearch/versions.py
@@ -13,13 +13,17 @@ from localstack.utils.common import get_arch
 
 # Internal representation of the OpenSearch versions (without the "OpenSearch_" prefix)
 _opensearch_install_versions = {
+    "3.1": "3.1.0",
+    "2.19": "2.19.3",
+    "2.17": "2.17.1",
+    "2.15": "2.15.0",
     "2.13": "2.13.0",
     "2.11": "2.11.1",
     "2.9": "2.9.0",
     "2.7": "2.7.0",
     "2.5": "2.5.0",
     "2.3": "2.3.0",
-    "1.3": "1.3.12",
+    "1.3": "1.3.20",
     "1.2": "1.2.4",
     "1.1": "1.1.0",
     "1.0": "1.0.0",
@@ -221,6 +225,9 @@ compatible_versions = [
             "OpenSearch_2.9",
             "OpenSearch_2.11",
             "OpenSearch_2.13",
+            "OpenSearch_2.15",
+            "OpenSearch_2.17",
+            "OpenSearch_2.19",
         ],
     ),
     CompatibleVersionsMap(
@@ -231,28 +238,68 @@ compatible_versions = [
             "OpenSearch_2.9",
             "OpenSearch_2.11",
             "OpenSearch_2.13",
+            "OpenSearch_2.15",
+            "OpenSearch_2.17",
+            "OpenSearch_2.19",
         ],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.5",
-        TargetVersions=["OpenSearch_2.7", "OpenSearch_2.9", "OpenSearch_2.11", "OpenSearch_2.13"],
+        TargetVersions=[
+            "OpenSearch_2.7",
+            "OpenSearch_2.9",
+            "OpenSearch_2.11",
+            "OpenSearch_2.13",
+            "OpenSearch_2.15",
+            "OpenSearch_2.17",
+            "OpenSearch_2.19",
+        ],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.7",
-        TargetVersions=["OpenSearch_2.9", "OpenSearch_2.11", "OpenSearch_2.13"],
+        TargetVersions=[
+            "OpenSearch_2.9",
+            "OpenSearch_2.11",
+            "OpenSearch_2.13",
+            "OpenSearch_2.15",
+            "OpenSearch_2.17",
+            "OpenSearch_2.19",
+        ],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.9",
-        TargetVersions=["OpenSearch_2.11", "OpenSearch_2.13"],
+        TargetVersions=[
+            "OpenSearch_2.11",
+            "OpenSearch_2.13",
+            "OpenSearch_2.15",
+            "OpenSearch_2.17",
+            "OpenSearch_2.19",
+        ],
     ),
     CompatibleVersionsMap(
         SourceVersion="OpenSearch_2.11",
-        TargetVersions=["OpenSearch_2.13"],
+        TargetVersions=["OpenSearch_2.13", "OpenSearch_2.15", "OpenSearch_2.17", "OpenSearch_2.19"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_2.13",
+        TargetVersions=["OpenSearch_2.15", "OpenSearch_2.17", "OpenSearch_2.19"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_2.15",
+        TargetVersions=["OpenSearch_2.17", "OpenSearch_2.19"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_2.17",
+        TargetVersions=["OpenSearch_2.19"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_2.19",
+        TargetVersions=["OpenSearch_3.1"],
     ),
 ]
 
 
-def get_install_type_and_version(version: str) -> (EngineType, str):
+def get_install_type_and_version(version: str) -> tuple[EngineType, str]:
     engine_type = EngineType(version.split("_")[0])
 
     if version not in install_versions:
@@ -297,6 +344,8 @@ def get_download_url(install_version: str, engine_type: EngineType) -> str:
         return _opensearch_url(install_version)
     elif engine_type == EngineType.Elasticsearch:
         return _es_url(install_version)
+    else:
+        raise ValueError(f"Unknown OpenSearch engine type: {engine_type}")
 
 
 def fetch_latest_versions() -> dict[str, str]:  # pragma: no cover

--- a/tests/aws/cdk_templates/Bookstore/BookstoreStack.json
+++ b/tests/aws/cdk_templates/Bookstore/BookstoreStack.json
@@ -202,7 +202,7 @@
         "EncryptionAtRestOptions": {
           "Enabled": false
         },
-        "EngineVersion": "OpenSearch_2.11",
+        "EngineVersion": "OpenSearch_3.1",
         "LogPublishingOptions": {},
         "NodeToNodeEncryptionOptions": {
           "Enabled": false

--- a/tests/aws/scenario/bookstore/test_bookstore.py
+++ b/tests/aws/scenario/bookstore/test_bookstore.py
@@ -287,7 +287,9 @@ class TestBookstoreApplication:
             "$..ClusterConfig.DedicatedMasterType",  # added in LS
             "$..ClusterConfig.Options.DedicatedMasterCount",  # added in LS
             "$..ClusterConfig.Options.DedicatedMasterType",  # added in LS
+            "$..DomainStatusList..AIMLOptions",  # missing
             "$..DomainStatusList..EBSOptions.Iops",  # added in LS
+            "$..DomainStatusList..IdentityCenterOptions",  # missing
             "$..DomainStatusList..IPAddressType",  # missing
             "$..DomainStatusList..DomainProcessingStatus",  # missing
             "$..DomainStatusList..ModifyingProperties",  # missing
@@ -299,7 +301,9 @@ class TestBookstoreApplication:
             "$..ClusterConfig.MultiAZWithStandbyEnabled",  # missing
             "$..AdvancedSecurityOptions.AnonymousAuthEnabled",  # missing
             "$..AdvancedSecurityOptions.Options.AnonymousAuthEnabled",  # missing
+            "$..DomainConfig.AIMLOptions",  # missing
             "$..DomainConfig.ClusterConfig.Options.WarmEnabled",  # missing
+            "$..DomainConfig.IdentityCenterOptions",  # missing
             "$..DomainConfig.IPAddressType",  # missing
             "$..DomainConfig.ModifyingProperties",  # missing
             "$..ClusterConfig.Options.ColdStorageOptions",  # missing

--- a/tests/aws/scenario/bookstore/test_bookstore.snapshot.json
+++ b/tests/aws/scenario/bookstore/test_bookstore.snapshot.json
@@ -549,11 +549,20 @@
     }
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_opensearch_crud": {
-    "recorded-date": "15-07-2024, 12:55:29",
+    "recorded-date": "12-09-2025, 09:51:48",
     "recorded-content": {
       "describe_domains": {
         "DomainStatusList": [
           {
+            "AIMLOptions": {
+              "NaturalLanguageQueryGenerationOptions": {
+                "CurrentState": "NOT_ENABLED",
+                "DesiredState": "DISABLED"
+              },
+              "S3VectorsEngine": {
+                "Enabled": false
+              }
+            },
             "ARN": "arn:<partition>:es:<region>:111111111111:domain/<domain-name:1>",
             "AccessPolicies": "",
             "AdvancedOptions": {
@@ -609,8 +618,9 @@
               "Enabled": false
             },
             "Endpoint": "<endpoint:1>",
-            "EngineVersion": "OpenSearch_2.11",
+            "EngineVersion": "OpenSearch_3.1",
             "IPAddressType": "ipv4",
+            "IdentityCenterOptions": {},
             "ModifyingProperties": [],
             "NodeToNodeEncryptionOptions": {
               "Enabled": false
@@ -628,7 +638,7 @@
             "ServiceSoftwareOptions": {
               "AutomatedUpdateDate": "datetime",
               "Cancellable": false,
-              "CurrentVersion": "OpenSearch_2_11_R20240502-P2",
+              "CurrentVersion": "OpenSearch_3_1_R20250904-P1",
               "Description": "There is no software update available for this domain.",
               "NewVersion": "",
               "OptionalDeployment": true,
@@ -663,6 +673,24 @@
       },
       "describe_domain_config": {
         "DomainConfig": {
+          "AIMLOptions": {
+            "Options": {
+              "NaturalLanguageQueryGenerationOptions": {
+                "CurrentState": "NOT_ENABLED",
+                "DesiredState": "DISABLED"
+              },
+              "S3VectorsEngine": {
+                "Enabled": false
+              }
+            },
+            "Status": {
+              "CreationDate": "datetime",
+              "PendingDeletion": false,
+              "State": "Active",
+              "UpdateDate": "datetime",
+              "UpdateVersion": "update-version"
+            }
+          },
           "AccessPolicies": {
             "Options": "",
             "Status": {
@@ -795,7 +823,7 @@
             }
           },
           "EngineVersion": {
-            "Options": "OpenSearch_2.11",
+            "Options": "OpenSearch_3.1",
             "Status": {
               "CreationDate": "datetime",
               "PendingDeletion": false,
@@ -806,6 +834,16 @@
           },
           "IPAddressType": {
             "Options": "ipv4",
+            "Status": {
+              "CreationDate": "datetime",
+              "PendingDeletion": false,
+              "State": "Active",
+              "UpdateDate": "datetime",
+              "UpdateVersion": "update-version"
+            }
+          },
+          "IdentityCenterOptions": {
+            "Options": {},
             "Status": {
               "CreationDate": "datetime",
               "PendingDeletion": false,
@@ -926,10 +964,8 @@
       "get_compatible_versions": {
         "CompatibleVersions": [
           {
-            "SourceVersion": "OpenSearch_2.11",
-            "TargetVersions": [
-              "OpenSearch_2.13"
-            ]
+            "SourceVersion": "OpenSearch_3.1",
+            "TargetVersions": []
           }
         ],
         "ResponseMetadata": {
@@ -939,6 +975,10 @@
       },
       "list_versions": {
         "Versions": [
+          "OpenSearch_3.1",
+          "OpenSearch_2.19",
+          "OpenSearch_2.17",
+          "OpenSearch_2.15",
           "OpenSearch_2.13",
           "OpenSearch_2.11",
           "OpenSearch_2.9",

--- a/tests/aws/scenario/bookstore/test_bookstore.validation.json
+++ b/tests/aws/scenario/bookstore/test_bookstore.validation.json
@@ -3,7 +3,13 @@
     "last_validated_date": "2024-07-15T12:54:17+00:00"
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_opensearch_crud": {
-    "last_validated_date": "2024-07-15T12:55:29+00:00"
+    "last_validated_date": "2025-09-12T10:07:07+00:00",
+    "durations_in_seconds": {
+      "setup": 1157.65,
+      "call": 3.36,
+      "teardown": 919.26,
+      "total": 2080.27
+    }
   },
   "tests/aws/scenario/bookstore/test_bookstore.py::TestBookstoreApplication::test_search_books": {
     "last_validated_date": "2024-07-15T12:55:25+00:00"

--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -5,8 +5,12 @@ import botocore.exceptions
 import pytest
 
 from localstack import config
-from localstack.constants import ELASTICSEARCH_DEFAULT_VERSION, OPENSEARCH_DEFAULT_VERSION
-from localstack.services.opensearch.packages import elasticsearch_package, opensearch_package
+from localstack.services.opensearch.packages import (
+    ELASTICSEARCH_DEFAULT_VERSION,
+    OPENSEARCH_DEFAULT_VERSION,
+    elasticsearch_package,
+    opensearch_package,
+)
 from localstack.testing.pytest import markers
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import short_uid, start_worker_thread

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -697,7 +697,6 @@ class TestEdgeProxiedOpensearchCluster:
 
             response = requests.get(cluster_url)
             assert response.ok, f"cluster endpoint returned an error: {response.text}"
-            assert response.json()["version"]["number"] == "2.11.1"
 
             response = requests.get(f"{cluster_url}/_cluster/health")
             assert response.ok, f"cluster health endpoint returned an error: {response.text}"

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -24,11 +24,6 @@ from localstack.aws.api.opensearch import (
     OpenSearchPartitionInstanceType,
     VolumeType,
 )
-from localstack.constants import (
-    ELASTICSEARCH_DEFAULT_VERSION,
-    OPENSEARCH_DEFAULT_VERSION,
-    OPENSEARCH_PLUGIN_LIST,
-)
 from localstack.services.opensearch import provider
 from localstack.services.opensearch.cluster import CustomEndpoint, EdgeProxiedOpensearchCluster
 from localstack.services.opensearch.cluster_manager import (
@@ -39,7 +34,12 @@ from localstack.services.opensearch.cluster_manager import (
     SingletonClusterManager,
     create_cluster_manager,
 )
-from localstack.services.opensearch.packages import opensearch_package
+from localstack.services.opensearch.packages import (
+    ELASTICSEARCH_DEFAULT_VERSION,
+    OPENSEARCH_DEFAULT_VERSION,
+    OPENSEARCH_PLUGIN_LIST,
+    opensearch_package,
+)
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.pytest import markers
 from localstack.utils.common import call_safe, poll_condition, retry, short_uid, start_worker_thread

--- a/tests/aws/services/opensearch/test_opensearch.snapshot.json
+++ b/tests/aws/services/opensearch/test_opensearch.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_get_compatible_versions": {
-    "recorded-date": "16-07-2024, 13:05:15",
+    "recorded-date": "12-09-2025, 07:49:30",
     "recorded-content": {
       "source_versions": [
         "Elasticsearch_5.1",
@@ -25,6 +25,10 @@
         "OpenSearch_1.2",
         "OpenSearch_1.3",
         "OpenSearch_2.11",
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19",
         "OpenSearch_2.3",
         "OpenSearch_2.5",
         "OpenSearch_2.7",
@@ -159,37 +163,70 @@
         "OpenSearch_2.7",
         "OpenSearch_2.9",
         "OpenSearch_2.11",
-        "OpenSearch_2.13"
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
       ],
       "source_opensearch_2.11": [
-        "OpenSearch_2.13"
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
+      ],
+      "source_opensearch_2.13": [
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
+      ],
+      "source_opensearch_2.15": [
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
+      ],
+      "source_opensearch_2.17": [
+        "OpenSearch_2.19"
+      ],
+      "source_opensearch_2.19": [
+        "OpenSearch_3.1"
       ],
       "source_opensearch_2.3": [
         "OpenSearch_2.5",
         "OpenSearch_2.7",
         "OpenSearch_2.9",
         "OpenSearch_2.11",
-        "OpenSearch_2.13"
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
       ],
       "source_opensearch_2.5": [
         "OpenSearch_2.7",
         "OpenSearch_2.9",
         "OpenSearch_2.11",
-        "OpenSearch_2.13"
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
       ],
       "source_opensearch_2.7": [
         "OpenSearch_2.9",
         "OpenSearch_2.11",
-        "OpenSearch_2.13"
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
       ],
       "source_opensearch_2.9": [
         "OpenSearch_2.11",
-        "OpenSearch_2.13"
+        "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19"
       ]
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {
-    "recorded-date": "16-07-2024, 13:18:18",
+    "recorded-date": "12-09-2025, 07:47:04",
     "recorded-content": {
       "versions": [
         "Elasticsearch_5.1",
@@ -215,23 +252,29 @@
         "OpenSearch_1.3",
         "OpenSearch_2.11",
         "OpenSearch_2.13",
+        "OpenSearch_2.15",
+        "OpenSearch_2.17",
+        "OpenSearch_2.19",
         "OpenSearch_2.3",
         "OpenSearch_2.5",
         "OpenSearch_2.7",
-        "OpenSearch_2.9"
+        "OpenSearch_2.9",
+        "OpenSearch_3.1"
       ]
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_sql_plugin": {
-    "recorded-date": "03-12-2024, 21:07:16",
+    "recorded-date": "12-09-2025, 07:44:41",
     "recorded-content": {
-      "sql_plugin_installed": true,
       "sql_query_response": {
         "datarows": [
           [
             "I'm just a simple man, trying to make my way in the universe.",
             "Fett",
-            "mandalorian armor",
+            [
+              "mandalorian armor",
+              "tusken culture"
+            ],
             "Boba",
             41
           ]
@@ -265,7 +308,7 @@
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_domain_lifecycle": {
-    "recorded-date": "07-07-2025, 23:26:58",
+    "recorded-date": "12-09-2025, 08:04:43",
     "recorded-content": {
       "account-arn": "<account-arn:1>",
       "create-response": {
@@ -273,6 +316,9 @@
           "NaturalLanguageQueryGenerationOptions": {
             "CurrentState": "NOT_ENABLED",
             "DesiredState": "DISABLED"
+          },
+          "S3VectorsEngine": {
+            "Enabled": false
           }
         },
         "ARN": "arn:<partition>:es:<region>:111111111111:domain/<domain-name:1>",
@@ -344,6 +390,14 @@
           },
           {
             "ActiveValue": "",
+            "Name": "AIMLOptions.S3VectorsEngine",
+            "PendingValue": {
+              "Enabled": false
+            },
+            "ValueType": "STRINGIFIED_JSON"
+          },
+          {
+            "ActiveValue": "",
             "Name": "AdvancedOptions",
             "PendingValue": {
               "override_main_response_version": "false",
@@ -360,6 +414,12 @@
           {
             "ActiveValue": "",
             "Name": "AdvancedSecurityOptions.AnonymousAuthEnabled",
+            "PendingValue": "false",
+            "ValueType": "PLAIN_TEXT"
+          },
+          {
+            "ActiveValue": "",
+            "Name": "AdvancedSecurityOptions.IAMFederationOptions",
             "PendingValue": "false",
             "ValueType": "PLAIN_TEXT"
           },
@@ -582,6 +642,9 @@
           "NaturalLanguageQueryGenerationOptions": {
             "CurrentState": "NOT_ENABLED",
             "DesiredState": "DISABLED"
+          },
+          "S3VectorsEngine": {
+            "Enabled": false
           }
         },
         "ARN": "arn:<partition>:es:<region>:111111111111:domain/<domain-name:1>",
@@ -680,6 +743,9 @@
             "NaturalLanguageQueryGenerationOptions": {
               "CurrentState": "NOT_ENABLED",
               "DesiredState": "DISABLED"
+            },
+            "S3VectorsEngine": {
+              "Enabled": false
             }
           },
           "Status": {
@@ -883,7 +949,7 @@
                 {
                   "Effect": "Allow",
                   "Principal": {
-                    "AWS": "111111111111"
+                    "AWS": "AIDAWJDXAOVI2A5WATHZF"
                   },
                   "Action": "es:*",
                   "Resource": "arn:<partition>:es:<region>:111111111111:domain/<domain-name:1>/*"
@@ -963,6 +1029,9 @@
           "NaturalLanguageQueryGenerationOptions": {
             "CurrentState": "NOT_ENABLED",
             "DesiredState": "DISABLED"
+          },
+          "S3VectorsEngine": {
+            "Enabled": false
           }
         },
         "ARN": "arn:<partition>:es:<region>:111111111111:domain/<domain-name:1>",
@@ -1072,6 +1141,9 @@
           "NaturalLanguageQueryGenerationOptions": {
             "CurrentState": "NOT_ENABLED",
             "DesiredState": "DISABLED"
+          },
+          "S3VectorsEngine": {
+            "Enabled": false
           }
         },
         "ARN": "arn:<partition>:es:<region>:111111111111:domain/<domain-name:1>",

--- a/tests/aws/services/opensearch/test_opensearch.snapshot.json
+++ b/tests/aws/services/opensearch/test_opensearch.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_get_compatible_versions": {
-    "recorded-date": "12-09-2025, 07:49:30",
+    "recorded-date": "12-09-2025, 10:51:06",
     "recorded-content": {
       "source_versions": [
         "Elasticsearch_5.1",

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -1,20 +1,38 @@
 {
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_domain_lifecycle": {
-    "last_validated_date": "2025-07-07T23:26:58+00:00",
+    "last_validated_date": "2025-09-12T08:04:43+00:00",
     "durations_in_seconds": {
-      "setup": 0.53,
-      "call": 839.91,
-      "teardown": 0.25,
-      "total": 840.69
+      "setup": 0.74,
+      "call": 839.36,
+      "teardown": 0.22,
+      "total": 840.32
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_get_compatible_versions": {
-    "last_validated_date": "2024-07-16T13:05:15+00:00"
+    "last_validated_date": "2025-09-12T07:49:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.69,
+      "call": 0.81,
+      "teardown": 0.01,
+      "total": 1.51
+    }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {
-    "last_validated_date": "2024-07-16T13:18:18+00:00"
+    "last_validated_date": "2025-09-12T07:47:04+00:00",
+    "durations_in_seconds": {
+      "setup": 0.84,
+      "call": 0.92,
+      "teardown": 0.01,
+      "total": 1.77
+    }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_sql_plugin": {
-    "last_validated_date": "2024-12-03T21:07:16+00:00"
+    "last_validated_date": "2025-09-12T07:44:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.94,
+      "call": 1317.86,
+      "teardown": 0.96,
+      "total": 1319.76
+    }
   }
 }

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -9,12 +9,12 @@
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_get_compatible_versions": {
-    "last_validated_date": "2025-09-12T07:49:30+00:00",
+    "last_validated_date": "2025-09-12T10:51:06+00:00",
     "durations_in_seconds": {
-      "setup": 0.69,
-      "call": 0.81,
+      "setup": 0.8,
+      "call": 0.82,
       "teardown": 0.01,
-      "total": 1.51
+      "total": 1.63
     }
   },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_list_versions": {


### PR DESCRIPTION
## Motivation
The LocalStack emulation of OpenSearch is a bit behind in terms of which OpenSearch version the service supports.
This PR updates the service such that it is on-par with AWS again.
Associated docs PR: https://github.com/localstack/localstack-docs/pull/190

## Changes
- Add new versions for OpenSearch:
  - 2.15
  - 2.17
  - 2.19
  - 3.1
- Set the new default version for OpenSearch domains (if no version is set) to 3.1