### PR TITLE
CFn: handle resolving parameter names constructed in intrinsics

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -435,19 +435,13 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             return value
 
         if dynamic_ref := extract_dynamic_reference(value):
-            try:
-                new_value = perform_dynamic_reference_lookup(
-                    reference=dynamic_ref,
-                    account_id=self._change_set.account_id,
-                    region_name=self._change_set.region_name,
-                )
-                if new_value:
-                    return REGEX_DYNAMIC_REF.sub(new_value, value)
-            except Exception:
-                # we cannot look this reference up right now, however that might be because we
-                # are visiting the arguments to an intrinsic function that will eventually create
-                # a full reference.
-                pass
+            new_value = perform_dynamic_reference_lookup(
+                reference=dynamic_ref,
+                account_id=self._change_set.account_id,
+                region_name=self._change_set.region_name,
+            )
+            if new_value:
+                return REGEX_DYNAMIC_REF.sub(new_value, value)
 
         return value
 

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -434,7 +434,7 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         if not isinstance(value, str):
             return value
         if isinstance(value, str) and (dynamic_ref_match := REGEX_DYNAMIC_REF.search(value)):
-            ref = DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2], dynamic_ref_match[3])
+            ref = DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2])
             try:
                 new_value = perform_dynamic_reference_lookup(
                     reference=ref,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -434,7 +434,7 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         if not isinstance(value, str):
             return value
         if isinstance(value, str) and (dynamic_ref_match := REGEX_DYNAMIC_REF.search(value)):
-            ref = DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2])
+            ref = DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2], dynamic_ref_match[3])
             try:
                 new_value = perform_dynamic_reference_lookup(
                     reference=ref,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -46,7 +46,7 @@ from localstack.services.cloudformation.engine.v2.change_set_model_visitor impor
 )
 from localstack.services.cloudformation.engine.v2.resolving import (
     REGEX_DYNAMIC_REF,
-    DynamicReference,
+    extract_dynamic_reference,
     perform_dynamic_reference_lookup,
 )
 from localstack.services.cloudformation.engine.validations import ValidationError
@@ -433,11 +433,11 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
     def _perform_dynamic_replacements(self, value: _T) -> _T:
         if not isinstance(value, str):
             return value
-        if isinstance(value, str) and (dynamic_ref_match := REGEX_DYNAMIC_REF.search(value)):
-            ref = DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2])
+
+        if dynamic_ref := extract_dynamic_reference(value):
             try:
                 new_value = perform_dynamic_reference_lookup(
-                    reference=ref,
+                    reference=dynamic_ref,
                     account_id=self._change_set.account_id,
                     region_name=self._change_set.region_name,
                 )

--- a/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
@@ -9,7 +9,7 @@ from localstack.aws.connect import connect_to
 
 LOG = logging.getLogger(__name__)
 
-REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):(.+)}}")
+REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):([a-zA-Z0-9_.\-/]+)}}")
 
 
 @dataclass

--- a/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
@@ -9,13 +9,21 @@ from localstack.aws.connect import connect_to
 
 LOG = logging.getLogger(__name__)
 
-REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):([a-zA-Z0-9_.\-/]+)}}")
+REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):([a-zA-Z0-9_.\-/]+)(?::(\d+))?}}")
 
 
 @dataclass
 class DynamicReference:
     service_name: str
     reference_key: str
+    version: str | None = None
+
+    @property
+    def versioned_name(self) -> str:
+        if self.version:
+            return f"{self.reference_key}:{self.version}"
+        else:
+            return self.reference_key
 
 
 def perform_dynamic_reference_lookup(
@@ -30,7 +38,7 @@ def perform_dynamic_reference_lookup(
     if reference.service_name == "ssm":
         ssm_client = connect_to(aws_access_key_id=account_id, region_name=region_name).ssm
         try:
-            return ssm_client.get_parameter(Name=reference.reference_key)["Parameter"]["Value"]
+            return ssm_client.get_parameter(Name=reference.versioned_name)["Parameter"]["Value"]
         except ClientError as e:
             LOG.error("client error accessing SSM parameter '%s': %s", reference.reference_key, e)
             raise

--- a/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from botocore.exceptions import ClientError
 
@@ -18,6 +19,13 @@ REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):([^${}]+)}}")
 class DynamicReference:
     service_name: str
     reference_key: str
