### PR TITLE
Add hot reload regression test cases for implicit behavior

### DIFF
--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -74,7 +74,7 @@ class TestHotReloading:
 
         get_function_response = aws_client.lambda_.get_function(FunctionName=function_name)
         code_location_path = Path.from_uri(get_function_response["Code"]["Location"])
-        assert str(code_location_path) == hot_reloading_dir_path
+        assert str(code_location_path) == mount_path
 
         response = aws_client.lambda_.invoke(FunctionName=function_name, Payload=b"{}")
         response_dict = json.load(response["Payload"])


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The heuristic in the AWS Toolkit integration (announced [here](https://aws.amazon.com/blogs/aws/accelerate-serverless-testing-with-localstack-integration-in-vs-code-ide/)) depends on the implicit assumption that it starts with `hot-reloading` (see code [here](https://aws.amazon.com/blogs/aws/accelerate-serverless-testing-with-localstack-integration-in-vs-code-ide/)). We should add a test to make that assumption explicit.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add assertion for the `CodeSha256` to start with `hot-reloading`
* Add assertion for the `GetFunction>Code>Location` to return a valid file URI pointing to the local hot-reload path

sidenote: `Path.from_uri` requires Python 3.13 (https://docs.python.org/3/library/pathlib.html#pathlib.Path.from_uri)

disclaimer: I haven't tested the path assertion on Windows.

## Testing

1. Start LocalStack in container dev mode using `python -m localstack.dev.run`
2. Run the test `aws.services.lambda_.test_lambda_developer_tools.TestHotReloading.test_hot_reloading` against the running container