### PR TITLE
Add dependency linting and clean up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ lint:              		  ## Run code linter to check code style, check if formatte
 	$(VENV_RUN); pre-commit run check-pinned-deps-for-needed-upgrade --files pyproject.toml # run pre-commit hook manually here to ensure that this check runs in CI as well
 	$(VENV_RUN); openapi-spec-validator localstack-core/localstack/openapi.yaml
 	$(VENV_RUN); cd localstack-core && mypy --install-types --non-interactive
+	$(VENV_RUN); deptry .
 
 lint-modified:     		  ## Run code linter to check code style, check if formatter would make changes on modified files, and check if dependency pins need to be updated because of modified files
 	($(VENV_RUN); python -m ruff check --output-format=full `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs` && python -m ruff format --check `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ description = "The core library and runtime of LocalStack"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "build",
     "click>=7.1",
     "cachetools>=5.0",
     "cryptography",
@@ -26,7 +25,6 @@ dependencies = [
     "rich>=12.3.0",
     "requests>=2.20.0",
     "semver>=2.10",
-    "tailer>=0.4.1",
 ]
 dynamic = ["version"]
 classifiers = [
@@ -56,17 +54,22 @@ base-runtime = [
     "boto3==1.40.51",
     # pinned / updated by ASF update action
     "botocore==1.40.51",
+    # transitive dependency of botocore, added to avoid specific version
     "awscrt>=0.13.14,!=0.27.1",
     "cbor2>=5.5.0",
     "dnspython>=1.16.0",
     "docker>=6.1.1",
     "jsonpatch>=1.24",
+    "jsonpointer>=3.0.0",
+    "jsonschema>=4.25.1",
     "hypercorn>=0.14.4",
     "localstack-twisted>=23.0",
     "openapi-core>=0.19.2",
     "pyopenssl>=23.0.0",
+    "python-dateutil>=2.9.0",
     "readerwriterlock>=1.0.7",
     "requests-aws4auth>=1.0",
+    "typing-extensions>=4.15.0",
     # explicitly set urllib3 to force its usage / ensure compatibility
     "urllib3>=2.0.7",
     "Werkzeug>=3.1.3",
@@ -80,23 +83,25 @@ runtime = [
     # pinned / updated by ASF update action
     "awscli==1.42.51",
     "airspeed-ext>=0.6.3",
-    # version that has a built wheel
-    "kclpy-ext>=3.0.0",
     # antlr4-python3-runtime: exact pin because antlr4 runtime is tightly coupled to the generated parser code
     "antlr4-python3-runtime==4.13.2",
     "apispec>=5.1.1",
     "aws-sam-translator>=1.15.1",
     "crontab>=0.22.6",
     "cryptography>=41.0.5",
+    "jinja2>=3.1.6",
     # allow Python programs full access to Java class libraries. Used for stepfunctions jsonata support
     "jpype1>=1.6.0",
-    "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
+    # version that has a built wheel
+    "kclpy-ext>=3.0.0",
     "moto-ext[all]>=5.1.12.post22",
     "opensearch-py>=2.4.1",
+    "pydantic>=2.11.9",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",
+    "responses>=0.25.8",
 ]
 
 # for running tests and coverage analysis
@@ -104,8 +109,8 @@ test = [
     # runtime dependencies are required for running the tests
     "localstack-core[runtime]",
     "coverage[toml]>=5.5",
-    "deepdiff>=6.4.1",
     "httpx[http2]>=0.25",
+    "json5>=0.12.1",
     "pluggy>=1.3.0",
     "pytest>=7.4.2",
     "pytest-split>=0.8.0",
@@ -122,6 +127,7 @@ dev = [
     # test dependencies are required for developing localstack
     "localstack-core[test]",
     "coveralls>=3.3.1",
+    "deptry>=0.13.0",
     "Cython",
     "networkx>=2.8.4",
     "openapi-spec-validator>=0.7.1",
@@ -202,6 +208,34 @@ exclude = [
 "localstack-core/localstack/utils/**" = "py310"  # imported by CLI tests
 "localstack-core/localstack/testing/pytest/**" = "py310" # imported by CLI tests
 
+[tool.deptry]
+known_first_party = [
+    "vosk", # managed by localstack package manager
+    "debugpy", # managed by localstack package manager
+]
+extend_exclude = [
+    "scripts/**", # dependencies not handled by pyproject.toml
+    "localstack-core/localstack/testing/**", # utilities for testing
+    "localstack-core/localstack/aws/mocking.py", # not used at runtime
+    "localstack-core/localstack/aws/scaffold.py", # not used at runtime
+    "localstack-core/localstack/dev/**", # internal dev tooling
+    "localstack-core/localstack/services/stepfunctions/asl/antlr/runtime/**" # generated code
+]
+pep621_dev_dependency_groups = ["dev", "typehint", "test"]
+
+[tool.deptry.package_module_name_map]
+"localstack-core" = ["localstack"]
+
+[tool.deptry.per_rule_ignores]
+DEP001 = [
+    "com", # This appears in jpype code and imports actual java packages like com.fasterxml.jackson.databind
+    "stevedore", # used for CLI plugin debugging - TODO move this debugging CLI into plux
+]
+DEP002 = [
+    "awscli", # necessary for python init scripts - TODO deprecate python init scripts and remove this
+    "awscrt", # defined to ignore a specific version - TODO evaluate and clean up
+]
+
 [tool.ruff.lint]
 ignore = [
     "B007", # TODO Loop control variable x not used within loop body
@@ -219,8 +253,8 @@ ignore = [
 ]
 select = ["B", "C", "E", "F", "I", "W", "T", "B9", "G", "UP"]
 extend-safe-fixes = [
-    "UP006",    # unsafe-fix for py39
-    "UP035",    # unsafe-fix for py39
+    "UP006", # unsafe-fix for py39
+    "UP035", # unsafe-fix for py39
 ]
 
 # The rules below fill fix the code in a way that leaves multiple unused imports.

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -9,7 +9,7 @@ attrs==25.4.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-awscrt==0.28.1
+awscrt==0.28.2
     # via localstack-core (pyproject.toml)
 boto3==1.40.51
     # via localstack-core (pyproject.toml)
@@ -18,8 +18,6 @@ botocore==1.40.51
     #   boto3
     #   localstack-core (pyproject.toml)
     #   s3transfer
-build==1.3.0
-    # via localstack-core (pyproject.toml)
 cachetools==6.2.1
     # via localstack-core (pyproject.toml)
 cbor2==5.7.0
@@ -78,9 +76,12 @@ jmespath==1.0.1
 jsonpatch==1.33
     # via localstack-core (pyproject.toml)
 jsonpointer==3.0.0
-    # via jsonpatch
+    # via
+    #   jsonpatch
+    #   localstack-core (pyproject.toml)
 jsonschema==4.25.1
     # via
+    #   localstack-core (pyproject.toml)
     #   openapi-core
     #   openapi-schema-validator
     #   openapi-spec-validator
@@ -112,8 +113,6 @@ openapi-schema-validator==0.6.3
     #   openapi-spec-validator
 openapi-spec-validator==0.7.2
     # via openapi-core
-packaging==25.0
-    # via build
 parse==1.20.2
     # via openapi-core
 pathable==0.4.4
@@ -134,10 +133,10 @@ pyopenssl==25.3.0
     # via
     #   localstack-core (pyproject.toml)
     #   localstack-twisted
-pyproject-hooks==1.2.0
-    # via build
 python-dateutil==2.9.0.post0
-    # via botocore
+    # via
+    #   botocore
+    #   localstack-core (pyproject.toml)
 python-dotenv==1.1.1
     # via localstack-core (pyproject.toml)
 pyyaml==6.0.3
@@ -178,10 +177,9 @@ six==1.17.0
     # via
     #   python-dateutil
     #   rfc3339-validator
-tailer==0.4.1
-    # via localstack-core (pyproject.toml)
 typing-extensions==4.15.0
     # via
+    #   localstack-core (pyproject.toml)
     #   localstack-twisted
     #   readerwriterlock
 urllib3==2.5.0

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --cert=None --client-cert=None --index-url=None --output-file=requirements-basic.txt --pip-args=None --strip-extras --unsafe-package=distribute --unsafe-package=localstack-core --unsafe-package=pip --unsafe-package=setuptools pyproject.toml
 #
-build==1.3.0
-    # via localstack-core (pyproject.toml)
 cachetools==6.2.1
     # via localstack-core (pyproject.toml)
 certifi==2025.10.5
@@ -30,8 +28,6 @@ markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-packaging==25.0
-    # via build
 plux==1.13.0
     # via localstack-core (pyproject.toml)
 psutil==7.1.0
@@ -40,8 +36,6 @@ pycparser==2.23
     # via cffi
 pygments==2.19.2
     # via rich
-pyproject-hooks==1.2.0
-    # via build
 python-dotenv==1.1.1
     # via localstack-core (pyproject.toml)
 pyyaml==6.0.3
@@ -51,8 +45,6 @@ requests==2.32.5
 rich==14.2.0
     # via localstack-core (pyproject.toml)
 semver==3.0.4
-    # via localstack-core (pyproject.toml)
-tailer==0.4.1
     # via localstack-core (pyproject.toml)
 urllib3==2.5.0
     # via requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,9 +29,9 @@ aws-cdk-asset-awscli-v1==2.2.242
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==48.14.0
+aws-cdk-cloud-assembly-schema==48.15.0
     # via aws-cdk-lib
-aws-cdk-lib==2.219.0
+aws-cdk-lib==2.220.0
     # via localstack-core
 aws-sam-translator==1.101.0
     # via
@@ -41,7 +41,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.42.51
     # via localstack-core
-awscrt==0.28.1
+awscrt==0.28.2
     # via localstack-core
 boto3==1.40.51
     # via
@@ -57,10 +57,6 @@ botocore==1.40.51
     #   localstack-core
     #   moto-ext
     #   s3transfer
-build==1.3.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 cachetools==6.2.1
     # via
     #   airspeed-ext
@@ -80,12 +76,13 @@ cffi==2.0.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.40.1
+cfn-lint==1.40.2
     # via moto-ext
 charset-normalizer==3.4.4
     # via requests
 click==8.3.0
     # via
+    #   deptry
     #   localstack-core
     #   localstack-core (pyproject.toml)
 colorama==0.4.6
@@ -114,9 +111,9 @@ cython==3.1.4
 decorator==5.2.1
     # via jsonpath-rw
 deepdiff==8.6.1
-    # via
-    #   localstack-core
-    #   localstack-snapshot
+    # via localstack-snapshot
+deptry==0.23.1
+    # via localstack-core (pyproject.toml)
 dill==0.3.6
     # via
     #   localstack-core
@@ -186,7 +183,9 @@ iniconfig==2.1.0
 isodate==0.7.2
     # via openapi-core
 jinja2==3.1.6
-    # via moto-ext
+    # via
+    #   localstack-core
+    #   moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -195,7 +194,7 @@ joserfc==1.4.0
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core
-jsii==1.115.0
+jsii==1.116.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-node-proxy-agent-v6
@@ -216,10 +215,13 @@ jsonpath-ng==1.7.0
 jsonpath-rw==1.4.0
     # via localstack-core
 jsonpointer==3.0.0
-    # via jsonpatch
+    # via
+    #   jsonpatch
+    #   localstack-core
 jsonschema==4.25.1
     # via
     #   aws-sam-translator
+    #   localstack-core
     #   moto-ext
     #   openapi-core
     #   openapi-schema-validator
@@ -284,10 +286,11 @@ orderly-set==5.5.0
 packaging==25.0
     # via
     #   apispec
-    #   build
+    #   deptry
     #   jpype1
     #   pytest
     #   pytest-rerunfailures
+    #   requirements-parser
 pandoc==2.4
     # via localstack-core (pyproject.toml)
 parse==1.20.2
@@ -337,9 +340,11 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pydantic==2.12.1
-    # via aws-sam-translator
-pydantic-core==2.41.3
+pydantic==2.12.2
+    # via
+    #   aws-sam-translator
+    #   localstack-core
+pydantic-core==2.41.4
     # via pydantic
 pygments==2.19.2
     # via
@@ -355,8 +360,6 @@ pypandoc==1.15
     # via localstack-core (pyproject.toml)
 pyparsing==3.2.5
     # via moto-ext
-pyproject-hooks==1.2.0
-    # via build
 pytest==8.4.2
     # via
     #   localstack-core
@@ -375,6 +378,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   jsii
+    #   localstack-core
     #   moto-ext
     #   opensearch-py
 python-dotenv==1.1.1
@@ -415,8 +419,12 @@ requests==2.32.5
     #   rolo
 requests-aws4auth==1.3.1
     # via localstack-core
+requirements-parser==0.13.0
+    # via deptry
 responses==0.25.8
-    # via moto-ext
+    # via
+    #   localstack-core
+    #   moto-ext
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rich==14.2.0
@@ -453,10 +461,6 @@ sniffio==1.3.1
     # via anyio
 sympy==1.14.0
     # via cfn-lint
-tailer==0.4.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 typeguard==2.13.3
     # via
     #   aws-cdk-asset-awscli-v1
@@ -471,6 +475,7 @@ typing-extensions==4.15.0
     #   cattrs
     #   cfn-lint
     #   jsii
+    #   localstack-core
     #   localstack-twisted
     #   mypy
     #   pydantic

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -29,7 +29,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.42.51
     # via localstack-core (pyproject.toml)
-awscrt==0.28.1
+awscrt==0.28.2
     # via localstack-core
 boto3==1.40.51
     # via
@@ -45,10 +45,6 @@ botocore==1.40.51
     #   localstack-core
     #   moto-ext
     #   s3transfer
-build==1.3.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 cachetools==6.2.1
     # via
     #   airspeed-ext
@@ -62,7 +58,7 @@ certifi==2025.10.5
     #   requests
 cffi==2.0.0
     # via cryptography
-cfn-lint==1.40.1
+cfn-lint==1.40.2
     # via moto-ext
 charset-normalizer==3.4.4
     # via requests
@@ -134,7 +130,9 @@ incremental==24.7.2
 isodate==0.7.2
     # via openapi-core
 jinja2==3.1.6
-    # via moto-ext
+    # via
+    #   localstack-core (pyproject.toml)
+    #   moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -142,8 +140,6 @@ jmespath==1.0.1
 joserfc==1.4.0
     # via moto-ext
 jpype1==1.6.0
-    # via localstack-core (pyproject.toml)
-json5==0.12.1
     # via localstack-core (pyproject.toml)
 jsonpatch==1.33
     # via
@@ -156,10 +152,13 @@ jsonpath-ng==1.7.0
 jsonpath-rw==1.4.0
     # via localstack-core (pyproject.toml)
 jsonpointer==3.0.0
-    # via jsonpatch
+    # via
+    #   jsonpatch
+    #   localstack-core
 jsonschema==4.25.1
     # via
     #   aws-sam-translator
+    #   localstack-core
     #   moto-ext
     #   openapi-core
     #   openapi-schema-validator
@@ -211,7 +210,6 @@ opensearch-py==3.0.0
 packaging==25.0
     # via
     #   apispec
-    #   build
     #   jpype1
 parse==1.20.2
     # via openapi-core
@@ -239,9 +237,11 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pydantic==2.12.1
-    # via aws-sam-translator
-pydantic-core==2.41.3
+pydantic==2.12.2
+    # via
+    #   aws-sam-translator
+    #   localstack-core (pyproject.toml)
+pydantic-core==2.41.4
     # via pydantic
 pygments==2.19.2
     # via rich
@@ -254,11 +254,10 @@ pyopenssl==25.3.0
     #   localstack-twisted
 pyparsing==3.2.5
     # via moto-ext
-pyproject-hooks==1.2.0
-    # via build
 python-dateutil==2.9.0.post0
     # via
     #   botocore
+    #   localstack-core
     #   moto-ext
     #   opensearch-py
 python-dotenv==1.1.1
@@ -297,7 +296,9 @@ requests==2.32.5
 requests-aws4auth==1.3.1
     # via localstack-core
 responses==0.25.8
-    # via moto-ext
+    # via
+    #   localstack-core (pyproject.toml)
+    #   moto-ext
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rich==14.2.0
@@ -328,14 +329,11 @@ six==1.17.0
     #   rfc3339-validator
 sympy==1.14.0
     # via cfn-lint
-tailer==0.4.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 typing-extensions==4.15.0
     # via
     #   aws-sam-translator
     #   cfn-lint
+    #   localstack-core
     #   localstack-twisted
     #   pydantic
     #   pydantic-core

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -29,9 +29,9 @@ aws-cdk-asset-awscli-v1==2.2.242
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==48.14.0
+aws-cdk-cloud-assembly-schema==48.15.0
     # via aws-cdk-lib
-aws-cdk-lib==2.219.0
+aws-cdk-lib==2.220.0
     # via localstack-core (pyproject.toml)
 aws-sam-translator==1.101.0
     # via
@@ -41,7 +41,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.42.51
     # via localstack-core
-awscrt==0.28.1
+awscrt==0.28.2
     # via localstack-core
 boto3==1.40.51
     # via
@@ -57,10 +57,6 @@ botocore==1.40.51
     #   localstack-core
     #   moto-ext
     #   s3transfer
-build==1.3.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 cachetools==6.2.1
     # via
     #   airspeed-ext
@@ -78,7 +74,7 @@ certifi==2025.10.5
     #   requests
 cffi==2.0.0
     # via cryptography
-cfn-lint==1.40.1
+cfn-lint==1.40.2
     # via moto-ext
 charset-normalizer==3.4.4
     # via requests
@@ -106,9 +102,7 @@ cryptography==46.0.2
 decorator==5.2.1
     # via jsonpath-rw
 deepdiff==8.6.1
-    # via
-    #   localstack-core (pyproject.toml)
-    #   localstack-snapshot
+    # via localstack-snapshot
 dill==0.3.6
     # via
     #   localstack-core
@@ -170,7 +164,9 @@ iniconfig==2.1.0
 isodate==0.7.2
     # via openapi-core
 jinja2==3.1.6
-    # via moto-ext
+    # via
+    #   localstack-core
+    #   moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -179,7 +175,7 @@ joserfc==1.4.0
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core
-jsii==1.115.0
+jsii==1.116.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-node-proxy-agent-v6
@@ -187,7 +183,7 @@ jsii==1.115.0
     #   aws-cdk-lib
     #   constructs
 json5==0.12.1
-    # via localstack-core
+    # via localstack-core (pyproject.toml)
 jsonpatch==1.33
     # via
     #   cfn-lint
@@ -200,10 +196,13 @@ jsonpath-ng==1.7.0
 jsonpath-rw==1.4.0
     # via localstack-core
 jsonpointer==3.0.0
-    # via jsonpatch
+    # via
+    #   jsonpatch
+    #   localstack-core
 jsonschema==4.25.1
     # via
     #   aws-sam-translator
+    #   localstack-core
     #   moto-ext
     #   openapi-core
     #   openapi-schema-validator
@@ -259,7 +258,6 @@ orderly-set==5.5.0
 packaging==25.0
     # via
     #   apispec
-    #   build
     #   jpype1
     #   pytest
     #   pytest-rerunfailures
@@ -301,9 +299,11 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pydantic==2.12.1
-    # via aws-sam-translator
-pydantic-core==2.41.3
+pydantic==2.12.2
+    # via
+    #   aws-sam-translator
+    #   localstack-core
+pydantic-core==2.41.4
     # via pydantic
 pygments==2.19.2
     # via
@@ -317,8 +317,6 @@ pyopenssl==25.3.0
     #   localstack-twisted
 pyparsing==3.2.5
     # via moto-ext
-pyproject-hooks==1.2.0
-    # via build
 pytest==8.4.2
     # via
     #   localstack-core (pyproject.toml)
@@ -337,6 +335,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   jsii
+    #   localstack-core
     #   moto-ext
     #   opensearch-py
 python-dotenv==1.1.1
@@ -376,7 +375,9 @@ requests==2.32.5
 requests-aws4auth==1.3.1
     # via localstack-core
 responses==0.25.8
-    # via moto-ext
+    # via
+    #   localstack-core
+    #   moto-ext
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rich==14.2.0
@@ -409,10 +410,6 @@ sniffio==1.3.1
     # via anyio
 sympy==1.14.0
     # via cfn-lint
-tailer==0.4.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 typeguard==2.13.3
     # via
     #   aws-cdk-asset-awscli-v1
@@ -427,6 +424,7 @@ typing-extensions==4.15.0
     #   cattrs
     #   cfn-lint
     #   jsii
+    #   localstack-core
     #   localstack-twisted
     #   pydantic
     #   pydantic-core

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -29,9 +29,9 @@ aws-cdk-asset-awscli-v1==2.2.242
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
-aws-cdk-cloud-assembly-schema==48.14.0
+aws-cdk-cloud-assembly-schema==48.15.0
     # via aws-cdk-lib
-aws-cdk-lib==2.219.0
+aws-cdk-lib==2.220.0
     # via localstack-core
 aws-sam-translator==1.101.0
     # via
@@ -41,7 +41,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.42.51
     # via localstack-core
-awscrt==0.28.1
+awscrt==0.28.2
     # via localstack-core
 boto3==1.40.51
     # via
@@ -49,7 +49,7 @@ boto3==1.40.51
     #   kclpy-ext
     #   localstack-core
     #   moto-ext
-boto3-stubs==1.40.51
+boto3-stubs==1.40.52
     # via localstack-core (pyproject.toml)
 botocore==1.40.51
     # via
@@ -59,12 +59,8 @@ botocore==1.40.51
     #   localstack-core
     #   moto-ext
     #   s3transfer
-botocore-stubs==1.40.51
+botocore-stubs==1.40.52
     # via boto3-stubs
-build==1.3.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 cachetools==6.2.1
     # via
     #   airspeed-ext
@@ -84,12 +80,13 @@ cffi==2.0.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.40.1
+cfn-lint==1.40.2
     # via moto-ext
 charset-normalizer==3.4.4
     # via requests
 click==8.3.0
     # via
+    #   deptry
     #   localstack-core
     #   localstack-core (pyproject.toml)
 colorama==0.4.6
@@ -118,9 +115,9 @@ cython==3.1.4
 decorator==5.2.1
     # via jsonpath-rw
 deepdiff==8.6.1
-    # via
-    #   localstack-core
-    #   localstack-snapshot
+    # via localstack-snapshot
+deptry==0.23.1
+    # via localstack-core
 dill==0.3.6
     # via
     #   localstack-core
@@ -190,7 +187,9 @@ iniconfig==2.1.0
 isodate==0.7.2
     # via openapi-core
 jinja2==3.1.6
-    # via moto-ext
+    # via
+    #   localstack-core
+    #   moto-ext
 jmespath==1.0.1
     # via
     #   boto3
@@ -199,7 +198,7 @@ joserfc==1.4.0
     # via moto-ext
 jpype1==1.6.0
     # via localstack-core
-jsii==1.115.0
+jsii==1.116.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-node-proxy-agent-v6
@@ -220,10 +219,13 @@ jsonpath-ng==1.7.0
 jsonpath-rw==1.4.0
     # via localstack-core
 jsonpointer==3.0.0
-    # via jsonpatch
+    # via
+    #   jsonpatch
+    #   localstack-core
 jsonschema==4.25.1
     # via
     #   aws-sam-translator
+    #   localstack-core
     #   moto-ext
     #   openapi-core
     #   openapi-schema-validator
@@ -284,7 +286,7 @@ mypy-boto3-athena==1.40.0
     # via boto3-stubs
 mypy-boto3-autoscaling==1.40.27
     # via boto3-stubs
-mypy-boto3-backup==1.40.46
+mypy-boto3-backup==1.40.52
     # via boto3-stubs
 mypy-boto3-batch==1.40.36
     # via boto3-stubs
@@ -324,7 +326,7 @@ mypy-boto3-dynamodb==1.40.44
     # via boto3-stubs
 mypy-boto3-dynamodbstreams==1.40.40
     # via boto3-stubs
-mypy-boto3-ec2==1.40.51
+mypy-boto3-ec2==1.40.52
     # via boto3-stubs
 mypy-boto3-ecr==1.40.0
     # via boto3-stubs
@@ -460,7 +462,7 @@ mypy-boto3-timestream-query==1.40.20
     # via boto3-stubs
 mypy-boto3-timestream-write==1.40.19
     # via boto3-stubs
-mypy-boto3-transcribe==1.40.8
+mypy-boto3-transcribe==1.40.52
     # via boto3-stubs
 mypy-boto3-verifiedpermissions==1.40.24
     # via boto3-stubs
@@ -494,10 +496,11 @@ orderly-set==5.5.0
 packaging==25.0
     # via
     #   apispec
-    #   build
+    #   deptry
     #   jpype1
     #   pytest
     #   pytest-rerunfailures
+    #   requirements-parser
 pandoc==2.4
     # via localstack-core
 parse==1.20.2
@@ -547,9 +550,11 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pydantic==2.12.1
-    # via aws-sam-translator
-pydantic-core==2.41.3
+pydantic==2.12.2
+    # via
+    #   aws-sam-translator
+    #   localstack-core
+pydantic-core==2.41.4
     # via pydantic
 pygments==2.19.2
     # via
@@ -565,8 +570,6 @@ pypandoc==1.15
     # via localstack-core
 pyparsing==3.2.5
     # via moto-ext
-pyproject-hooks==1.2.0
-    # via build
 pytest==8.4.2
     # via
     #   localstack-core
@@ -585,6 +588,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   jsii
+    #   localstack-core
     #   moto-ext
     #   opensearch-py
 python-dotenv==1.1.1
@@ -625,8 +629,12 @@ requests==2.32.5
     #   rolo
 requests-aws4auth==1.3.1
     # via localstack-core
+requirements-parser==0.13.0
+    # via deptry
 responses==0.25.8
-    # via moto-ext
+    # via
+    #   localstack-core
+    #   moto-ext
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rich==14.2.0
@@ -663,10 +671,6 @@ sniffio==1.3.1
     # via anyio
 sympy==1.14.0
     # via cfn-lint
-tailer==0.4.1
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 typeguard==2.13.3
     # via
     #   aws-cdk-asset-awscli-v1
@@ -685,6 +689,7 @@ typing-extensions==4.15.0
     #   cattrs
     #   cfn-lint
     #   jsii
+    #   localstack-core
     #   localstack-twisted
     #   mypy
     #   pydantic


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

So far it has been difficult to maintain our dependencies and keep them clean. We face two issues:

1. We nominally depend on packages which we actually don't use in our code
2. We use packages in our code which we only transitively depend on

To solve these issues we can add a step to our linting which uses https://github.com/fpgmaas/deptry

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Add deptry and suitable configuration to indicate what our dev-dependencies are and which code is only used during development
- Run deptry in the linting make target
- Define all dependencies that are actually used by our package
  - packages that we use and only depend on transitively are now defined as actual dependencies
  - packages that we define as dependencies and don't use are removed
  - packages that we define as runtime packages but are actually only test packages are moved to the test dependencies
- Run the dependency upgrade to regenerate the pins correctly.

part of FLC-86

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