+
+
+def extract_dynamic_reference(value: Any) -> DynamicReference | None:
+    if isinstance(value, str):
+        if dynamic_ref_match := REGEX_DYNAMIC_REF.search(value):
+            return DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2])
+    return None
 
 
 def perform_dynamic_reference_lookup(

--- a/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any
 
 from botocore.exceptions import ClientError
 
@@ -17,13 +16,6 @@ REGEX_DYNAMIC_REF = re.compile(r"{{resolve:([^:]+):(.+)}}")
 class DynamicReference:
     service_name: str
     reference_key: str
-
-
-def extract_dynamic_reference(value: Any) -> DynamicReference | None:
-    if isinstance(value, str):
-        if dynamic_ref_match := REGEX_DYNAMIC_REF.match(value):
-            return DynamicReference(dynamic_ref_match[1], dynamic_ref_match[2])
-    return None
 
 
 def perform_dynamic_reference_lookup(

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -349,20 +349,20 @@ class TestSsmParameters:
         )
 
     @markers.aws.validated
-    def test_resolve_ssm(self, create_parameter, deploy_cfn_template):
+    def test_resolve_ssm(self, create_parameter, deploy_cfn_template, snapshot):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.regex(parameter_value, "<parameter-value>"))
         create_parameter(Name=parameter_key, Value=parameter_value, Type="String")
 
         result = deploy_cfn_template(
-            parameters={"DynamicParameter": parameter_key},
+            parameters={"DynamicParameter": parameter_key, "ParameterName": parameter_key},
             template_path=os.path.join(
                 os.path.dirname(__file__), "../../templates/resolve_ssm.yaml"
             ),
         )
 
-        topic_name = result.outputs["TopicName"]
-        assert topic_name == parameter_value
+        snapshot.match("results", result.outputs)
 
     @markers.aws.validated
     def test_resolve_ssm_with_version(self, create_parameter, deploy_cfn_template, aws_client):

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -349,6 +349,7 @@ class TestSsmParameters:
         )
 
     @markers.aws.validated
+    @skip_if_legacy_engine()
     def test_resolve_ssm(self, create_parameter, deploy_cfn_template, snapshot):
         parameter_key = f"param-key-{short_uid()}"
         parameter_value = f"param-value-{short_uid()}"

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -381,8 +381,12 @@ class TestSsmParameters:
             Name=parameter_key, Overwrite=True, Type="String", Value=parameter_value_v2
         )
 
