### PR TITLE
Sns/v2 topic migration

### DIFF
--- a/localstack-core/localstack/services/sns/v2/models.py
+++ b/localstack-core/localstack/services/sns/v2/models.py
@@ -6,8 +6,10 @@ from localstack.aws.api.sns import TopicAttributesMap
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
+    CrossRegionAttribute,
     LocalAttribute,
 )
+from localstack.utils.tagging import TaggingService
 
 
 class TopicAttributes(TypedDict, total=False):
@@ -88,7 +90,7 @@ class Topic:
 class SnsStore(BaseStore):
     topics: dict[str, Topic] = LocalAttribute(default=dict)
 
-    # TAGS: TaggingService = CrossRegionAttribute()# TODO
+    TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)
 
 
 sns_stores = AccountRegionBundle("sns", SnsStore)

--- a/localstack-core/localstack/services/sns/v2/models.py
+++ b/localstack-core/localstack/services/sns/v2/models.py
@@ -35,21 +35,27 @@ class Topic:
         self.name = name
         self.arn = arn
         self.attributes = self.default_attributes()
-        self.attributes.update(attributes)
+        self.attributes.update(attributes or {})
 
     def default_attributes(self) -> TopicAttributesMap:
-        return {
-            "ContentBasedDeduplication": "false",
-            "DisplayName": self.name,
-            "FifoTopic": "false",
+        default_attributes = {
+            "DisplayName": "",
             "Owner": self.account_id,
             "Policy": self.create_default_topic_policy(),
-            "SignatureVersion": "2",
             "SubscriptionsConfirmed": "0",
             "SubscriptionsDeleted": "0",
             "SubscriptionsPending": "0",
             "TopicArn": self.arn,
         }
+        if self.name.endswith(".fifo"):
+            default_attributes.update(
+                {
+                    "ContentBasedDeduplication": "false",
+                    "FifoTopic": "false",
+                    "SignatureVersion": "2",
+                }
+            )
+        return default_attributes
 
     def create_default_topic_policy(self) -> str:  # Dict[str, Any]:
         return json.dumps(

--- a/localstack-core/localstack/services/sns/v2/models.py
+++ b/localstack-core/localstack/services/sns/v2/models.py
@@ -1,0 +1,88 @@
+import json
+from typing import Any, TypedDict
+
+from localstack.aws.api import RequestContext
+from localstack.aws.api.sns import TopicAttributesMap
+from localstack.services.stores import (
+    AccountRegionBundle,
+    BaseStore,
+    LocalAttribute,
+)
+
+
+class TopicAttributes(TypedDict, total=False):
+    contentBasedDeduplication: bool
+    displayName: str
+    fifoTopic: bool
+    owner: str
+    policy: dict[str, Any]
+    subscriptionsConfirmed: int
+    subscriptionsDeleted: int
+    subscriptionsPending: int
+    topicArn: str
+
+
+class Topic:
+    arn: str
+    name: str
+    region: str
+    account_id: str
+    attributes: dict[str, Any]
+
+    def __init__(self, name, arn, attributes: dict, context: RequestContext):
+        self.account_id = context.account_id
+        self.region = context.region
+        self.name = name
+        self.arn = arn
+        self.attributes = self.default_attributes()
+        self.attributes.update(attributes)
+
+    def default_attributes(self) -> TopicAttributesMap:
+        return {
+            "ContentBasedDeduplication": "false",
+            "DisplayName": self.name,
+            "FifoTopic": "false",
+            "Owner": self.account_id,
+            "Policy": self.create_default_topic_policy(),
+            "SignatureVersion": "2",
+            "SubscriptionsConfirmed": "0",
+            "SubscriptionsDeleted": "0",
+            "SubscriptionsPending": "0",
+            "TopicArn": self.arn,
+        }
+
+    def create_default_topic_policy(self) -> str:  # Dict[str, Any]:
+        return json.dumps(
+            {
+                "Version": "2008-10-17",
+                "Id": "__default_policy_ID",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Sid": "__default_statement_ID",
+                        "Principal": {"AWS": "*"},
+                        "Action": [
+                            "SNS:GetTopicAttributes",
+                            "SNS:SetTopicAttributes",
+                            "SNS:AddPermission",
+                            "SNS:RemovePermission",
+                            "SNS:DeleteTopic",
+                            "SNS:Subscribe",
+                            "SNS:ListSubscriptionsByTopic",
+                            "SNS:Publish",
+                        ],
+                        "Resource": self.arn,
+                        "Condition": {"StringEquals": {"AWS:SourceOwner": self.account_id}},
+                    }
+                ],
+            }
+        )
+
+
+class SnsStore(BaseStore):
+    topics: dict[str, Topic] = LocalAttribute(default=dict)
+
+    # TAGS: TaggingService = CrossRegionAttribute()# TODO
+
+
+sns_stores = AccountRegionBundle("sns", SnsStore)

