### PR TITLE
CFn: fix invalid behaviour for nested intrinsic calls

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -844,21 +844,20 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         # TODO: add further support for schema validation
         def _compute_fn_select(args: list[Any]) -> Any:
             values = args[1]
+            # defer evaluation if the selection list contains unresolved elements (e.g., unresolved intrinsics)
+            if isinstance(values, list) and not all(isinstance(value, str) for value in values):
+                raise RuntimeError("Fn::Select list contains unresolved elements")
+
             if not isinstance(values, list) or not values:
                 raise ValidationError(
                     "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"
                 )
-            values_len = len(values)
             try:
                 index: int = int(args[0])
             except ValueError as e:
                 raise ValidationError(
                     "Template error: Fn::Select requires a list argument with two elements: an integer index and a list"
                 ) from e
-
-            # defer evaluation if the selection list contains unresolved elements (e.g., unresolved intrinsics)
-            if any(v is None for v in values):
-                raise RuntimeError("Fn::Select list contains unresolved elements")
 
             values_len = len(values)
             if index < 0 or index >= values_len:

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_transform.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_transform.py
@@ -501,7 +501,10 @@ class ChangeSetModelTransform(ChangeSetModelPreproc):
     def visit_node_intrinsic_function_fn_get_att(
         self, node_intrinsic_function: NodeIntrinsicFunction
     ) -> PreprocEntityDelta:
-        return self.visit(node_intrinsic_function.arguments)
+        try:
+            return super().visit_node_intrinsic_function_fn_get_att(node_intrinsic_function)
+        except RuntimeError:
+            return self.visit(node_intrinsic_function.arguments)
 
     def visit_node_intrinsic_function_fn_sub(
         self, node_intrinsic_function: NodeIntrinsicFunction

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_validator.py
@@ -4,7 +4,6 @@ from typing import Any
 from botocore.exceptions import ParamValidationError
 
 from localstack.services.cloudformation.engine.v2.change_set_model import (
-    Maybe,
     NodeIntrinsicFunction,
     NodeProperty,
     NodeResource,
@@ -32,19 +31,10 @@ class ChangeSetModelValidator(ChangeSetModelPreproc):
     def visit_node_intrinsic_function_fn_get_att(
         self, node_intrinsic_function: NodeIntrinsicFunction
     ) -> PreprocEntityDelta:
-        arguments_delta = self.visit(node_intrinsic_function.arguments)
-        before_arguments: Maybe[str | list[str]] = arguments_delta.before
-        after_arguments: Maybe[str | list[str]] = arguments_delta.after
-
-        before = self._before_cache.get(node_intrinsic_function.scope, Nothing)
-        if is_nothing(before) and not is_nothing(before_arguments):
-            before = ".".join(before_arguments)
-
-        after = self._after_cache.get(node_intrinsic_function.scope, Nothing)
-        if is_nothing(after) and not is_nothing(after_arguments):
-            after = ".".join(after_arguments)
-
-        return PreprocEntityDelta(before=before, after=after)
+        try:
+            return super().visit_node_intrinsic_function_fn_get_att(node_intrinsic_function)
+        except RuntimeError:
+            return self.visit(node_intrinsic_function.arguments)
 
     def visit_node_intrinsic_function_fn_sub(
         self, node_intrinsic_function: NodeIntrinsicFunction

--- a/localstack-core/localstack/services/ecr/resource_providers/aws_ecr_repository.py
+++ b/localstack-core/localstack/services/ecr/resource_providers/aws_ecr_repository.py
@@ -90,6 +90,10 @@ class ECRRepositoryProvider(ResourceProvider[ECRRepositoryProperties]):
 
         """
         model = request.desired_state
+        model["RepositoryName"] = (
+            model.get("RepositoryName")
+            or util.generate_default_name(request.stack_name, request.logical_resource_id).lower()
+        )
 
         default_repos_per_stack[request.stack_name] = model["RepositoryName"]
         LOG.warning(

--- a/tests/aws/services/cloudformation/test_change_set_fn_select.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_select.snapshot.json
@@ -2436,5 +2436,14 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_nested_select_within_other_intrinsics": {
+    "recorded-date": "16-09-2025, 10:30:37",
+    "recorded-content": {
+      "parameter-value": {
+        "ParameterValue": "111111111111.dkr.ecr.<region>.<domain>/<repo-name>",
+        "RepoName": "<repo-name>"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_fn_select.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_fn_select.validation.json
@@ -43,5 +43,14 @@
       "teardown": 0.0,
       "total": 0.14
     }
+  },
+  "tests/aws/services/cloudformation/test_change_set_fn_select.py::TestChangeSetFnSelect::test_nested_select_within_other_intrinsics": {
+    "last_validated_date": "2025-09-16T10:30:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.95,
+      "call": 12.37,
+      "teardown": 6.51,
+      "total": 19.83
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A previous PR #13136 broke template deployment in the Pro repsitory. The issue was that while visiting the template for CreateChangeSet in the transformer, we were not handling the case where the nested intrinsic function calls would not return `None` but would still return a semi-valid transformed value. In particular, the inner intrinsic would return the visited arguments (say `["Resource", "Attribute"]` from a `GetAtt` call. The arguments to select may be something like:

```
Fn::Select: [4, [":", ["Resource", "Attribute"]]]
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    the result of visiting `Fn::Join` arguments
                      ^^^^^^^^^^^^^^^^^^^^^^^^      the result of visiting `Fn::GetAtt` arguments
             ^                                      index still out of range
```


This problem is really highlighting that we need a way of traversing the template, but returning a _KNOWN_ sentinel value representing an unknown value. Let's tackle this in a follow up.



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Fix the `Fn::Select` argument handling
* Add validated test that captures the behaviour that failed in the Pro pipeline
* Update the `transform` `visit...get_att` to better match the other overrides
* Update the `validator` `visit...get_att` to replicate the structure of the `transform` implementation
* Update the ECR repo resource provider to assign a default repository name
    * Ensure the name is lowercase to match the regex that ECR expects: `(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
