### PR TITLE
Cfn: Fix backslash processing for dynamic replacement values

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -441,7 +441,11 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
                 region_name=self._change_set.region_name,
             )
             if new_value:
-                return REGEX_DYNAMIC_REF.sub(new_value, value)
+                # We need to use a function here, to avoid backslash processing by regex.
+                # From the regex sub documentation:
+                # repl can be a string or a function; if it is a string, any backslash escapes in it are processed.
+                # Using a function, we can avoid this processing.
+                return REGEX_DYNAMIC_REF.sub(lambda _: new_value, value)
 
         return value
 

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -236,7 +236,7 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
         issue_url = "?".join([base, urlencode(query_args)])
         LOG.info(
             "You have opted in to the new CloudFormation deployment engine. "
-            "You can opt in to using the old engine by setting PROVIDER_OVERRIDE_CLOUDFORMATION=legacy. "
+            "You can opt in to using the old engine by setting PROVIDER_OVERRIDE_CLOUDFORMATION=engine-legacy. "
             "If you experience issues, please submit a bug report at this URL: %s",
             issue_url,
         )

--- a/tests/aws/services/cloudformation/test_template_engine.py
+++ b/tests/aws/services/cloudformation/test_template_engine.py
@@ -531,6 +531,23 @@ class TestSecretsManagerParameters:
         topic_name = result.outputs["TopicName"]
         assert topic_name == parameter_value
 
+    @markers.aws.validated
+    def test_resolve_secretsmanager_with_backslashes(self, create_secret, deploy_cfn_template):
+        parameter_key = f"param-key-{short_uid()}"
+        secret_value = json.dumps({"password": r"p\\30\asw\\\ord"})
+
+        create_secret(Name=parameter_key, SecretString=secret_value)
+
+        result = deploy_cfn_template(
+            parameters={"DynamicParameter": parameter_key},
+            template_path=os.path.join(
+                os.path.dirname(__file__),
+                "../../templates/resolve_secretsmanager_with_backslashes.yaml",
+            ),
+        )
+
+        assert secret_value == result.outputs["ParameterValue"]
+
 
 class TestPreviousValues:
     @pytest.mark.skip(reason="outputs don't behave well in combination with conditions")

--- a/tests/aws/services/cloudformation/test_template_engine.validation.json
+++ b/tests/aws/services/cloudformation/test_template_engine.validation.json
@@ -98,6 +98,15 @@
   "tests/aws/services/cloudformation/test_template_engine.py::TestPseudoParameters::test_stack_id": {
     "last_validated_date": "2024-07-18T08:56:47+00:00"
   },
+  "tests/aws/services/cloudformation/test_template_engine.py::TestSecretsManagerParameters::test_resolve_secretsmanager_with_backslashes": {
+    "last_validated_date": "2025-09-30T15:36:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 11.22,
+      "teardown": 4.49,
+      "total": 15.72
+    }
+  },
   "tests/aws/services/cloudformation/test_template_engine.py::TestSsmParameters::test_create_change_set_with_ssm_parameter_list": {
     "last_validated_date": "2024-08-08T21:21:23+00:00"
   },

--- a/tests/aws/templates/resolve_secretsmanager_with_backslashes.yaml
+++ b/tests/aws/templates/resolve_secretsmanager_with_backslashes.yaml
@@ -1,0 +1,24 @@
+Parameters:
+  DynamicParameter:
+    Type: String
+
+Resources:
+  MyParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value:
+        Fn::Join:
+          - ""
+          - - "{{resolve:secretsmanager:arn:"
+            - Ref: AWS::Partition
+            - ":secretsmanager:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":secret:"
+            - Ref: DynamicParameter
+            -  ":SecretString:::}}"
+Outputs:
+  ParameterValue:
+    Value: !GetAtt MyParameter.Value


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
When dynamic references (like `{{resolve:secretsmanager:secret-id:secret-string:json-key::}}`) return backslashes, they are currently not handled correctly. Mainly, they are interpreted by `re.sub`, and used to escape characters (or reference sections of the regex match).

The [python documentation](https://docs.python.org/3/library/re.html#re.sub) says this about this topic:

> repl can be a string or a function; if it is a string, any backslash escapes in it are processed. That is, \n is converted to a single newline character, \r is converted to a carriage return, and so forth. Unknown escapes of ASCII letters are reserved for future use and treated as errors. Other unknown escapes such as \& are left alone. Backreferences, such as \6, are replaced with the substring matched by group 6 in the pattern.

This leads to issues if the secret contains one or multiple backslashes, leading either to escape errors (`bad escape \<something> at position <something>` or changed values (`\\` -> `\`, `\&` -> `&`).

This can lead to significant, but hard to debug issues.

The change replaces the string with a function returning a string, as the backslashes are not processed:

> If repl is a function, it is called for every non-overlapping occurrence of pattern. The function takes a single Match argument, and returns the replacement string.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* dynamic references referencing secrets or parameters with backslashes should now work correctly.
* Added test
* The information for the new cloudformation engine contained an invalid provider name (`legacy` instead of `engine-legacy`).

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
