### PR TITLE
Allow storing test metrics in local filesystem of LocalStack container

### DIFF
--- a/localstack-core/localstack/config.py
+++ b/localstack-core/localstack/config.py
@@ -19,6 +19,7 @@ from localstack.constants import (
     DEFAULT_VOLUME_DIR,
     ENV_INTERNAL_TEST_COLLECT_METRIC,
     ENV_INTERNAL_TEST_RUN,
+    ENV_INTERNAL_TEST_STORE_METRICS_IN_LOCALSTACK,
     FALSE_STRINGS,
     LOCALHOST,
     LOCALHOST_IP,
@@ -1449,6 +1450,11 @@ def is_local_test_mode() -> bool:
 def is_collect_metrics_mode() -> bool:
     """Returns True if metric collection is enabled."""
     return is_env_true(ENV_INTERNAL_TEST_COLLECT_METRIC)
+
+
+def store_test_metrics_in_local_filesystem() -> bool:
+    """Returns True if test metrics should be stored in the local filesystem (instead of the system that runs pytest)."""
+    return is_env_true(ENV_INTERNAL_TEST_STORE_METRICS_IN_LOCALSTACK)
 
 
 def collect_config_items() -> list[tuple[str, Any]]:

--- a/localstack-core/localstack/constants.py
+++ b/localstack-core/localstack/constants.py
@@ -80,6 +80,10 @@ ENV_INTERNAL_TEST_RUN = "LOCALSTACK_INTERNAL_TEST_RUN"
 # environment variable name to tag collect metrics during a test run
 ENV_INTERNAL_TEST_COLLECT_METRIC = "LOCALSTACK_INTERNAL_TEST_COLLECT_METRIC"
 
+# environment variable name to indicate that metrics should be stored within the container
+ENV_INTERNAL_TEST_STORE_METRICS_IN_LOCALSTACK = "LOCALSTACK_INTERNAL_TEST_METRICS_IN_LOCALSTACK"
+ENV_INTERNAL_TEST_STORE_METRICS_PATH = "LOCALSTACK_INTERNAL_TEST_STORE_METRICS_PATH"
+
 # environment variable that flags whether pro was activated. do not use it for security purposes!
 ENV_PRO_ACTIVATED = "PRO_ACTIVATED"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We want to collect test metrics when the system running pytest is not the same running LocalStack

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Introduces the ability to store test metrics directly within the LocalStack container's filesystem instead of only in the system running pytest. This provides more flexibility for metric collection in different deployment scenarios (like when running in k8s)
* Adds `ENV_INTERNAL_TEST_STORE_METRICS_IN_LOCALSTACK` environment variable to enable local filesystem storage
* Adds `ENV_INTERNAL_TEST_STORE_METRICS_PATH` environment variable to specify custom storage path (defaults to `/tmp/localstack-metrics`)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
