### PR TITLE
Upgrade dynamodb local to version 3.1

### DIFF
--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -17,6 +17,7 @@ from localstack.utils.run import run
 DDB_AGENT_JAR_URL = f"{ARTIFACTS_REPO}/raw/e4e8c8e294b1fcda90c678ff6af5d5ebe1f091eb/dynamodb-local-patch/target/ddb-local-loader-0.2.jar"
 JAVASSIST_JAR_URL = f"{MAVEN_REPO_URL}/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar"
 
+# URL points to 2.x here - however the latest 3.x builds are available under this URL
 DDBLOCAL_URL = "https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_latest.zip"
 
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR upgrades dynamodb local to version 3.1.
This version includes several performance improvements.

Please note that the PR seems counter intuitive, but the latest dynamodb local release is available under the `/2.x/` path, not the `/3.x/` path. The path was changed in #12879, however it seems AWS is continuing to release the new versions under the 2.x path.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Improved performance for PartiQl queries.
* Reduced detected CVEs.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
