### PR TITLE
CFn: better validation of select construct

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -843,13 +843,22 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
     ):
         # TODO: add further support for schema validation
         def _compute_fn_select(args: list[Any]) -> Any:
-            values: list[Any] = args[1]
+            values = args[1]
             if not isinstance(values, list) or not values:
-                raise RuntimeError(f"Invalid arguments list value for Fn::Select: '{values}'")
+                raise ValidationError(
+                    "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"
+                )
             values_len = len(values)
-            index: int = int(args[0])
-            if not isinstance(index, int) or index < 0 or index > values_len:
-                raise RuntimeError(f"Invalid or out of range index value for Fn::Select: '{index}'")
+            try:
+                index: int = int(args[0])
+            except ValueError as e:
+                raise ValidationError(
+                    "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"
+                ) from e
+            if index < 0 or index >= values_len:
+                raise ValidationError(
+                    "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"
+                )
             selection = values[index]
             return selection
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -855,6 +855,12 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
                 raise ValidationError(
                     "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"
                 ) from e
+
+            # defer evaluation if the selection list contains unresolved elements (e.g., unresolved intrinsics)
+            if any(v is None for v in values):
+                raise RuntimeError("Fn::Select list contains unresolved elements")
+
+            values_len = len(values)
             if index < 0 or index >= values_len:
                 raise ValidationError(
                     "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"

--- a/tests/aws/services/cloudformation/test_change_set_fn_select.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_select.snapshot.json
@@ -2388,5 +2388,53 @@
         "Tags": []
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_invalid_select_index_type[non-integer-index]": {
+    "recorded-date": "12-09-2025, 11:09:16",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template error: Fn::Select requires a list argument with two elements: an integer index and a list",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_invalid_select_index_type[non-list-list]": {
+    "recorded-date": "12-09-2025, 11:09:16",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template error: Fn::Select requires a list argument with two elements: an integer index and a list",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_invalid_select_index_type[index-out-of-range]": {
+    "recorded-date": "12-09-2025, 11:09:16",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template error: Fn::Select requires a list argument with two elements: an integer index and a list",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_select.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_select.validation.json
@@ -16,5 +16,32 @@
   },
   "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_fn_select_remove_from_static_property": {
     "last_validated_date": "2025-05-28T13:17:47+00:00"
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_invalid_select_index_type[index-out-of-range]": {
+    "last_validated_date": "2025-09-12T11:09:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.13,
+      "teardown": 0.0,
+      "total": 0.13
+    }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_invalid_select_index_type[non-integer-index]": {
+    "last_validated_date": "2025-09-12T11:09:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.76,
+      "call": 0.3,
+      "teardown": 0.0,
+      "total": 1.06
+    }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_invalid_select_index_type[non-list-list]": {
+    "last_validated_date": "2025-09-12T11:09:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.14,
+      "teardown": 0.0,
+      "total": 0.14
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A user experienced the following issue when deploying their stack:

```
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py", line 853, in _compute_fn_select
    selection = values[index]
```

We already have validation of index, but guess what: it was an off-by-one error!

> [!NOTE]
> This was actually during template _modelling_ and was not a result of an error on their part. In the transformer we try to call the preprocessor's method (in case any child intrinsic functions only access parameter values) and ignore any exceptions and continue visiting. However in this case the bad index check was raising an `IndexError` rather than the specific `RuntimeError` that we already catch.
> We should still be more strict in validating the select construct



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Fix the off-by-one error
* Add tests covering other bad select constructions

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
