### PR TITLE
Update dev scripts to assume python 3.13

### DIFF
--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -32,7 +32,7 @@ def generate_mount_points(
 
     # container paths
     target_path = "/opt/code/localstack/"
-    venv_path = os.path.join(target_path, ".venv", "lib", "python3.11", "site-packages")
+    venv_path = os.path.join(target_path, ".venv", "lib", "python3.13", "site-packages")
 
     # Community code
     if pro:

--- a/localstack-core/localstack/dev/run/paths.py
+++ b/localstack-core/localstack/dev/run/paths.py
@@ -68,7 +68,7 @@ class ContainerPaths:
     """Important paths in the container"""
 
     project_dir: str = "/opt/code/localstack"
-    site_packages_target_dir: str = "/opt/code/localstack/.venv/lib/python3.11/site-packages"
+    site_packages_target_dir: str = "/opt/code/localstack/.venv/lib/python3.13/site-packages"
     docker_entrypoint: str = "/usr/local/bin/docker-entrypoint.sh"
     localstack_supervisor: str = "/usr/local/bin/localstack-supervisor"
     localstack_source_dir: str


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

In #13037 we updated to Python 3.13 (🎉) however we missed updating a couple of dev scripts. These overwrite the venv site-packages path in a running pro container/pod and as such need to use the correct path. 


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Swap 3.11 for 3.13

## Testing

Run `python -m localstack.dev.run` with the pro image with a code change and it should be picked up. Without this PR the code change is not picked up.


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
