### PR TITLE
unpin moto-ext, upgrade to 5.1.12.post22

### DIFF
--- a/localstack-core/localstack/services/ses/provider.py
+++ b/localstack-core/localstack/services/ses/provider.py
@@ -183,6 +183,8 @@ class SesProvider(SesApi, ServiceLifecycleHook):
     #
 
     def on_after_init(self):
+        self._apply_patches()
+
         # Allow sent emails to be retrieved from the SES emails endpoint
         register_ses_api_resource()
 
@@ -197,6 +199,12 @@ class SesProvider(SesApi, ServiceLifecycleHook):
             if "From:" in entity:
                 return entity.replace("From:", "").strip()
         return None
+
+    def _apply_patches(self) -> None:
+        # Suppress Moto's validation of receipt rule actions. These validations use Moto's implementation of S3, Lambda
+        # and SQS, which fail because these services have been internalised in LocalStack.
+        # Besides, AWS does not run the same validations as evidenced by our AWS-validated tests.
+        SESBackend._validate_receipt_rule_actions = lambda *_: None
 
     #
     # Implementations for SES operations
@@ -519,8 +527,10 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         backend.create_receipt_rule_set(rule_set_name)
         original_rule_set = backend.describe_receipt_rule_set(original_rule_set_name)
 
+        after = None
         for rule in original_rule_set.rules:
-            backend.create_receipt_rule(rule_set_name, rule)
+            backend.create_receipt_rule(rule_set_name, rule, after)
+            after = rule["Name"]
 
         return CloneReceiptRuleSetResponse()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.11.post1",
+    "moto-ext[all]>=5.1.12.post22",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.11.post1
+moto-ext==5.1.12.post22
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.11.post1
+moto-ext==5.1.12.post22
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.11.post1
+moto-ext==5.1.12.post22
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.11.post1
+moto-ext==5.1.12.post22
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/tests/aws/services/ses/test_ses.snapshot.json
+++ b/tests/aws/services/ses/test_ses.snapshot.json
@@ -806,7 +806,7 @@
     }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_clone_receipt_rule_set": {
-    "recorded-date": "25-08-2023, 23:05:14",
+    "recorded-date": "17-09-2025, 11:56:18",
     "recorded-content": {
       "create-receipt-rule-set": {
         "ResponseMetadata": {

--- a/tests/aws/services/ses/test_ses.validation.json
+++ b/tests/aws/services/ses/test_ses.validation.json
@@ -3,7 +3,13 @@
     "last_validated_date": "2023-08-25T22:04:12+00:00"
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_clone_receipt_rule_set": {
-    "last_validated_date": "2023-08-25T21:05:14+00:00"
+    "last_validated_date": "2025-09-17T11:56:18+00:00",
+    "durations_in_seconds": {
+      "setup": 1.83,
+      "call": 2.56,
+      "teardown": 2.05,
+      "total": 6.44
+    }
   },
   "tests/aws/services/ses/test_ses.py::TestSES::test_creating_event_destination_without_configuration_set": {
     "last_validated_date": "2023-08-25T22:04:35+00:00"


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/moto/pull/78, we introduced a new workflow in `localstack/moto` which should automatically - on a weekly schedule - sync-rebase and release our fork of `moto` (pushing `moto-ext` to pypi).
In order to implement this continuous integration of changes in `moto` here in LocalStack, we now should now make sure that updates to `moto(-ext)` get included regularly.
This is why this PR removes the pin to a specific version in the requirements of `localstack-core` and bumps the version of `moto-ext` to the latest release (the first one which has been created fully automatically).

This bump will cause some issues (since there was quite a distance), but afterwards we are hoping that the more frequent integration decreases the pain there. Basically this means getting a bit lower on the X-axis on this simple diagram from Martin Fowler ([posted 14 years ago in this blog post](https://martinfowler.com/bliki/FrequencyReducesDifficulty.html) 😅) will hopefully get us down on the pain axis:
<img width="560" height="300" alt="image" src="https://github.com/user-attachments/assets/84f55502-c129-409e-9d4b-b2f753d9c963" />

## Changes
- Unpin `moto-ext` in the `pyproject.toml`
- Update the dependency pins for `moto-ext`
- TODO: Add fixes to upgrade to the latest version here.

## TODO
- [x] Make sure all pipelines here and in our downstream project are 💚 

## Related

Related to PNX-127