### PR TITLE
S3: fix DeleteObjectTagging on current object

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -3298,7 +3298,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         s3_object = s3_bucket.get_object(key=key, version_id=version_id, http_method="DELETE")
 
-        store.TAGS.tags.pop(get_unique_key_id(bucket, key, version_id), None)
+        store.TAGS.tags.pop(get_unique_key_id(bucket, key, s3_object.version_id), None)
         response = DeleteObjectTaggingOutput()
         if s3_object.version_id:
             response["VersionId"] = s3_object.version_id

--- a/tests/aws/services/s3/test_s3_api.snapshot.json
+++ b/tests/aws/services/s3/test_s3_api.snapshot.json
@@ -2007,7 +2007,7 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
-    "recorded-date": "21-01-2025, 18:11:16",
+    "recorded-date": "19-09-2025, 23:28:45",
     "recorded-content": {
       "put-obj-0": {
         "ChecksumCRC32": "XCKz9A==",
@@ -2079,6 +2079,22 @@
           }
         ],
         "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-deleted-current": {
+        "TagSet": [],
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-tags-previous-version-deleted": {
+        "TagSet": [],
+        "VersionId": "<version-id:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/s3/test_s3_api.validation.json
+++ b/tests/aws/services/s3/test_s3_api.validation.json
@@ -63,7 +63,13 @@
     }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tagging_versioned": {
-    "last_validated_date": "2025-01-21T18:11:16+00:00"
+    "last_validated_date": "2025-09-19T23:28:46+00:00",
+    "durations_in_seconds": {
+      "setup": 1.08,
+      "call": 2.55,
+      "teardown": 1.07,
+      "total": 4.7
+    }
   },
   "tests/aws/services/s3/test_s3_api.py::TestS3BucketObjectTagging::test_object_tags_delete_or_overwrite_object": {
     "last_validated_date": "2025-01-21T18:11:22+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported in #13162, we had an issue when deleting tags on an versioned object without specifying the version id, meaning we'd target the top of the object stack (current object)

This PR addressed it by using the actual retrieved object version id

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update a test to validate the case
- update which version id is using to delete the object tags

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
