### PR TITLE
IaC: Update CatalogPlugin class and common catalog plugins logic

### DIFF
--- a/localstack-core/localstack/utils/catalog/catalog.py
+++ b/localstack-core/localstack/utils/catalog/catalog.py
@@ -48,6 +48,10 @@ class CatalogPlugin(Plugin):
 
         return SERVICE_PLUGINS.list_available()
 
+    @staticmethod
+    def _get_cfn_resources_available_at_runtime():
+        return set(cfn_plugin_manager.list_names())
+
     @abstractmethod
     def get_aws_service_status(
         self, service_name: str, operation_name: str | None = None
@@ -97,7 +101,7 @@ class AwsCatalogRemoteStatePlugin(CatalogPlugin):
         self.cfn_resources_in_latest = self.get_cfn_resources_catalog(
             remote_catalog.cloudformation_resources
         )
-        self.cfn_resources_at_runtime = set(cfn_plugin_manager.list_names())
+        self.cfn_resources_at_runtime = self._get_cfn_resources_available_at_runtime()
         self.services_at_runtime = self.get_aws_services_at_runtime()
 
     def get_aws_service_status(

--- a/localstack-core/localstack/utils/catalog/catalog.py
+++ b/localstack-core/localstack/utils/catalog/catalog.py
@@ -35,7 +35,7 @@ class CatalogPlugin(Plugin):
     namespace = "localstack.utils.catalog"
 
     @staticmethod
-    def get_cfn_resources_catalog(cloudformation_resources: dict):
+    def _get_cfn_resources_catalog(cloudformation_resources: dict):
         cfn_resources_catalog = {}
         for emulator_type, resources in cloudformation_resources.items():
             for resource_name, resource in resources.items():
@@ -43,13 +43,13 @@ class CatalogPlugin(Plugin):
         return cfn_resources_catalog
 
     @staticmethod
-    def get_aws_services_at_runtime():
+    def _get_services_at_runtime():
         from localstack.services.plugins import SERVICE_PLUGINS
 
-        return SERVICE_PLUGINS.list_available()
+        return set(SERVICE_PLUGINS.list_available())
 
     @staticmethod
-    def get_cfn_resources_available_at_runtime():
+    def _get_cfn_resources_available_at_runtime():
         return set(cfn_plugin_manager.list_names())
 
     @abstractmethod
@@ -98,11 +98,11 @@ class AwsCatalogRemoteStatePlugin(CatalogPlugin):
                     service_provider.operations
                 )
 
-        self.cfn_resources_in_latest = self.get_cfn_resources_catalog(
+        self.cfn_resources_in_latest = self._get_cfn_resources_catalog(
             remote_catalog.cloudformation_resources
         )
         self.cfn_resources_at_runtime = self._get_cfn_resources_available_at_runtime()
-        self.services_at_runtime = self.get_aws_services_at_runtime()
+        self.services_at_runtime = self._get_services_at_runtime()
 
     def get_aws_service_status(
         self, service_name: str, operation_name: str | None = None

--- a/localstack-core/localstack/utils/catalog/catalog.py
+++ b/localstack-core/localstack/utils/catalog/catalog.py
@@ -49,7 +49,7 @@ class CatalogPlugin(Plugin):
         return SERVICE_PLUGINS.list_available()
 
     @staticmethod
-    def _get_cfn_resources_available_at_runtime():
+    def get_cfn_resources_available_at_runtime():
         return set(cfn_plugin_manager.list_names())
 
     @abstractmethod

--- a/localstack-core/localstack/utils/catalog/catalog.py
+++ b/localstack-core/localstack/utils/catalog/catalog.py
@@ -60,7 +60,7 @@ class CatalogPlugin(Plugin):
 
     @abstractmethod
     def get_cloudformation_resource_status(
-        self, resource_name: str, service_name: str
+        self, resource_name: str, service_name: str, is_pro_resource: bool = False
     ) -> CfnResourceSupportStatus | AwsServicesSupportInLatest | None:
         pass
 
@@ -74,7 +74,7 @@ class AwsCatalogRuntimePlugin(CatalogPlugin):
         return None
 
     def get_cloudformation_resource_status(
-        self, resource_name: str, service_name: str
+        self, resource_name: str, service_name: str, is_pro_resource: bool = False
     ) -> CfnResourceSupportStatus | AwsServicesSupportInLatest | None:
         return None
 

--- a/localstack-core/localstack/utils/catalog/common.py
+++ b/localstack-core/localstack/utils/catalog/common.py
@@ -55,3 +55,4 @@ class CloudFormationResourcesSupportInLatest(StrEnum):
 
 class CloudFormationResourcesSupportAtRuntime(StrEnum):
     AVAILABLE = "AVAILABLE"
+    NOT_IMPLEMENTED = "NOT_IMPLEMENTED"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This is a companion branch, the changes in this PR are primarily needed for the pro catalog.

The logic to retrieve CloudFormation resources available at runtime has been moved to `CatalogPlugin`, renamed private methods for better readability, added new state `CloudFormationResourcesSupportAtRuntime.NOT_IMPLEMENTED`

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Moved logic to obtain CloudFormation resources available at runtime to `CatalogPlugin`
- Renamed method `get_aws_services_at_runtime` 
- Added new argument `is_pro_resource` to the `get_cloudformation_resource_status`, this logic is needed in pro catalog

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