--- a/localstack-core/localstack/services/sns/v2/models.py
+++ b/localstack-core/localstack/services/sns/v2/models.py
@@ -1,7 +1,5 @@
-import json
 from typing import TypedDict
 
-from localstack.aws.api import RequestContext
 from localstack.aws.api.sns import TopicAttributesMap
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -9,83 +7,13 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
-from localstack.utils.aws.arns import sns_topic_arn
 from localstack.utils.tagging import TaggingService
 
 
 class Topic(TypedDict, total=True):
     arn: str
     name: str
-    region: str
-    account_id: str
     attributes: TopicAttributesMap
-
-
-def create_topic(name: str, attributes: dict, context: RequestContext) -> Topic:
-    topic_arn = sns_topic_arn(
-        topic_name=name, region_name=context.region, account_id=context.account_id
-    )
-    topic: Topic = {
-        "name": name,
-        "arn": topic_arn,
-        "region": context.region,
-        "account_id": context.account_id,
-        "attributes": {},
-    }
-    attrs = default_attributes(topic)
-    attrs.update(attributes or {})
-    topic["attributes"] = attrs
-
-    return topic
-
-
-def default_attributes(topic: Topic) -> TopicAttributesMap:
-    default_attributes = {
-        "DisplayName": "",
-        "Owner": topic["account_id"],
-        "Policy": create_default_topic_policy(topic),
-        "SubscriptionsConfirmed": "0",
-        "SubscriptionsDeleted": "0",
-        "SubscriptionsPending": "0",
-        "TopicArn": topic["arn"],
-    }
-    if topic["name"].endswith(".fifo"):
-        default_attributes.update(
-            {
-                "ContentBasedDeduplication": "false",
-                "FifoTopic": "false",
-                "SignatureVersion": "2",
-            }
-        )
-    return default_attributes
-
-
-def create_default_topic_policy(topic: Topic) -> str:
-    return json.dumps(
-        {
-            "Version": "2008-10-17",
-            "Id": "__default_policy_ID",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Sid": "__default_statement_ID",
-                    "Principal": {"AWS": "*"},
-                    "Action": [
-                        "SNS:GetTopicAttributes",
-                        "SNS:SetTopicAttributes",
-                        "SNS:AddPermission",
-                        "SNS:RemovePermission",
-                        "SNS:DeleteTopic",
-                        "SNS:Subscribe",
-                        "SNS:ListSubscriptionsByTopic",
-                        "SNS:Publish",
-                    ],
-                    "Resource": topic["arn"],
-                    "Condition": {"StringEquals": {"AWS:SourceOwner": topic["account_id"]}},
-                }
-            ],
-        }
-    )
 
 
 class SnsStore(BaseStore):

--- a/localstack-core/localstack/services/sns/v2/provider.py
+++ b/localstack-core/localstack/services/sns/v2/provider.py
@@ -1,9 +1,140 @@
 import logging
+import re
 
-from localstack.aws.api.sns import SnsApi
+from botocore.utils import InvalidArnException
+
+from localstack.aws.api import RequestContext
+from localstack.aws.api.sns import (
+    CreateTopicResponse,
+    GetTopicAttributesResponse,
+    InvalidParameterException,
+    InvalidParameterValueException,
+    ListTopicsResponse,
+    NotFoundException,
+    SnsApi,
+    TagList,
+    TopicAttributesMap,
+    attributeValue,
+    nextToken,
+    topicARN,
+    topicName,
+)
+from localstack.services.sns.v2.models import SnsStore, Topic, sns_stores
+from localstack.utils.aws.arns import ArnData, parse_arn, sns_topic_arn
 
 # set up logger
 LOG = logging.getLogger(__name__)
 
+SNS_TOPIC_NAME_PATTERN_FIFO = r"^[a-zA-Z0-9_-]{1,256}\.fifo$"
+SNS_TOPIC_NAME_PATTERN = r"^[a-zA-Z0-9_-]{1,256}$"
 
