### PR TITLE
CFn: fix CDK redeploy

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -285,15 +285,18 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
                     except Exception as e:
                         # we could not find the parameter however CDK provides the resolved value rather than the
                         # parameter name again so try to look up the value in the previous parameters
-                        if given_value:
+                        if (
+                            before_parameters
+                            and (before_param := before_parameters.get(name))
+                            and isinstance(before_param, dict)
+                            and (resolved_value := before_param.get("resolved_value"))
+                        ):
                             LOG.debug(
-                                "Parameter %s could not be resolved, using given value of %s",
+                                "Parameter %s could not be resolved, using previous value of %s",
                                 name,
-                                given_value,
-                                exc_info=LOG.isEnabledFor(logging.DEBUG)
-                                and config.CFN_VERBOSE_ERRORS,
+                                resolved_value,
                             )
-                            resolved_parameter["resolved_value"] = given_value
+                            resolved_parameter["resolved_value"] = resolved_value
                         else:
                             raise ValidationError(
                                 f"Parameter {name} should either have input value or default value"

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -285,20 +285,16 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
                     except Exception as e:
                         # we could not find the parameter however CDK provides the resolved value rather than the
                         # parameter name again so try to look up the value in the previous parameters
-                        found = False
-                        if before_param := before_parameters.get(name):
-                            # the type should be an EngineParameter from before so try this
-                            if isinstance(before_param, dict):
-                                if resolved_value := before_param.get("resolved_value"):
-                                    LOG.debug(
-                                        "Parameter %s could not be resolved, using previous value of %s",
-                                        name,
-                                        resolved_value,
-                                    )
-                                    resolved_parameter["resolved_value"] = resolved_value
-                                    found = True
-
-                        if not found:
+                        if given_value:
+                            LOG.debug(
+                                "Parameter %s could not be resolved, using given value of %s",
+                                name,
+                                given_value,
+                                exc_info=LOG.isEnabledFor(logging.DEBUG)
+                                and config.CFN_VERBOSE_ERRORS,
+                            )
+                            resolved_parameter["resolved_value"] = given_value
+                        else:
                             raise ValidationError(
                                 f"Parameter {name} should either have input value or default value"
                             ) from e

--- a/tests/aws/services/cloudformation/api/test_reference_resolving.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_reference_resolving.snapshot.json
@@ -32,5 +32,9 @@
         "MyTopicSubWithMap": "<topic-name>|arn:<partition>:sns:<region>:111111111111:<topic-name>|something"
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_reference_resolving.py::test_redeploy_cdk_with_reference": {
+    "recorded-date": "24-09-2025, 19:40:59",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/cloudformation/api/test_reference_resolving.validation.json
+++ b/tests/aws/services/cloudformation/api/test_reference_resolving.validation.json
@@ -5,6 +5,15 @@
   "tests/aws/services/cloudformation/api/test_reference_resolving.py::test_nested_getatt_ref[TopicName]": {
     "last_validated_date": "2023-05-11T11:43:51+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_reference_resolving.py::test_redeploy_cdk_with_reference": {
+    "last_validated_date": "2025-09-24T19:41:46+00:00",
+    "durations_in_seconds": {
+      "setup": 12.48,
+      "call": 102.32,
+      "teardown": 47.28,
+      "total": 162.08
+    }
+  },
   "tests/aws/services/cloudformation/api/test_reference_resolving.py::test_sub_resolving": {
     "last_validated_date": "2023-05-12T05:51:06+00:00"
   }

--- a/tests/aws/templates/cdk-lambda-redeploy.json
+++ b/tests/aws/templates/cdk-lambda-redeploy.json
@@ -1,0 +1,124 @@
+{
+  "Resources": {
+    "ReproPaymentsHandlerServiceRole7453EE1B": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "CdkStack/Repro/PaymentsHandler/ServiceRole/Resource"
+      }
+    },
+    "ReproPaymentsHandlerFA388BE4": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeployBucket"
+          },
+          "S3Key": {
+            "Ref": "DeployKey"
+          }
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ReproPaymentsHandlerServiceRole7453EE1B",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs22.x"
+      },
+      "DependsOn": [
+        "ReproPaymentsHandlerServiceRole7453EE1B"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "CdkStack/Repro/PaymentsHandler/Resource",
+        "aws:asset:path": "asset.83bd6ee15f56848d793729be08e79f53eed8a43e4d0857f3ad9a83280cb4784b",
+        "aws:asset:is-bundled": true,
+        "aws:asset:property": "Code"
+      }
+    },
+    "CDKMetadata": {
+      "Type": "AWS::CDK::Metadata",
+      "Properties": {
+        "Analytics": "v2:deflate64:H4sIAAAAAAAA/zXNywqDMBCF4WdxP05thEKXVeiyBX0AGeMo8RKLk9SF+O4lSlff6vxHoUrueI1olVg3QzyaGrfSkR6AVqm2kaa6ocrODfeCr4Ont9qZ2YKhCbdiHhny1gZ3kLQiEXaCjwBIipnXA7uMhOGsYd7af2OHgmX2i2Y4BqWjztguBN/efbzbIXxjL5evUni9YRL1Yky8eOvMxFic/gBWkHMZyAAAAA=="
+      },
+      "Metadata": {
+        "aws:cdk:path": "CdkStack/CDKMetadata/Default"
+      }
+    }
+  },
+  "Outputs": {
+    "ReproLambdaName070199FC": {
+      "Value": {
+        "Ref": "ReproPaymentsHandlerFA388BE4"
+      }
+    }
+  },
+  "Parameters": {
+    "DeployBucket": {
+      "Type": "String"
+    },
+    "DeployKey": {
+      "Type": "String"
+    },
+    "BootstrapVersion": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+    }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                  ],
+                  {
+                    "Ref": "BootstrapVersion"
+                  }
+                ]
+              }
+            ]
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

On first deploy of a CDK stack, it does not provide any parameters meaning the defaults are used. However on second deploy it provides the resolved value for the `BootstrapVersion` value. So on first deploy it uses the default (like `/cdk-bootstrap/hnb659fds/version`) but on the second it uses the resolved value (e.g. `28`).


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Add test that captures this behaviour
* If the parameter value could not be found, and the previous deployment has a resolved value, then take the value from there

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
