### PR TITLE
CloudWatch: fix MA/MR for new snapshot test `test_put_metric_alarm_escape_character`

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -837,7 +837,9 @@ class TestCloudwatch:
     @markers.snapshot.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..MetricAlarms..StateTransitionedTimestamp"]
     )
-    def test_put_metric_alarm_escape_character(self, cleanups, aws_cloudwatch_client, snapshot):
+    def test_put_metric_alarm_escape_character(
+        self, cleanups, aws_cloudwatch_client, snapshot, region_name
+    ):
         snapshot.add_transformers_list(
             [
                 snapshot.transform.key_value("AlarmName"),
@@ -856,7 +858,7 @@ class TestCloudwatch:
             Threshold=1,
             ComparisonOperator="GreaterThanThreshold",
             EvaluationPeriods=1,
-            AlarmActions=["arn:aws:sns:us-east-1:111122223333:MyTopic"],
+            AlarmActions=[f"arn:aws:sns:{region_name}:111122223333:MyTopic"],
         )
         cleanups.append(lambda: aws_cloudwatch_client.delete_alarms(AlarmNames=["cpu-mon"]))
 

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1279,7 +1279,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[query]": {
-    "recorded-date": "19-09-2025, 20:51:19",
+    "recorded-date": "24-09-2025, 15:16:44",
     "recorded-content": {
       "describe-alarms-escaped-character": {
         "CompositeAlarms": [],
@@ -1317,7 +1317,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[json]": {
-    "recorded-date": "19-09-2025, 20:51:19",
+    "recorded-date": "24-09-2025, 15:16:45",
     "recorded-content": {
       "describe-alarms-escaped-character": {
         "CompositeAlarms": [],
@@ -1355,7 +1355,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[smithy-rpc-v2-cbor]": {
-    "recorded-date": "19-09-2025, 20:51:20",
+    "recorded-date": "24-09-2025, 15:16:46",
     "recorded-content": {
       "describe-alarms-escaped-character": {
         "CompositeAlarms": [],

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -1326,30 +1326,30 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[json]": {
-    "last_validated_date": "2025-09-19T20:51:20+00:00",
+    "last_validated_date": "2025-09-24T15:16:45+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.32,
-      "teardown": 0.26,
-      "total": 0.58
+      "call": 0.4,
+      "teardown": 0.34,
+      "total": 0.74
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[query]": {
-    "last_validated_date": "2025-09-19T20:51:19+00:00",
+    "last_validated_date": "2025-09-24T15:16:45+00:00",
     "durations_in_seconds": {
       "setup": 0.49,
-      "call": 0.68,
-      "teardown": 0.22,
-      "total": 1.39
+      "call": 0.71,
+      "teardown": 0.23,
+      "total": 1.43
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[smithy-rpc-v2-cbor]": {
-    "last_validated_date": "2025-09-19T20:51:20+00:00",
+    "last_validated_date": "2025-09-24T15:16:46+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.34,
-      "teardown": 0.21,
-      "total": 0.55
+      "call": 0.31,
+      "teardown": 0.23,
+      "total": 0.54
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_data_validation[json]": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Follow up from #13173 

It added snapshots for a few tests, but I missed that one region was hardcoded in some field.

This PR updates it to use the region from the client for proper transformation. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- update test to use `region_name` instead of hardcoded value

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