-class SnsProvider(SnsApi): ...
+
+class SnsProvider(SnsApi):
+    def create_topic(
+        self,
+        context: RequestContext,
+        name: topicName,
+        attributes: TopicAttributesMap | None = None,
+        tags: TagList | None = None,
+        data_protection_policy: attributeValue | None = None,
+        **kwargs,
+    ) -> CreateTopicResponse:
+        store = self.get_store(context.account_id, context.region)
+
+        topicARN = sns_topic_arn(
+            topic_name=name, region_name=context.region, account_id=context.account_id
+        )
+        topic = Topic(name=name, attributes=attributes, arn=topicARN, context=context)
+
+        if attributes is None:
+            attributes = {}
+        if attributes.get("FifoTopic") and attributes["FifoTopic"].lower() == "true":
+            fifo_match = re.match(SNS_TOPIC_NAME_PATTERN_FIFO, name)
+            if not fifo_match:
+                raise InvalidParameterValueException(
+                    "Fifo Topic names must end with .fifo and must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long."
+                )
+        else:
+            name_match = re.match(SNS_TOPIC_NAME_PATTERN, name)
+            if not name_match:
+                raise InvalidParameterValueException(
+                    "Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long."
+                )
+
+        # if attributes:
+        # self.set_topic_defaults(topic, context)
+        # topic["attributes"] = attributes
+        store.topics[topicARN] = topic
+        # todo: tags
+
+        return CreateTopicResponse(TopicArn=topicARN)
+
+    def get_topic_attributes(
+        self, context: RequestContext, topic_arn: topicARN, **kwargs
+    ) -> GetTopicAttributesResponse:
+        topic: Topic = self._get_topic(arn=topic_arn, context=context)
+        if topic:
+            attributes = topic.attributes
+            return GetTopicAttributesResponse(Attributes=attributes)
+        else:
+            raise NotFoundException("Topic does not exist")
+
+    def delete_topic(self, context: RequestContext, topic_arn: topicARN, **kwargs) -> None:
+        store = self.get_store(context.account_id, context.region)
+
+        if store.topics.get(topic_arn):
+            del store.topics[topic_arn]
+
+    def list_topics(
+        self, context: RequestContext, next_token: nextToken | None = None, **kwargs
+    ) -> ListTopicsResponse:
+        store = self.get_store(context.account_id, context.region)
+
+        return ListTopicsResponse(Topics=[t.arn for t in store.topics.values()])
+
+    @staticmethod
+    def set_topic_defaults(topic: Topic, context: RequestContext):
+        attributes = {}
+        attributes["FifoTopic"] = False
+        attributes["ContentBasedDeduplication"] = False
+        attributes["Owner"] = context.account_id
+        attributes["Resource"] = topic["arn"]
+        attributes["SubscriptionsConfirmed"] = 0
+        attributes["SubscriptionsDeleted"] = 0
+
+        attributes.update(topic["attributes"])
+
+        topic["attributes"] = attributes
+
+    @staticmethod
+    def get_store(account_id: str, region: str) -> SnsStore:
+        return sns_stores[account_id][region]
+
+    @staticmethod
+    def _get_topic(arn: str, context: RequestContext) -> Topic:
+        """
+        :param arn: the Topic ARN
+        :param context: the RequestContext of the request
+        :param multiregion: if the request can fetch the topic across regions or not (ex. Publish cannot publish to a
+        topic in a different region than the request)
+        :return: the Moto model Topic
+        """
+        arn_data = parse_and_validate_topic_arn(arn)
+        if context.region != arn_data["region"]:
+            raise InvalidParameterException("Invalid parameter: TopicArn")
+        try:
+            store = SnsProvider.get_store(context.account_id, context.region)
+            return store.topics[arn]
+        except KeyError:
+            raise NotFoundException("Topic does not exist")
+
+
+def parse_and_validate_topic_arn(topic_arn: str | None) -> ArnData:
+    topic_arn = topic_arn or ""
+    try:
+        return parse_arn(topic_arn)
+    except InvalidArnException:
+        count = len(topic_arn.split(":"))
+        raise InvalidParameterException(
+            f"Invalid parameter: TopicArn Reason: An ARN must have at least 6 elements, not {count}"
+        )

--- a/localstack-core/localstack/services/sns/v2/provider.py
+++ b/localstack-core/localstack/services/sns/v2/provider.py
@@ -60,6 +60,7 @@ class SnsProvider(SnsApi):
         if attributes.get("FifoTopic") and attributes["FifoTopic"].lower() == "true":
             fifo_match = re.match(SNS_TOPIC_NAME_PATTERN_FIFO, name)
             if not fifo_match:
+                # TODO: check this with a separate test
                 raise InvalidParameterException(
                     "Fifo Topic names must end with .fifo and must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long."
                 )

