### PR TITLE
fix pr-enforce-pr-labels workflow reference

### DIFF
--- a/.github/workflows/pr-enforce-pr-labels.yml
+++ b/.github/workflows/pr-enforce-pr-labels.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   labels:
-    uses: localstack/meta/.github/workflows/pr-enforce-labels.yml@notes-labels
+    uses: localstack/meta/.github/workflows/pr-enforce-labels.yml@main
     secrets:
       github-token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13189 a little bit of copy-pasta slipped through.
It still references the branch used when working on the workflow with https://github.com/localstack/meta/pull/31.
This PR fixes this reference.

## Changes
- Fix the reference to the notes label check workflow.

## Follow up
- Remove the `notes-labels` branch in the meta repository which was created temporarily to mitigate the workflow execution issues until this PR is merged.