### PR TITLE
update old references to venv paths

### DIFF
--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -32,7 +32,7 @@ def generate_mount_points(
 
     # container paths
     target_path = "/opt/code/localstack/"
-    venv_path = os.path.join(target_path, ".venv", "lib", "python3.11", "site-packages")
+    venv_path = os.path.join(target_path, ".venv", "lib", "python3.13", "site-packages")
 
     # Community code
     if pro:

--- a/localstack-core/localstack/dev/run/paths.py
+++ b/localstack-core/localstack/dev/run/paths.py
@@ -68,7 +68,7 @@ class ContainerPaths:
     """Important paths in the container"""
 
     project_dir: str = "/opt/code/localstack"
-    site_packages_target_dir: str = "/opt/code/localstack/.venv/lib/python3.11/site-packages"
+    site_packages_target_dir: str = "/opt/code/localstack/.venv/lib/python3.13/site-packages"
     docker_entrypoint: str = "/usr/local/bin/docker-entrypoint.sh"
     localstack_supervisor: str = "/usr/local/bin/localstack-supervisor"
     localstack_source_dir: str


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13037 we upgraded to Python 3.13.
Unfortunately, we have some dev tooling which contains some direct path handling to the venv which we missed to update.
This PR cleans that up. As far as I can tell, there are no other references to `python3.11` anymore in the codebase.

## Changes
- Updates venv paths in `localstack-core/localstack/dev/` for Python 3.13.