--- a/tests/aws/services/sns/conftest.py
+++ b/tests/aws/services/sns/conftest.py
@@ -24,6 +24,10 @@ def is_sns_v2_provider():
     return os.environ.get("PROVIDER_OVERRIDE_SNS") == "v2" and not is_aws_cloud()
 
 
+def is_sns_v1_provider():
+    return not os.environ.get("PROVIDER_OVERRIDE_SNS") == "v2" and not is_aws_cloud()
+
+
 skip_if_sns_v2 = pytest.mark.skipif(
     is_sns_v2_provider(),
     reason="Skipping test for v2 provider as it contains operations not yet supported",

--- a/tests/aws/services/sns/conftest.py
+++ b/tests/aws/services/sns/conftest.py
@@ -24,7 +24,7 @@ def is_sns_v2_provider():
     return os.environ.get("PROVIDER_OVERRIDE_SNS") == "v2" and not is_aws_cloud()
 
 
-def is_sns_v1_provider():
+def is_sns_v1_provider() -> bool:
     return not os.environ.get("PROVIDER_OVERRIDE_SNS") == "v2" and not is_aws_cloud()
 
 

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -192,7 +192,6 @@ class TestSNSTopicCrud:
         snapshot.match("topic-not-exists", e.value.response)
 
     @markers.aws.validated
-    @skip_if_sns_v2
     def test_delete_topic_idempotency(self, sns_create_topic, aws_client, snapshot):
         topic_arn = sns_create_topic()["TopicArn"]
 

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -93,12 +93,12 @@ class TestSNSTopicCrud:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$.get-topic-attrs.Attributes.DeliveryPolicy",
+            # "$.get-topic-attrs.Attributes.DeliveryPolicy",
             "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
-            "$.get-topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
+            # "$.get-topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
         ]
     )
-    @skip_if_sns_v2
+    # @skip_if_sns_v2
     def test_create_topic_with_attributes(self, sns_create_topic, snapshot, aws_client):
         create_topic = sns_create_topic(
             Name="topictest.fifo",

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -93,12 +93,10 @@ class TestSNSTopicCrud:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            # "$.get-topic-attrs.Attributes.DeliveryPolicy",
+            "$.get-topic-attrs.Attributes.DeliveryPolicy",  # TODO: remove this with the v2 provider switch
             "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
-            # "$.get-topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
         ]
     )
-    # @skip_if_sns_v2
     def test_create_topic_with_attributes(self, sns_create_topic, snapshot, aws_client):
         create_topic = sns_create_topic(
             Name="topictest.fifo",
@@ -166,13 +164,10 @@ class TestSNSTopicCrud:
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[
-            "$.get-topic-attrs.Attributes.DeliveryPolicy",
+            "$.get-topic-attrs.Attributes.DeliveryPolicy",  # TODO: remove this with the v2 provider switch
             "$.get-topic-attrs.Attributes.EffectiveDeliveryPolicy",
-            "$.get-topic-attrs.Attributes.Policy.Statement..Action",
-            # SNS:Receive is added by moto but not returned in AWS
         ]
     )
