### PR TITLE
update elasticsearch default version to 7.10.2

### DIFF
--- a/localstack-core/localstack/services/opensearch/versions.py
+++ b/localstack-core/localstack/services/opensearch/versions.py
@@ -30,7 +30,7 @@ _opensearch_install_versions = {
 }
 # Internal representation of the Elasticsearch versions (without the "Elasticsearch_" prefix)
 _elasticsearch_install_versions = {
-    "7.10": "7.10.0",
+    "7.10": "7.10.2",
     "7.9": "7.9.3",
     "7.8": "7.8.1",
     "7.7": "7.7.1",


### PR DESCRIPTION
## Motivation
With #13134 I overlooked that there is also a patch version for 7.10 of ElasticSearch available which we are not yet using: 7.10.2.
This PR upgrades the default version of ElasticSearch to this version.

## Changes
- Change patch version used for the default version of ElasticSearch 7.10 to 7.10.2.