### PR TITLE
ASF: implement multi-protocol support

### DIFF
--- a/localstack-core/localstack/aws/api/core.py
+++ b/localstack-core/localstack/aws/api/core.py
@@ -115,6 +115,7 @@ class RequestContext(RoloRequestContext):
     def __init__(self, request: Request):
         super().__init__(request)
         self.service = None
+        self.protocol = None
         self.operation = None
         self.region = None  # type: ignore[assignment]  # type=str, because we know it will always be set downstream
         self.partition = "aws"  # Sensible default - will be overwritten by region-handler

--- a/localstack-core/localstack/aws/api/core.py
+++ b/localstack-core/localstack/aws/api/core.py
@@ -13,6 +13,7 @@ from botocore.model import OperationModel, ServiceModel
 from rolo.gateway import RequestContext as RoloRequestContext
 
 from localstack.aws.connect import InternalRequestParameters
+from localstack.aws.spec import ProtocolName
 from localstack.http import Request, Response
 from localstack.utils.strings import long_uid
 
@@ -88,6 +89,8 @@ class RequestContext(RoloRequestContext):
     """The underlying incoming HTTP request."""
     service: ServiceModel | None
     """The botocore ServiceModel of the service the request is made to."""
+    protocol: ProtocolName | None
+    """The botocore Protocol for the service the request is made to."""
     operation: OperationModel | None
     """The botocore OperationModel of the AWS operation being invoked."""
     region: str

--- a/localstack-core/localstack/aws/handlers/service.py
+++ b/localstack-core/localstack/aws/handlers/service.py
@@ -66,7 +66,7 @@ class ServiceRequestParser(Handler):
         return self.parse_and_enrich(context)
 
     def parse_and_enrich(self, context: RequestContext):
-        parser = create_parser(context.service)
+        parser = create_parser(context.service, context.protocol)
         operation, instance = parser.parse(context.request)
 
         # enrich context
@@ -140,7 +140,7 @@ class ServiceRequestRouter(Handler):
         operation_name = operation.name
         message = f"no handler for operation '{operation_name}' on service '{service_name}'"
         error = CommonServiceException("InternalFailure", message, status_code=501)
-        serializer = create_serializer(context.service)
+        serializer = create_serializer(context.service, context.protocol)
         return serializer.serialize_error_to_response(
             error, operation, context.request.headers, context.request_id
         )
@@ -212,7 +212,7 @@ class ServiceExceptionSerializer(ExceptionHandler):
             ).with_traceback(exception.__traceback__)
             context.service_exception = error
 
-        serializer = create_serializer(context.service)  # TODO: serializer cache
+        serializer = create_serializer(context.service, context.protocol)
         return serializer.serialize_error_to_response(
             error, operation, context.request.headers, context.request_id
         )

--- a/localstack-core/localstack/aws/handlers/service.py
+++ b/localstack-core/localstack/aws/handlers/service.py
@@ -17,7 +17,7 @@ from ..chain import CompositeResponseHandler, ExceptionHandler, Handler, Handler
 from ..client import parse_response, parse_service_exception
 from ..protocol.parser import RequestParser, create_parser
 from ..protocol.serializer import create_serializer
-from ..protocol.service_router import determine_aws_service_model
+from ..protocol.service_router import determine_aws_protocol, determine_aws_service_model
 from ..skeleton import Skeleton, create_skeleton
 
 LOG = logging.getLogger(__name__)
@@ -33,6 +33,8 @@ class ServiceNameParser(Handler):
         # example). If it is already set, we can skip the parsing of the request. It is very important for S3, because
         # parsing the request will consume the data stream and prevent streaming.
         if context.service:
+            if not context.protocol:
+                context.protocol = determine_aws_protocol(context.request, context.service)
             return
 
         service_model = determine_aws_service_model(context.request)
@@ -41,6 +43,7 @@ class ServiceNameParser(Handler):
             return
 
         context.service = service_model
+        context.protocol = determine_aws_protocol(context.request, service_model)
 
 
 class ServiceRequestParser(Handler):

--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -1266,8 +1266,6 @@ class BaseRpcV2RequestParser(RequestParser):
                 "RPC v2 does not accept 'X-Amz-Target' or 'X-Amzn-Target'. "
                 "Such requests are rejected for security reasons."
             )
