### PR TITLE
CFN: fix for dynamic ref when value is a number

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/resolving.py
@@ -92,9 +92,9 @@ def perform_dynamic_reference_lookup(
                 raise RuntimeError(
                     f"JSON value for {reference.service_name}.{reference.reference_key} not present"
                 )
-            return json_secret[json_key]
+            return str(json_secret[json_key])
         else:
-            return secret_value
+            return str(secret_value)
 
     LOG.warning(
         "Unsupported service for dynamic parameter: service_name=%s", reference.service_name


### PR DESCRIPTION
## Motivation
- This PR fixes an issue in the pipeline caused by `perform_dynamic_reference_lookup` returning a number in certain occasions. 


## Changes
- convert returning type to string as the type annotation suggests
