### PR TITLE
APIGW: fix TestInvokeMethod 500 failures

### DIFF
--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/integrations/http.py
@@ -8,7 +8,7 @@ from werkzeug.datastructures import Headers
 from localstack.aws.api.apigateway import Integration
 
 from ..context import EndpointResponse, IntegrationRequest, RestApiInvocationContext
-from ..gateway_response import ApiConfigurationError, IntegrationFailureError
+from ..gateway_response import ApiConfigurationError, IntegrationFailureError, InternalServerError
 from ..header_utils import build_multi_value_headers
 from .core import RestApiIntegration
 
@@ -72,7 +72,7 @@ class RestApiHttpIntegration(BaseRestApiHttpIntegration):
         except (requests.exceptions.InvalidURL, requests.exceptions.InvalidSchema) as e:
             LOG.warning("Execution failed due to configuration error: Invalid endpoint address")
             LOG.debug("The URI specified for the HTTP/HTTP_PROXY integration is invalid: %s", uri)
-            raise ApiConfigurationError("Internal server error") from e
+            raise InternalServerError("Internal server error") from e
 
         except (requests.exceptions.Timeout, requests.exceptions.SSLError) as e:
             # TODO make the exception catching more fine grained
@@ -127,7 +127,7 @@ class RestApiHttpProxyIntegration(BaseRestApiHttpIntegration):
         except (requests.exceptions.InvalidURL, requests.exceptions.InvalidSchema) as e:
             LOG.warning("Execution failed due to configuration error: Invalid endpoint address")
             LOG.debug("The URI specified for the HTTP/HTTP_PROXY integration is invalid: %s", uri)
-            raise ApiConfigurationError("Internal server error") from e
+            raise InternalServerError("Internal server error") from e
 
         except (requests.exceptions.Timeout, requests.exceptions.SSLError):
             # TODO make the exception catching more fine grained

--- a/localstack-core/localstack/services/apigateway/next_gen/provider.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/provider.py
@@ -429,6 +429,11 @@ class ApigatewayNextGenProvider(ApigatewayProvider):
         if not resource:
             raise NotFoundException("Invalid Resource identifier specified")
 
+        resource_methods = resource.resource_methods
+
+        if request["httpMethod"] not in resource_methods and "ANY" not in resource_methods:
+            raise NotFoundException("Invalid Method identifier specified")
+
         # test httpMethod
 
         rest_api_container = get_rest_api_container(context, rest_api_id=rest_api_id)

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -2813,7 +2813,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
-    "recorded-date": "19-08-2025, 17:20:41",
+    "recorded-date": "29-09-2025, 19:28:50",
     "recorded-content": {
       "test-invoke-method-get-pets": {
         "body": {
@@ -3044,6 +3044,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "resource-method-not-found": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       },
       "resource-id-not-found": {
@@ -4858,6 +4869,42 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_failed_invoke_test_method": {
+    "recorded-date": "29-09-2025, 19:44:14",
+    "recorded-content": {
+      "test-invoke-failure": {
+        "body": {
+          "message": "Internal server error"
+        },
+        "headers": {
+          "x-amzn-ErrorType": "InternalServerErrorException"
+        },
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-1>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-1>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Execution failed due to configuration error: Invalid endpoint address",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 500",
+          "line09": ""
+        },
+        "multiValueHeaders": {
+          "x-amzn-ErrorType": [
+            "InternalServerErrorException"
+          ]
+        },
+        "status": 500,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -389,13 +389,22 @@
       "total": 3.98
     }
   },
-  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
-    "last_validated_date": "2025-08-19T17:20:41+00:00",
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_failed_invoke_test_method": {
+    "last_validated_date": "2025-09-29T19:44:14+00:00",
     "durations_in_seconds": {
-      "setup": 0.83,
-      "call": 4.12,
+      "setup": 0.81,
+      "call": 1.14,
       "teardown": 0.67,
-      "total": 5.62
+      "total": 2.62
+    }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayTestInvoke::test_invoke_test_method": {
+    "last_validated_date": "2025-09-29T19:28:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.86,
+      "call": 4.31,
+      "teardown": 0.67,
+      "total": 5.84
     }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.py
+++ b/tests/aws/services/apigateway/test_apigateway_import.py
@@ -802,15 +802,14 @@ class TestApiGatewayImportRestApi:
 
             url_error = api_invoke_url(api_id=rest_api_id, stage="v2", path="/path1")
 
-            def call_api_error():
+            def call_api_error() -> requests.Response:
                 res = requests.get(url_error)
                 assert res.status_code == 500
-                return res.json()
+                return res
 
             resp = retry(call_api_error, retries=5, sleep=2)
-            # we remove the headers from the response, not really needed for this test
-            resp.pop("headers", None)
-            snapshot.match("get-error-resp-from-http", resp)
+            error = {"body": resp.json(), "errorType": resp.headers.get("x-amzn-ErrorType")}
+            snapshot.match("get-error-resp-from-http", error)
 
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -4823,7 +4823,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
-    "recorded-date": "02-07-2025, 16:31:50",
+    "recorded-date": "29-09-2025, 20:07:21",
     "recorded-content": {
       "get-resp-from-http": {
         "args": {
@@ -4836,7 +4836,10 @@
         "path": "/test-path"
       },
       "get-error-resp-from-http": {
-        "message": "Internal server error"
+        "body": {
+          "message": "Internal server error"
+        },
+        "errorType": "InternalServerErrorException"
       }
     }
   },

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -144,12 +144,12 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_with_stage_variables": {
-    "last_validated_date": "2025-07-02T16:31:50+00:00",
+    "last_validated_date": "2025-09-29T20:07:21+00:00",
     "durations_in_seconds": {
-      "setup": 0.11,
-      "call": 5.83,
-      "teardown": 69.73,
-      "total": 75.67
+      "setup": 11.64,
+      "call": 11.14,
+      "teardown": 2.26,
+      "total": 25.04
     }
   },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_put_rest_api_mode_binary_media_types[merge]": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As part of our weekly report, I've spotted 2 issues with APIGW `TestInvokeMethod`:

```python
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/services/apigateway/next_gen/execute_api/test_invoke.py", line 263, in run_test_invocation
    log = log_template(invocation_context, response_headers)
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/services/apigateway/next_gen/execute_api/test_invoke.py", line 104, in log_template
    endpoint_response_status_code=endpoint_resp.get("status_code"),
                                  ^^^^^^^^^^^^^^^^^
localstack.aws.api.core.CommonServiceException: exception while calling apigateway.TestInvokeMethod: 'NoneType' object has no attribute 'get'
```
and this one:
```python
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/services/apigateway/next_gen/execute_api/test_invoke.py", line 234, in run_test_invocation
    invocation_context = create_test_invocation_context(test_request, deployment)
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/services/apigateway/next_gen/execute_api/test_invoke.py", line 219, in create_test_invocation_context
    resource_method = resource["resourceMethods"][http_method]
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
localstack.aws.api.core.CommonServiceException: exception while calling apigateway.TestInvokeMethod: 'POST'
```

The first one is because we probably didn't handle failed invocation, and always expected every failed to be present. We need to guard against None-values when calling `.get()`, and improve it all together. The solution is not bullet proof, because to have perfect logging, we need to store the log as we progress in the invocation to be able to "stop" at the right moment, where the exception happens.

The second one is because we did not handle the `ANY` values properly, and also did not handle failures when the method would not exist. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add new tests to cover the exceptions raised
- improve exception handling in the `TestInvokeMethod` and add some fallbacks
- sneaked a small fix with the kind of exception raised which was shown in the failing test
- add better validation of existing methods 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
