### PR TITLE
Update version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-:zap: We are thrilled to announce the release of <a href="https://blog.localstack.cloud/localstack-for-aws-release-v-4-7-0/">LocalStack 4.7</a> :zap:
+:zap: We are thrilled to announce the release of <a href="https://blog.localstack.cloud/localstack-for-aws-release-v-4-8-0/">LocalStack 4.8</a> :zap:
 </p>
 
 <p align="center">
@@ -93,7 +93,7 @@ Start LocalStack inside a Docker container by running:
   / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
  /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|
 
-- LocalStack CLI: 4.7.0
+- LocalStack CLI: 4.8.0
 - Profile: default
 - App: https://app.localstack.cloud
 


### PR DESCRIPTION
## Motivation
Yesterday we released LocalStack for AWS 4.8.0. This PR updates the `README.md` accordingly.
Similar to https://github.com/localstack/localstack/pull/12942 for 4.7.0. :)

## Changes
- Updates the version in the README and the blog link to 4.8.0.