-        # TODO: add this special path handling to the ServiceNameParser to allow RPC v2 service to be properly extracted
-        #  path = '/service/{service_name}/operation/{operation_name}'
         # The Smithy RPCv2 CBOR protocol will only use the last four segments of the URL when routing requests.
         rpc_v2_params = request.path.lstrip("/").split("/")
         if len(rpc_v2_params) < 4 or not (

--- a/localstack-core/localstack/aws/protocol/parser.py
+++ b/localstack-core/localstack/aws/protocol/parser.py
@@ -1580,8 +1580,6 @@ def create_parser(service: ServiceModel, protocol: ProtocolName | None = None) -
         # this is not an "official" protocol defined from the spec, but is derived from ``json``
     }
 
-    # TODO: do we want to add a check if the user-defined protocol is part of the available ones in the ServiceModel?
-    #  or should it be checked once
     service_protocol = protocol or service.protocol
 
     # Try to select a service- and protocol-specific parser implementation

--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -2304,7 +2304,7 @@ def aws_response_serializer(
     def _decorate(fn):
         service_model = load_service(service_name, protocol=protocol)
         operation_model = service_model.operation_model(operation)
-        serializer = create_serializer(service_model)
+        serializer = create_serializer(service_model, protocol=protocol)
 
         def _proxy(*args, **kwargs) -> WerkzeugResponse:
             # extract request from function invocation (decorator can be used for methods as well as for functions).

--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -2263,9 +2263,6 @@ def create_serializer(
         #  CBOR handling from JSONResponseParser
         # this is not an "official" protocol defined from the spec, but is derived from ``json``
     }
-    # TODO: even though our Service Name Parser will only use a protocol that is available for the service, we might
-    #  want to verify if the given protocol here is available for that service, in case we are manually calling
-    #  this factory. Revisit once we implement multi-protocol support
     service_protocol = protocol or service.protocol
 
     # Try to select a service- and protocol-specific serializer implementation

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -54,6 +54,7 @@ def _extract_service_indicators(request: Request) -> _ServiceIndicators:
     """Extracts all different fields that might indicate which service a request is targeting."""
     x_amz_target = request.headers.get("x-amz-target")
     authorization = request.headers.get("authorization")
+    is_rpc_v2 = "rpc-v2-cbor" in request.headers.get("Smithy-Protocol", "")
 
     signing_name = None
     if authorization:
@@ -66,7 +67,15 @@ def _extract_service_indicators(request: Request) -> _ServiceIndicators:
         except (ValueError, KeyError):
             LOG.debug("auth header could not be parsed for service routing: %s", authorization)
             pass
-    if x_amz_target:
+    if is_rpc_v2:
+        # https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests
+        rpc_v2_params = request.path.lstrip("/").split("/")
+        if len(rpc_v2_params) >= 4:
+            *_, service_shape_name, __, operation = rpc_v2_params
+            target_prefix = service_shape_name.split("#")[-1]
+        else:
+            target_prefix, operation = None, None
+    elif x_amz_target:
         if "." in x_amz_target:
             target_prefix, operation = x_amz_target.split(".", 1)
         else:

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -6,9 +6,11 @@ from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.http import parse_dict_header
 
 from localstack.aws.spec import (
+    ProtocolName,
     ServiceCatalog,
     ServiceModelIdentifier,
     get_service_catalog,
+    is_protocol_in_service_model_identifier,
 )
 from localstack.http import Request
 from localstack.services.s3.utils import uses_host_addressing
@@ -16,6 +18,15 @@ from localstack.services.sqs.utils import is_sqs_queue_url
 from localstack.utils.strings import to_bytes
 
 LOG = logging.getLogger(__name__)
+
+_PROTOCOL_DETECTION_PRIORITY: list[ProtocolName] = [
+    "smithy-rpc-v2-cbor",
+    "json",
+    "query",
+    "ec2",
+    "rest-json",
+    "rest-xml",
+]
 
 
 class _ServiceIndicators(NamedTuple):
@@ -65,6 +76,46 @@ def _extract_service_indicators(request: Request) -> _ServiceIndicators:
         target_prefix, operation = None, None
 
     return _ServiceIndicators(signing_name, target_prefix, operation, request.host, request.path)
+
+
+def _matches_protocol(request: Request, protocol: ProtocolName) -> bool:
+    headers = request.headers
+    content_type = headers.get("Content-Type", "").lower()
+    match protocol:
+        case "smithy-rpc-v2-cbor":
+            # Every request for the rpcv2Cbor protocol MUST contain a `Smithy-Protocol` header with the value
+            # of `rpc-v2-cbor`.
+            # https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html
+            return headers.get("Smithy-Protocol", "") == "rpc-v2-cbor"
+        case "json":
+            return content_type.startswith("application/x-amz-json")
+        case "query" | "ec2":
+            # https://smithy.io/2.0/aws/protocols/aws-query-protocol.html#request-serialization
+            return content_type == "application/x-www-form-urlencoded"
+        case "rest-xml" | "rest-json":
+            # `rest-json` and `rest-xml` can accept any kind of Content-Type, and it can be configured on the operation
+            # level.
+            # https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html
+            return True
+        case _:
+            return False
+
+
+def _get_protocol_from_request(
+    request: Request, available_protocols: list[ProtocolName]
+) -> ProtocolName | None:
+    """
+    Tries to match the current request and determine the protocol used amongst the available protocols given.
+    We use a priority order to try to determine the protocol, as some protocols are more permissive that others.
+    :param request: the incoming request
+    :param available_protocols: the available protocols of the Service the request is directed to
+    :return: the protocol matched, if any
+    """
+    for protocol in _PROTOCOL_DETECTION_PRIORITY:
+        if protocol in available_protocols and _matches_protocol(request, protocol):
+            return protocol
+
+    return None
 
 
 signing_name_path_prefix_rules = {
@@ -248,10 +299,10 @@ def resolve_conflicts(
         # The `application/x-amz-json-1.0` header is mandatory for requests targeting SQS with the `json` protocol. We
         # can safely route them to the `sqs` JSON parser/serializer. If not present, route the request to the
         # sqs-query protocol.
-        content_type = request.headers.get("Content-Type")
+        protocol = _get_protocol_from_request(request, available_protocols=["json", "query"])
         return (
             ServiceModelIdentifier("sqs")
-            if content_type == "application/x-amz-json-1.0"
+            if protocol == "json"
             else ServiceModelIdentifier("sqs", "query")
         )
 
@@ -266,7 +317,19 @@ def determine_aws_service_model_for_data_plane(
     custom_host_match = custom_host_addressing_rules(request.host)
     if custom_host_match:
         services = services or get_service_catalog()
-        return services.get(*custom_host_match)
+        return services.get(custom_host_match.name, custom_host_match.protocol)
+
+
+def determine_aws_protocol(request: Request, service_model: ServiceModel) -> ProtocolName:
+    if not (protocols := service_model.metadata.get("protocols")):
+        # if the service does not define multiple protocols, return the `protocol` defined for the service
+        return service_model.protocol
+
+    if protocol := _get_protocol_from_request(request, available_protocols=protocols):
+        return protocol
+
+    # if we could not determine the protocol based on the request, we fall back to the default protocol of the service
+    return service_model.protocol
 
 
 def determine_aws_service_model(
@@ -287,12 +350,13 @@ def determine_aws_service_model(
         signing_name_candidates = services.by_signing_name(signing_name)
         if len(signing_name_candidates) == 1:
             # a unique signing-name -> service name mapping is the case for ~75% of service operations
-            return services.get(*signing_name_candidates[0])
+            candidate = signing_name_candidates[0]
+            return services.get(candidate.name, candidate.protocol)
 
         # try to find a match with the custom signing name rules
         custom_match = custom_signing_name_rules(signing_name, path)
         if custom_match:
-            return services.get(*custom_match)
+            return services.get(custom_match.name, custom_match.protocol)
 
         # still ambiguous - add the services to the list of candidates
         candidates.update(signing_name_candidates)
@@ -302,33 +366,34 @@ def determine_aws_service_model(
         target_candidates = services.by_target_prefix(target_prefix)
         if len(target_candidates) == 1:
             # a unique target prefix
-            return services.get(*target_candidates[0])
+            candidate = target_candidates[0]
+            return services.get(candidate.name, candidate.protocol)
 
         # still ambiguous - add the services to the list of candidates
         candidates.update(target_candidates)
 
         # exclude services where the operation is not contained in the service spec
         for service_identifier in list(candidates):
-            service = services.get(*service_identifier)
+            service = services.get(service_identifier.name, service_identifier.protocol)
             if operation not in service.operation_names:
                 candidates.remove(service_identifier)
     else:
         # exclude services which have a target prefix (the current request does not have one)
         for service_identifier in list(candidates):
-            service = services.get(*service_identifier)
+            service = services.get(service_identifier.name, service_identifier.protocol)
             if service.metadata.get("targetPrefix") is not None:
                 candidates.remove(service_identifier)
 
     if len(candidates) == 1:
         service_identifier = candidates.pop()
-        return services.get(*service_identifier)
+        return services.get(service_identifier.name, service_identifier.protocol)
 
     # 3. check the path if it is set and not a trivial root path
     if path and path != "/":
         # try to find a match with the custom path rules
         custom_path_match = custom_path_addressing_rules(path)
         if custom_path_match:
-            return services.get(*custom_path_match)
+            return services.get(custom_path_match.name, custom_path_match.protocol)
 
     # 4. check the host (custom host addressing rules)
     if host:
@@ -337,12 +402,14 @@ def determine_aws_service_model(
             # this prevents a virtual host addressed bucket to be wrongly recognized
             if host.startswith(f"{prefix}.") and ".s3." not in host:
                 if len(services_per_prefix) == 1:
-                    return services.get(*services_per_prefix[0])
+                    candidate = services_per_prefix[0]
+                    return services.get(candidate.name, candidate.protocol)
                 candidates.update(services_per_prefix)
 
         custom_host_match = custom_host_addressing_rules(host)
         if custom_host_match:
-            return services.get(*custom_host_match)
+            candidate = custom_host_match[0]
+            return services.get(candidate.name, candidate.protocol)
 
     if request.shallow:
         # from here on we would need access to the request body, which doesn't exist for shallow requests like
@@ -357,21 +424,28 @@ def determine_aws_service_model(
             query_candidates = [
                 service
                 for service in services.by_operation(values["Action"])
-                if service.protocol in ("ec2", "query")
+                if any(
+                    is_protocol_in_service_model_identifier(protocol, service)
+                    for protocol in ("ec2", "query")
+                )
             ]
 
             if len(query_candidates) == 1:
-                return services.get(*query_candidates[0])
+                candidate = query_candidates[0]
+                return services.get(candidate.name, candidate.protocol)
 
             if "Version" in values:
                 for service_identifier in list(query_candidates):
-                    service_model = services.get(*service_identifier)
+                    service_model = services.get(
+                        service_identifier.name, service_identifier.protocol
+                    )
                     if values["Version"] != service_model.api_version:
                         # the combination of Version and Action is not unique, add matches to the candidates
                         query_candidates.remove(service_identifier)
 
             if len(query_candidates) == 1:
-                return services.get(*query_candidates[0])
+                candidate = query_candidates[0]
+                return services.get(candidate.name, candidate.protocol)
 
             candidates.update(query_candidates)
 
@@ -387,15 +461,16 @@ def determine_aws_service_model(
     # 6. resolve service spec conflicts
     resolved_conflict = resolve_conflicts(candidates, request)
     if resolved_conflict:
-        return services.get(*resolved_conflict)
+        return services.get(resolved_conflict.name, resolved_conflict.protocol)
 
     # 7. check the legacy S3 rules in the end
     legacy_match = legacy_s3_rules(request)
     if legacy_match:
-        return services.get(*legacy_match)
+        return services.get(legacy_match.name, legacy_match.protocol)
 
     if signing_name:
         return services.get(name=signing_name)
     if candidates:
-        return services.get(*candidates.pop())
+        candidate = candidates.pop()
+        return services.get(candidate.name, candidate.protocol)
     return None

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -29,6 +29,14 @@ _PROTOCOL_DETECTION_PRIORITY: list[ProtocolName] = [
 ]
 
 
+class ProtocolError(Exception):
+    """
+    Error which is thrown if we cannot detect the protocol for the request.
+    """
+
+    pass
+
+
 class _ServiceIndicators(NamedTuple):
     """
     Encapsulates the different fields that might indicate which service a request is targeting.
@@ -337,9 +345,11 @@ def determine_aws_protocol(request: Request, service_model: ServiceModel) -> Pro
     if protocol := _get_protocol_from_request(request, available_protocols=protocols):
         return protocol
 
-    # TODO: raise error here!!!
-    # if we could not determine the protocol based on the request, we fall back to the default protocol of the service
-    return service_model.protocol
+    raise ProtocolError(
+        f"Could not determine the protocol for the request: "
+        f"{request.method} {request.path} for the service '{service_model.service_name}' "
+        f"(available protocols: {protocols}"
+    )
 
 
 def determine_aws_service_model(

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -353,7 +353,7 @@ def determine_aws_protocol(request: Request, service_model: ServiceModel) -> Pro
     raise ProtocolError(
         f"Could not determine the protocol for the request: "
         f"{request.method} {request.path} for the service '{service_model.service_name}' "
-        f"(available protocols: {protocols}"
+        f"(available protocols: {protocols})"
     )
 
 

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -120,7 +120,7 @@ def _matches_protocol(request: Request, protocol: ProtocolName) -> bool:
             return False
 
 
-def get_protocol_from_request(
+def match_available_protocols(
     request: Request, available_protocols: list[ProtocolName]
 ) -> ProtocolName | None:
     """
@@ -318,7 +318,7 @@ def resolve_conflicts(
         # The `application/x-amz-json-1.0` header is mandatory for requests targeting SQS with the `json` protocol. We
         # can safely route them to the `sqs` JSON parser/serializer. If not present, route the request to the
         # sqs-query protocol.
-        protocol = get_protocol_from_request(request, available_protocols=["json", "query"])
+        protocol = match_available_protocols(request, available_protocols=["json", "query"])
         return (
             ServiceModelIdentifier("sqs")
             if protocol == "json"
@@ -347,7 +347,7 @@ def determine_aws_protocol(request: Request, service_model: ServiceModel) -> Pro
     if len(protocols) == 1:
         return protocols[0]
 
-    if protocol := get_protocol_from_request(request, available_protocols=protocols):
+    if protocol := match_available_protocols(request, available_protocols=protocols):
         return protocol
 
     raise ProtocolError(

--- a/localstack-core/localstack/aws/protocol/service_router.py
+++ b/localstack-core/localstack/aws/protocol/service_router.py
@@ -89,7 +89,7 @@ def _extract_service_indicators(request: Request) -> _ServiceIndicators:
 
 def _matches_protocol(request: Request, protocol: ProtocolName) -> bool:
     headers = request.headers
-    content_type = headers.get("Content-Type", "").lower()
+    mimetype = request.mimetype.lower()
     match protocol:
         case "smithy-rpc-v2-cbor":
             # Every request for the rpcv2Cbor protocol MUST contain a `Smithy-Protocol` header with the value
@@ -97,10 +97,10 @@ def _matches_protocol(request: Request, protocol: ProtocolName) -> bool:
             # https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html
             return headers.get("Smithy-Protocol", "") == "rpc-v2-cbor"
         case "json":
-            return content_type.startswith("application/x-amz-json")
+            return mimetype.startswith("application/x-amz-json")
         case "query" | "ec2":
             # https://smithy.io/2.0/aws/protocols/aws-query-protocol.html#request-serialization
-            return content_type == "application/x-www-form-urlencoded"
+            return mimetype.startswith("application/x-www-form-urlencoded")
         case "rest-xml" | "rest-json":
             # `rest-json` and `rest-xml` can accept any kind of Content-Type, and it can be configured on the operation
             # level.
@@ -337,6 +337,7 @@ def determine_aws_protocol(request: Request, service_model: ServiceModel) -> Pro
     if protocol := _get_protocol_from_request(request, available_protocols=protocols):
         return protocol
 
+    # TODO: raise error here!!!
     # if we could not determine the protocol based on the request, we fall back to the default protocol of the service
     return service_model.protocol
 

--- a/localstack-core/localstack/aws/skeleton.py
+++ b/localstack-core/localstack/aws/skeleton.py
@@ -130,14 +130,16 @@ class Skeleton:
             self.dispatch_table = create_dispatch_table(implementation)
 
     def invoke(self, context: RequestContext) -> Response:
-        serializer = create_serializer(context.service)
+        serializer = create_serializer(context.service, context.protocol)
 
         if context.operation and context.service_request:
             # if the parsed request is already set in the context, re-use them
             operation, instance = context.operation, context.service_request
         else:
             # otherwise, parse the incoming HTTPRequest
-            operation, instance = create_parser(context.service).parse(context.request)
+            operation, instance = create_parser(context.service, context.protocol).parse(
+                context.request
+            )
             context.operation = operation
 
         try:

--- a/localstack-core/localstack/aws/spec.py
+++ b/localstack-core/localstack/aws/spec.py
@@ -115,8 +115,6 @@ def load_service(
     :raises: UnknownServiceProtocolError if the specific protocol of the service cannot be found
     """
     service_description = loader.load_service_model(service, "service-2", version)
-    print(f"{service_description=}")
-    # TODO: look at this and verify it works!
     service_metadata = service_description.get("metadata", {})
     service_protocols = {service_metadata.get("protocol")}
     if protocols := service_metadata.get("protocols"):

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/aws.py
@@ -211,6 +211,9 @@ class RestApiAwsIntegration(RestApiIntegration):
             action = parsed_uri["path"]
 
             if target := self.get_action_service_target(service_name, action):
+                # TODO: properly implement the auto-`Content-Type` headers depending on the service protocol
+                #  e.g. `x-amz-json-1.0` for DynamoDB
+                #  this is needed to properly support multi-protocol
                 headers["X-Amz-Target"] = target
 
             query_params["Action"] = action

--- a/localstack-core/localstack/services/sqs/query_api.py
+++ b/localstack-core/localstack/services/sqs/query_api.py
@@ -35,7 +35,7 @@ LOG = logging.getLogger(__name__)
 
 service = load_service("sqs-query")
 parser = create_parser(service)
-serializer = create_serializer(service)
+serializer = create_serializer(service, "query")
 
 
 @route(

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -6,11 +6,36 @@ import pytest
 from botocore.awsrequest import AWSRequest, create_request_object
 from botocore.config import Config
 from botocore.model import OperationModel, ServiceModel, Shape, StructureShape
+from botocore.serialize import create_serializer
 
-from localstack.aws.protocol.service_router import determine_aws_service_model
+from localstack.aws.protocol.service_router import (
+    determine_aws_protocol,
+    determine_aws_service_model,
+)
 from localstack.aws.spec import get_service_catalog
 from localstack.http import Request
 from localstack.utils.run import to_str
+
+
+@pytest.fixture
+def get_aws_client_for_protocol(aws_client_factory, monkeypatch):
+    def _create_client(service_name: str, protocol: str):
+        client = aws_client_factory.get_client(
+            service_name,
+            config=Config(
+                connect_timeout=1_000,
+                read_timeout=1_000,
+                retries={"total_max_attempts": 1},
+                parameter_validation=False,
+                user_agent="aws-cli/1.33.7",
+            ),
+        )
+        # TODO: we should come up with a better way to create a protocol-aware client
+        protocol_serializer = create_serializer(protocol_name=protocol, include_validation=False)
+        monkeypatch.setattr(client, "_serializer", protocol_serializer)
+        return client
+
+    yield _create_client
 
 
 def _collect_operations() -> tuple[ServiceModel, OperationModel]:
@@ -20,88 +45,93 @@ def _collect_operations() -> tuple[ServiceModel, OperationModel]:
     service_catalog = get_service_catalog()
     for service_name in service_catalog.service_names:
         service = service_catalog.get(service_name)
-        for operation_name in service.operation_names:
-            # FIXME try to support more and more services, get these exclusions down!
-            # Exclude all operations for the following, currently _not_ supported services
-            if service.service_name in [
-                "bedrock-agent",
-                "bedrock-agentcore",
-                "bedrock-agentcore-control",
-                "bedrock-agent-runtime",
-                "bedrock-data-automation",
-                "bedrock-data-automation-runtime",
-                "chime",
-                "chime-sdk-identity",
-                "chime-sdk-media-pipelines",
-                "chime-sdk-meetings",
-                "chime-sdk-messaging",
-                "chime-sdk-voice",
-                "codecatalyst",
-                "connect",
-                "connect-contact-lens",
-                "connectcampaigns",
-                "connectcampaignsv2",
-                "greengrassv2",
-                "iot1click",
-                "iot1click-devices",
-                "iot1click-projects",
-                "ivs",
-                "ivs-realtime",
-                "kinesis-video-archived",
-                "kinesis-video-archived-media",
-                "kinesis-video-media",
-                "kinesis-video-signaling",
-                "kinesis-video-webrtc-storage",
-                "kinesisvideo",
-                "lex-models",
-                "lex-runtime",
-                "lexv2-models",
-                "lexv2-runtime",
-                "mailmanager",
-                "marketplace-catalog",
-                "marketplace-deployment",
-                "marketplace-reporting",
-                "personalize",
-                "personalize-events",
-                "personalize-runtime",
-                "pinpoint-sms-voice",
-                "qconnect",
-                "sagemaker-edge",
-                "sagemaker-featurestore-runtime",
-                "sagemaker-metrics",
-                "sms-voice",
-                "sso",
-                "sso-oidc",
-                "wisdom",
-                "workdocs",
-            ]:
-                yield pytest.param(
-                    service,
-                    service.protocol,
-                    service.operation_model(operation_name),
-                    marks=pytest.mark.skip(
-                        reason=f"{service.service_name} is currently not supported by the service router"
-                    ),
-                )
-            # Exclude services / operations which have ambiguities and where the service routing needs to resolve those
-            elif (
-                service.service_name in ["docdb", "neptune"]  # maps to rds
-                or service.service_name in "timestream-write"  # maps to timestream-query
-                or (
-                    service.service_name == "sesv2"
-                    and operation_name == "PutEmailIdentityDkimSigningAttributes"
-                )
-            ):
-                yield pytest.param(
-                    service,
-                    service.protocol,
-                    service.operation_model(operation_name),
-                    marks=pytest.mark.skip(
-                        reason=f"{service.service_name} may differ due to ambiguities in the service specs"
-                    ),
-                )
-            else:
-                yield service, service.protocol, service.operation_model(operation_name)
+        service_protocols = {service.protocol}
+        if protocols := service.metadata.get("protocols"):
+            service_protocols.update(protocols)
+
+        for service_protocol in sorted(service_protocols):
+            for operation_name in service.operation_names:
+                # FIXME try to support more and more services, get these exclusions down!
+                # Exclude all operations for the following, currently _not_ supported services
+                if service.service_name in [
+                    "bedrock-agent",
+                    "bedrock-agentcore",
+                    "bedrock-agentcore-control",
+                    "bedrock-agent-runtime",
+                    "bedrock-data-automation",
+                    "bedrock-data-automation-runtime",
+                    "chime",
+                    "chime-sdk-identity",
+                    "chime-sdk-media-pipelines",
+                    "chime-sdk-meetings",
+                    "chime-sdk-messaging",
+                    "chime-sdk-voice",
+                    "codecatalyst",
+                    "connect",
+                    "connect-contact-lens",
+                    "connectcampaigns",
+                    "connectcampaignsv2",
+                    "greengrassv2",
+                    "iot1click",
+                    "iot1click-devices",
+                    "iot1click-projects",
+                    "ivs",
+                    "ivs-realtime",
+                    "kinesis-video-archived",
+                    "kinesis-video-archived-media",
+                    "kinesis-video-media",
+                    "kinesis-video-signaling",
+                    "kinesis-video-webrtc-storage",
+                    "kinesisvideo",
+                    "lex-models",
+                    "lex-runtime",
+                    "lexv2-models",
+                    "lexv2-runtime",
+                    "mailmanager",
+                    "marketplace-catalog",
+                    "marketplace-deployment",
+                    "marketplace-reporting",
+                    "personalize",
+                    "personalize-events",
+                    "personalize-runtime",
+                    "pinpoint-sms-voice",
+                    "qconnect",
+                    "sagemaker-edge",
+                    "sagemaker-featurestore-runtime",
+                    "sagemaker-metrics",
+                    "sms-voice",
+                    "sso",
+                    "sso-oidc",
+                    "wisdom",
+                    "workdocs",
+                ]:
+                    yield pytest.param(
+                        service,
+                        service_protocol,
+                        service.operation_model(operation_name),
+                        marks=pytest.mark.skip(
+                            reason=f"{service.service_name} is currently not supported by the service router"
+                        ),
+                    )
+                # Exclude services / operations which have ambiguities and where the service routing needs to resolve those
+                elif (
+                    service.service_name in ["docdb", "neptune"]  # maps to rds
+                    or service.service_name in "timestream-write"  # maps to timestream-query
+                    or (
+                        service.service_name == "sesv2"
+                        and operation_name == "PutEmailIdentityDkimSigningAttributes"
+                    )
+                ):
+                    yield pytest.param(
+                        service,
+                        service_protocol,
+                        service.operation_model(operation_name),
+                        marks=pytest.mark.skip(
+                            reason=f"{service.service_name} may differ due to ambiguities in the service specs"
+                        ),
+                    )
+                else:
+                    yield service, service_protocol, service.operation_model(operation_name)
 
 
 def _botocore_request_to_localstack_request(request_object: AWSRequest) -> Request:
@@ -161,7 +191,11 @@ def _generate_test_name(param: Any):
     ids=_generate_test_name,
 )
 def test_service_router_works_for_every_service(
-    service: ServiceModel, protocol: str, operation: OperationModel, caplog, aws_client_factory
+    service: ServiceModel,
+    protocol: str,
+    operation: OperationModel,
+    caplog,
+    get_aws_client_for_protocol,
 ):
     caplog.set_level("CRITICAL", "botocore")
 
@@ -174,16 +208,7 @@ def test_service_router_works_for_every_service(
     )
 
     # Create a dummy request for the service router
-    client = aws_client_factory.get_client(
-        service_name,
-        config=Config(
-            connect_timeout=1_000,
-            read_timeout=1_000,
-            retries={"total_max_attempts": 1},
-            parameter_validation=False,
-            user_agent="aws-cli/1.33.7",
-        ),
-    )
+    client = get_aws_client_for_protocol(service_name, protocol)
 
     request_context = {
         "client_region": client.meta.region_name,
@@ -205,10 +230,11 @@ def test_service_router_works_for_every_service(
 
     # Execute the service router
     detected_service_model = determine_aws_service_model(request)
+    detected_service_protocol = determine_aws_protocol(request, detected_service_model)
 
-    # Make sure the detected service is the same as the one we generated the request for
+    # Make sure the detected service and protocol are the same as the one we generated the request for
     assert detected_service_model.service_name == service.service_name
-    assert detected_service_model.protocol == service.protocol
+    assert detected_service_protocol == protocol
 
 
 def test_endpoint_prefix_based_routing():
@@ -245,6 +271,29 @@ def test_endpoint_prefix_based_routing_s3_virtual_host():
 
 
 def test_endpoint_prefix_based_routing_for_sqs():
+    # test without content type
+    detected_service_model = determine_aws_service_model(
+        Request(method="GET", path="/", headers={"Host": "sqs.localhost.localstack.cloud"})
+    )
+    assert detected_service_model.service_name == "sqs"
+    assert detected_service_model.protocol == "query"
+
+    # test explicitly with JSON
+    detected_service_model = determine_aws_service_model(
+        Request(
+            method="GET",
+            path="/",
+            headers={
+                "Host": "sqs.localhost.localstack.cloud",
+                "Content-Type": "application/x-amz-json-1.0",
+            },
+        )
+    )
+    assert detected_service_model.service_name == "sqs"
+    assert detected_service_model.protocol == "json"
+
+
+def test_multi_protocols_detection():
     # test without content type
     detected_service_model = determine_aws_service_model(
         Request(method="GET", path="/", headers={"Host": "sqs.localhost.localstack.cloud"})

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -12,7 +12,7 @@ from localstack.aws.protocol.service_router import (
     ProtocolError,
     determine_aws_protocol,
     determine_aws_service_model,
-    get_protocol_from_request,
+    match_available_protocols,
 )
 from localstack.aws.spec import get_service_catalog
 from localstack.http import Request
@@ -367,4 +367,4 @@ def test_query_protocol_detection_with_empty_body():
     assert detected_service_model.protocol == "query"
 
     # we set wrong protocol here just to verify we can match `query` even if we don't have the Content-Type
-    assert get_protocol_from_request(sns_request, ["query", "json"])
+    assert match_available_protocols(sns_request, ["query", "json"])


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR is part of a bigger initiative (see #13028) to implement support for the [new Smithy Protocol](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html) smithy-rpc-v2-cbor, as well as the new Botocore multi-protocol support for single services (before, a service could only define one protocol).

This PR implements a new protocol detection for services who support multiple protocols. It sets the `protocol` as a first class citizen in our handler chain, allowing us to use the detected protocol to create our parser and serializer. 

The protocol detection is done by following the different specs as defined at https://smithy.io/2.0/aws/protocols/ and https://smithy.io/2.0/additional-specs/protocols

We have extensive testing of the protocol determination by upgrading our current automated service detection tests, by running them for all protocols a service supports and verifying that the protocol is the one we selected when serializing the request. 

This also implements the retrieval of Service Indicators when trying to match a service based on the request, to find indicator if the request is done via `smithy-rpc-v2-cbor`, as [it defines a special way to encode its service and operation in the path](https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html#requests). 

We also implement a priority detection on the protocol, as some services are pretty greedy (`rest`-based services). 

One important change is of the signature of `ServiceModelIdentifier`, as we now need to know all `protocols` a service support for the `query` and `ec2` service detection (we need it to match it with `services.by_operation(values["Action"])`)

You can see how it is used for CloudWatch with the follow-up PR: #13161 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- make `protocol` part of the `RequestContext`
- implement protocol detection for services who support multiple protocols
- use the detected protocol to create the parser and serializer
- implement RPC v2 service indicators to properly route requests
- add `protocols` to `ServiceModelIdentifier` in `aws/spec.py`
- update `test_service_router_works_for_every_service` to also verify protocol

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