+        versioned_parameter_reference = f"{parameter_key}:{v1['Version']}"
         result = deploy_cfn_template(
-            parameters={"DynamicParameter": f"{parameter_key}:{v1['Version']}"},
+            parameters={
+                "DynamicParameter": versioned_parameter_reference,
+                "ParameterName": versioned_parameter_reference,
+            },
             template_path=os.path.join(
                 os.path.dirname(__file__), "../../templates/resolve_ssm.yaml"
             ),

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -520,7 +520,7 @@ class TestSecretsManagerParameters:
         create_secret(Name=parameter_key, SecretString=parameter_value)
 
         result = deploy_cfn_template(
-            parameters={"DynamicParameter": f"{parameter_key}"},
+            parameters={"DynamicParameter": parameter_key},
             template_path=os.path.join(
                 os.path.dirname(__file__),
                 "../../templates",

--- a/tests/aws/services/cloudformation/test_template_engine.snapshot.json
+++ b/tests/aws/services/cloudformation/test_template_engine.snapshot.json
@@ -691,5 +691,14 @@
     "recorded-content": {
       "error-response": "An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameter InputValue should either have input value or default value"
     }
+  },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestSsmParameters::test_resolve_ssm": {
+    "recorded-date": "24-09-2025, 22:06:32",
+    "recorded-content": {
+      "results": {
+        "ParameterValue": "abc:<parameter-value>",
+        "TopicName": "<parameter-value>"
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -110,6 +110,15 @@
       "total": 61.74
     }
   },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestSsmParameters::test_resolve_ssm": {
+    "last_validated_date": "2025-09-24T22:07:22+00:00",
+    "durations_in_seconds": {
+      "setup": 0.95,
+      "call": 10.67,
+      "teardown": 50.0,
+      "total": 61.62
+    }
+  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestSsmParameters::test_resolve_ssm_missing_parameter": {
     "last_validated_date": "2025-08-06T09:34:07+00:00",
     "durations_in_seconds": {

--- a/tests/aws/templates/resolve_ssm.yaml
+++ b/tests/aws/templates/resolve_ssm.yaml
@@ -2,14 +2,25 @@ Parameters:
   DynamicParameter:
     Type: String
 
+  ParameterName:
+    Type: String
+
 Resources:
   topic69831491:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: !Join [ "", [ "{{resolve:ssm:", !Ref DynamicParameter, "}}"  ] ]
+      TopicName: !Join [ "", [ "{{resolve:ssm:", !Ref DynamicParameter, "}}" ] ]
+  MyParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !Sub "abc:{{resolve:ssm:${ParameterName}}}"
 Outputs:
   TopicName:
     Value:
       Fn::GetAtt:
         - topic69831491
         - TopicName
+
+  ParameterValue:
+    Value: !GetAtt MyParameter.Value

--- a/tests/unit/services/cloudformation/test_cloudformation.py
+++ b/tests/unit/services/cloudformation/test_cloudformation.py
@@ -1,9 +1,12 @@
+import pytest
+
 from localstack.services.cloudformation.api_utils import is_local_service_url
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
     remove_none_values,
 )
 from localstack.services.cloudformation.engine.template_deployer import order_resources
+from localstack.services.cloudformation.engine.v2.resolving import REGEX_DYNAMIC_REF
 
 
 def test_is_local_service_url():
@@ -60,3 +63,16 @@ def test_order_resources():
     )
 
     assert list(sorted_resources.keys()) == ["A", "B"]
+
+
+class TestDynamicResolving:
+    @pytest.mark.parametrize(
+        "value,matches",
+        [
+            pytest.param("{{resolve:ssm:abc123}}", True, id="basic"),
+            pytest.param("abc:{{resolve:ssm:abc123}}:foo", True, id="with-surrounding"),
+            pytest.param("{{resolve:ssm:${ParameterName}}}", False, id="in-sub"),
+        ],
+    )
+    def test_dynamic_ref_regex_matches(self, value, matches):
+        assert bool(REGEX_DYNAMIC_REF.search(value)) == matches

--- a/tests/unit/services/cloudformation/test_cloudformation.py
+++ b/tests/unit/services/cloudformation/test_cloudformation.py
@@ -69,9 +69,21 @@ class TestDynamicResolving:
     @pytest.mark.parametrize(
         "value,matches",
         [
-            pytest.param("{{resolve:ssm:abc123}}", True, id="basic"),
-            pytest.param("abc:{{resolve:ssm:abc123}}:foo", True, id="with-surrounding"),
-            pytest.param("{{resolve:ssm:${ParameterName}}}", False, id="in-sub"),
+            pytest.param("{{resolve:ssm:abc123}}", True, id="ssm-basic"),
+            pytest.param("abc:{{resolve:ssm:abc123}}:foo", True, id="ssm-with-surrounding"),
+            pytest.param("{{resolve:ssm:${ParameterName}}}", False, id="ssm-in-sub"),
+            pytest.param("{{resolve:secretsmanager:foo}}", True, id="secrets-basic"),
+            pytest.param(
+                "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:000000000000:secret:foo:SecretString:}}",
+                True,
+                id="secrets-partial",
+            ),
+            pytest.param(
+                "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:000000000000:secret:foo:SecretString:::}}",
+                True,
+                id="secrets-full",
+            ),
+            pytest.param("{{resolve:secretsmanager:${SecretName}}}", False, id="secrets-in-sub"),
         ],
     )
     def test_dynamic_ref_regex_matches(self, value, matches):


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

From #13169 we have an example of dynamic resolving where the name of the SSM parameter is built up from an `Fn::Sub` call, e.g.

```yaml
Value: !Sub "abc:{{resolve:ssm:${ParameterName}}}"
```

This means the `!Sub` intrinsic should be invoked before the SSM parameter is resolved.



<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

We now 
* perform better matching of whether a parameter is present
* handle failure to resolve the parameter and assume that we will come back to it later

Also: 
* add a unit test for the regex matching
* update an exisitng test to include this use case

Closes #13169



<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
