### PR TITLE
ASF: fix empty exception member serialization when required

### DIFF
--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -1338,7 +1338,13 @@ class JSONResponseSerializer(QueryCompatibleProtocolMixin, ResponseSerializer):
                 else:
                     continue
 
-                if value or (member in shape.required_members and value is not None):
+                if value is None:
+                    # do not serialize a value that is set to `None`
+                    continue
+
+                # if the value is falsy (empty string, empty list) and not in the Shape required members, AWS will
+                # not serialize it, and it will not be part of the response body.
+                if value or member in shape.required_members:
                     remaining_params[member] = value
 
             self._serialize(body, remaining_params, shape, None, mime_type)
@@ -1845,7 +1851,13 @@ class BaseCBORResponseSerializer(ResponseSerializer):
             else:
                 continue
 
-            if value or (member in shape.required_members and value is not None):
+            if value is None:
+                # do not serialize a value that is set to `None`
+                continue
+
+            # if the value is falsy (empty string, empty list) and not in the Shape required members, AWS will
+            # not serialize it, and it will not be part of the response body.
+            if value or member in shape.required_members:
                 params[member] = value
 
         self._serialize_type_structure(body, params, shape, None, shape_members=shape_members)

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -765,7 +765,8 @@ def test_json_protocol_error_serialization_with_shaped_default_members_on_root()
 
 
 def test_json_protocol_error_serialization_empty_message():
-    # if the exception message is not passed, an empty message will be passed as an empty string `""`
+    # if the exception message is not passed when instantiating the exception, the message attribute will be set to
+    # an empty string "". This is not serialized if the message field is not a required member
     exception = TransactionCanceledException()
 
     response = _botocore_error_serializer_integration_test(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #13180 

When working on multi-protocol support, it came to light that we shouldn't serialize empty members on exception structures. However, one test started failing for the `verifiedpermissions` service after we merged this.

This is because the shape of that exception explicitly declares `required` members on the exception structure shape:

```json
{
  "ResourceNotFoundException":{
      "type":"structure",
      "required":[
        "message",
        "resourceId",
        "resourceType"
      ],
      "members":{
        "message":{"shape":"String"},
        "resourceId":{
          "shape":"String",
          "documentation":"<p>The unique ID of the resource referenced in the failed request.</p>"
        },
        "resourceType":{
          "shape":"ResourceType",
          "documentation":"<p>The resource type of the resource referenced in the failed request.</p>"
        }
      },
      "documentation":"<p>The request failed because it references a resource that doesn't exist.</p>",
      "exception":true
    }
}
```

I've added unit tests to validate the fix and confirm the behavior, and validated that it fixed the test of the dependency. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- fix behavior when serializing exception members to take into account required non-truthy values members
  - validate that the `None` value is still not serialized
- also validated the fix for `smithy-rpc-v2-cbor` even though we don't have a service supporting required members yet

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
