### PR TITLE
Fix DNS not supporting wildcard matching

### DIFF
--- a/localstack-core/localstack/dns/server.py
+++ b/localstack-core/localstack/dns/server.py
@@ -445,7 +445,7 @@ class Resolver(DnsServerProtocol):
                 return True
         return False
 
-    def _find_matching_aliases(self, question: DNSQuestion) -> list[AliasTarget] | None :
+    def _find_matching_aliases(self, question: DNSQuestion) -> list[AliasTarget] | None:
         """
         Find aliases matching the question, supporting wildcards.
         """

--- a/tests/unit/test_dns_server.py
+++ b/tests/unit/test_dns_server.py
@@ -139,11 +139,9 @@ class TestDNSServer:
 
     def test_dns_server_resolves_alias_wildcards(self, dns_server, query_dns):
         """Check if server resolves aliases with wildcards"""
-        dns_server.add_host(
-            "example.org", TargetRecord("1.1.1.1", RecordType.A)
-        )
+        dns_server.add_host("example.org", TargetRecord("1.1.1.1", RecordType.A))
         answer = query_dns("subdomain1.example.org", "A")
-        assert len(answer.answer) is 0
+        assert len(answer.answer) == 0
 
         dns_server.add_alias(
             source_name="*.example.org",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The LocalStack DNS service doesn't support wildcards in aliases. In such cases, the DNS will not resolve the query to the record it points to.

For example, given the following DNS configuration:

```
domain          record    address
my-domain.io    A         1.1.1.1
*.my-domain.io  A         alias(my-domain.io)
```

See the following pseudo-output:

```
$ dig @127.0.0.1 my-domain.io
[...]
;; ANSWER SECTION:
my-domain.io. 300	IN	A	127.0.0.1
[...]

$ dig @127.0.0.1 subdomain.my-domain.io
[...]
;; ANSWER SECTION:
(not found)
[...]
```

After the fix, the output is as follows:

```
$ dig @127.0.0.1 my-domain.io
[...]
;; ANSWER SECTION:
my-domain.io. 300	IN	A	127.0.0.1
[...]

$ dig @127.0.0.1 subdomain.my-domain.io
[...]
;; ANSWER SECTION:
subdomain.my-domain.io. 300	IN	A	127.0.0.1
[...]
```


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

It refactors the alias resolution from raw string comparison in favor of a pattern matching comparison by reusing the `DNSLabel.matchWildcard` method.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
