### PR TITLE
add sqs tests for ApproximateNumberOfMessagesNotVisible queue attribute

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -153,7 +153,7 @@ class SqsMessage:
         """
         Returns false if the message has a visibility deadline that is in the future.
 
-        :return: whether the message is visibile or not.
+        :return: whether the message is visible or not.
         """
         if self.visibility_deadline is None:
             return True

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -4203,5 +4203,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_approximate_number_of_messages_not_visible[sqs]": {
+    "recorded-date": "25-09-2025, 21:46:19",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_approximate_number_of_messages_not_visible[sqs_query]": {
+    "recorded-date": "25-09-2025, 21:47:19",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs]": {
+    "recorded-date": "25-09-2025, 21:53:42",
+    "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs_query]": {
+    "recorded-date": "25-09-2025, 21:54:43",
+    "recorded-content": {}
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -1,4 +1,22 @@
 {
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_approximate_number_of_messages_not_visible[sqs]": {
+    "last_validated_date": "2025-09-25T21:46:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.17,
+      "call": 60.64,
+      "teardown": 0.07,
+      "total": 60.88
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_approximate_number_of_messages_not_visible[sqs_query]": {
+    "last_validated_date": "2025-09-25T21:47:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 60.47,
+      "teardown": 0.09,
+      "total": 60.56
+    }
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_aws_trace_header_propagation[sqs]": {
     "last_validated_date": "2025-06-27T10:55:55+00:00",
     "durations_in_seconds": {
@@ -144,6 +162,24 @@
       "call": 0.56,
       "teardown": 0.16,
       "total": 0.86
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs]": {
+    "last_validated_date": "2025-09-25T21:53:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.26,
+      "call": 60.54,
+      "teardown": 0.08,
+      "total": 60.88
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs_query]": {
+    "last_validated_date": "2025-09-25T21:54:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 60.57,
+      "teardown": 0.09,
+      "total": 60.66
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -1,20 +1,20 @@
 {
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_approximate_number_of_messages_not_visible[sqs]": {
-    "last_validated_date": "2025-09-25T21:46:19+00:00",
+    "last_validated_date": "2025-09-26T16:41:28+00:00",
     "durations_in_seconds": {
-      "setup": 0.17,
-      "call": 60.64,
+      "setup": 0.19,
+      "call": 61.13,
       "teardown": 0.07,
-      "total": 60.88
+      "total": 61.39
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_approximate_number_of_messages_not_visible[sqs_query]": {
-    "last_validated_date": "2025-09-25T21:47:19+00:00",
+    "last_validated_date": "2025-09-26T16:42:30+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 60.47,
+      "call": 61.63,
       "teardown": 0.09,
-      "total": 60.56
+      "total": 61.72
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_aws_trace_header_propagation[sqs]": {
@@ -165,21 +165,21 @@
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs]": {
-    "last_validated_date": "2025-09-25T21:53:42+00:00",
+    "last_validated_date": "2025-09-26T16:46:35+00:00",
     "durations_in_seconds": {
-      "setup": 0.26,
-      "call": 60.54,
+      "setup": 5.18,
+      "call": 62.17,
       "teardown": 0.08,
-      "total": 60.88
+      "total": 67.43
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs_query]": {
-    "last_validated_date": "2025-09-25T21:54:43+00:00",
+    "last_validated_date": "2025-09-26T16:47:37+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 60.57,
-      "teardown": 0.09,
-      "total": 60.66
+      "call": 62.34,
+      "teardown": 0.07,
+      "total": 62.41
     }
   },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_change_to_high_throughput_after_creation[sqs]": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We had an open issue in our internal issue tracker that was arguing that `ApproximateNumberOfMessagesNotVisible` was broken because of the same reason of #13196. Turns out it works fine! This just adds aws validated tests to demonstrate that it does.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* No functional changes, just adding tests after an investigation

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