-    @skip_if_sns_v2
     def test_create_topic_test_arn(self, sns_create_topic, snapshot, aws_client, account_id):
         topic_name = "topic-test-create"
         response = sns_create_topic(Name=topic_name)

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5401,5 +5401,350 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_name_constraints": {
+    "recorded-date": "29-09-2025, 10:46:44",
+    "recorded-content": {
+      "valid-name-max-length": {
+        "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "name-too-short": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-too-long": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-:": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-;": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-!": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-@": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-|": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-^": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char-%": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-invalid-char- ": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_topic_get_attributes_with_fifo_false": {
+    "recorded-date": "29-09-2025, 11:10:41",
+    "recorded-content": {
+      "get-attrs-standard-topic": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "set-fifo-false-after-creation": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: AttributeName",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_in_multiple_regions": {
+    "recorded-date": "29-09-2025, 11:34:38",
+    "recorded-content": {
+      "list-east": {
+        "Topics": [
+          {
+            "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-west": {
+        "Topics": [
+          {
+            "TopicArn": "arn:<partition>:sns:us-west-1:111111111111:<resource:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "topic-east": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "topic-west": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:<partition>:sns:us-west-1:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:<partition>:sns:us-west-1:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -146,7 +146,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_test_arn": {
-    "recorded-date": "24-08-2023, 22:30:45",
+    "recorded-date": "29-09-2025, 09:32:56",
     "recorded-content": {
       "create-topic": {
         "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5265,5 +5265,141 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_delete_non_existent_topic": {
+    "recorded-date": "29-09-2025, 10:10:56",
+    "recorded-content": {
+      "delete-non-existent-topic": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_should_be_idempotent": {
+    "recorded-date": "29-09-2025, 10:23:24",
+    "recorded-content": {
+      "topic-attrs-idempotent-1": {
+        "Attributes": {
+          "DisplayName": "AlreadySet",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "topic-attrs-idempotent-2": {
+        "Attributes": {
+          "DisplayName": "AlreadySet",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5208,7 +5208,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_delete_topic_idempotency": {
-    "recorded-date": "28-05-2025, 10:08:38",
+    "recorded-date": "29-09-2025, 09:46:20",
     "recorded-content": {
       "delete-topic": {
         "ResponseMetadata": {

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -273,7 +273,13 @@
     "last_validated_date": "2023-08-24T20:30:48+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_test_arn": {
-    "last_validated_date": "2023-08-24T20:30:45+00:00"
+    "last_validated_date": "2025-09-29T09:32:56+00:00",
+    "durations_in_seconds": {
+      "setup": 1.07,
+      "call": 2.33,
+      "teardown": 0.2,
+      "total": 3.6
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_with_attributes": {
     "last_validated_date": "2025-09-25T07:41:34+00:00",

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -305,6 +305,24 @@
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_topic_delivery_policy_crud": {
     "last_validated_date": "2024-10-03T21:46:17+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_in_multiple_regions": {
+    "last_validated_date": "2025-09-29T11:34:38+00:00",
+    "durations_in_seconds": {
+      "setup": 1.06,
+      "call": 3.66,
+      "teardown": 0.01,
+      "total": 4.73
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_name_constraints": {
+    "last_validated_date": "2025-09-29T10:46:44+00:00",
+    "durations_in_seconds": {
+      "setup": 1.38,
+      "call": 4.19,
+      "teardown": 0.31,
+      "total": 5.88
+    }
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_should_be_idempotent": {
     "last_validated_date": "2025-09-29T10:40:50+00:00",
     "durations_in_seconds": {
@@ -321,6 +339,24 @@
       "call": 1.4,
       "teardown": 0.02,
       "total": 2.58
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_list_topic_paging": {
+    "last_validated_date": "2025-09-29T11:39:42+00:00",
+    "durations_in_seconds": {
+      "setup": 1.14,
+      "call": 38.91,
+      "teardown": 37.48,
+      "total": 77.53
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_topic_get_attributes_with_fifo_false": {
+    "last_validated_date": "2025-09-29T11:10:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.94,
+      "call": 1.77,
+      "teardown": 0.31,
+      "total": 3.02
     }
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -291,7 +291,13 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_delete_topic_idempotency": {
-    "last_validated_date": "2025-05-28T10:08:38+00:00"
+    "last_validated_date": "2025-09-29T09:46:20+00:00",
+    "durations_in_seconds": {
+      "setup": 0.95,
+      "call": 1.72,
+      "teardown": 0.15,
+      "total": 2.82
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_tags": {
     "last_validated_date": "2023-08-24T20:30:44+00:00"

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -276,7 +276,13 @@
     "last_validated_date": "2023-08-24T20:30:45+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_create_topic_with_attributes": {
-    "last_validated_date": "2023-10-06T18:11:02+00:00"
+    "last_validated_date": "2025-09-25T07:41:34+00:00",
+    "durations_in_seconds": {
+      "setup": 0.87,
+      "call": 2.31,
+      "teardown": 0.3,
+      "total": 3.48
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_delete_topic_idempotency": {
     "last_validated_date": "2025-05-28T10:08:38+00:00"

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -304,5 +304,23 @@
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrud::test_topic_delivery_policy_crud": {
     "last_validated_date": "2024-10-03T21:46:17+00:00"
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_should_be_idempotent": {
+    "last_validated_date": "2025-09-29T10:40:50+00:00",
+    "durations_in_seconds": {
+      "setup": 1.14,
+      "call": 1.89,
+      "teardown": 0.47,
+      "total": 3.5
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_delete_non_existent_topic": {
+    "last_validated_date": "2025-09-29T10:10:56+00:00",
+    "durations_in_seconds": {
+      "setup": 1.16,
+      "call": 1.4,
+      "teardown": 0.02,
+      "total": 2.58
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
First step of internalization of the SNS provider by migrating topics. This PR addresses both topics and topic attributes since they are intertwined

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add create_topic, list_topics, delete_topics, get_topic_attributes, set_topic_attributes
- activates all applicable tests in TestSnsTopicCrud
- adds new class TestSnsTopicCrudV2 for tests that were covered in moto
  - The tests were only used as reference to "what is tested", the tests themselves were written from scratch

closes PNX-83, closes PNX-79
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
