### PR TITLE
fix(kinesis): Add account and region context when using connect_to

### DIFF
--- a/localstack-core/localstack/services/kinesis/provider.py
+++ b/localstack-core/localstack/services/kinesis/provider.py
@@ -110,7 +110,9 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
         if not is_valid_kinesis_arn(resource_arn):
             raise ValidationException(f"invalid kinesis arn {resource_arn}")
 
-        kinesis = connect_to().kinesis
+        kinesis = connect_to(
+            aws_access_key_id=context.account_id, region_name=context.region
+        ).kinesis
         try:
             kinesis.describe_stream_summary(StreamARN=resource_arn)
         except kinesis.exceptions.ResourceNotFoundException:
@@ -128,7 +130,9 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
         if not is_valid_kinesis_arn(resource_arn):
             raise ValidationException(f"invalid kinesis arn {resource_arn}")
 
-        kinesis = connect_to().kinesis
+        kinesis = connect_to(
+            aws_access_key_id=context.account_id, region_name=context.region
+        ).kinesis
         try:
             kinesis.describe_stream_summary(StreamARN=resource_arn)
         except kinesis.exceptions.ResourceNotFoundException:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
In order to target the correct kinesis mock server, we need to pass the account ID and region name from the request context.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Pass the `account_id` and `region_name` from the request context when creating a kinesis client using `connect_to(...)` 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
