### PR TITLE
CFn: implement list change sets for new provider

### DIFF
--- a/tests/aws/services/cloudformation/test_change_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_sets.snapshot.json
@@ -5927,5 +5927,28 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_change_sets.py::test_list_change_sets": {
+    "recorded-date": "16-09-2025, 14:49:32",
+    "recorded-content": {
+      "change-sets": {
+        "Summaries": [
+          {
+            "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "ChangeSetName": "<change-set-name:1>",
+            "CreationTime": "datetime",
+            "ExecutionStatus": "AVAILABLE",
+            "IncludeNestedStacks": false,
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Status": "CREATE_COMPLETE"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_sets.validation.json
+++ b/tests/aws/services/cloudformation/test_change_sets.validation.json
@@ -125,6 +125,15 @@
       "total": 23.45
     }
   },
+  "tests/aws/services/cloudformation/test_change_sets.py::test_list_change_sets": {
+    "last_validated_date": "2025-09-16T14:49:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.95,
+      "call": 15.36,
+      "teardown": 4.4,
+      "total": 20.71
+    }
+  },
   "tests/aws/services/cloudformation/test_change_sets.py::test_single_resource_static_update": {
     "last_validated_date": "2025-03-18T16:52:35+00:00"
   },


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I was playing around with our [local-surf](https://github.com/localstack/local-surf) extension trying to find missing pieces of the provider. I found that `list_change_sets` has not been migrated to the new provider so there were error messages.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Implement list-change-sets


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
