### PR TITLE
CFn: ecr repo uses request account and region

### DIFF
--- a/localstack-core/localstack/services/ecr/resource_providers/aws_ecr_repository.py
+++ b/localstack-core/localstack/services/ecr/resource_providers/aws_ecr_repository.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import TypedDict
 
 import localstack.services.cloudformation.provider_utils as util
-from localstack.constants import AWS_REGION_US_EAST_1, DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.cloudformation.resource_provider import (
     OperationStatus,
     ProgressEvent,
@@ -102,7 +101,7 @@ class ECRRepositoryProvider(ResourceProvider[ECRRepositoryProperties]):
         model.update(
             {
                 "Arn": arns.ecr_repository_arn(
-                    model["RepositoryName"], DEFAULT_AWS_ACCOUNT_ID, AWS_REGION_US_EAST_1
+                    model["RepositoryName"], request.account_id, request.region_name
                 ),
                 "RepositoryUri": "http://localhost:4566",
                 "ImageTagMutability": "MUTABLE",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While implementing some fixes for the ECR repository in #13146, we broke the multi-account/multi-region pipeline. It turns out the ECR repository resoure provider hard-codes the account id `000000000000` and region `us-east-1` in its response. I presume this has not been caught before as it is not asserted anywhere in the tests?


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes


* Use the account id and region of the stack

## Testing

No additional tests have been added, but a green CI run with both the normal integration tests and MA/MR pipeline is enough to validate this behaviour.

[MA/MR test run](https://github.com/localstack/localstack/actions/runs/17798412765)

<!-- Optional section: How to test these changes? -->
<!--

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
