### PR TITLE
CFN: add validation in GetAtt for conditionally canceled resources

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -568,6 +568,21 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             resource_name=logical_name_of_resource,
             node_template=self._change_set.update_model.node_template,
         )
+
+        if not is_nothing(node_resource.condition_reference):
+            condition = self._get_node_condition_if_exists(node_resource.condition_reference.value)
+            evaluation_result = self._resolve_condition(condition.name)
+
+            if select_before and not evaluation_result.before:
+                raise ValidationError(
+                    f"Template format error: Unresolved resource dependencies [{logical_name_of_resource}] in the Resources block of the template"
+                )
+
+            if not select_before and not evaluation_result.after:
+                raise ValidationError(
+                    f"Template format error: Unresolved resource dependencies [{logical_name_of_resource}] in the Resources block of the template"
+                )
+
         node_property: NodeProperty | None = self._get_node_property_for(
             property_name=attribute_name, node_resource=node_resource
         )

--- a/tests/aws/services/cloudformation/engine/test_conditions.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_conditions.snapshot.json
@@ -759,5 +759,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_dependent_get_att": {
+    "recorded-date": "30-09-2025, 19:25:10",
+    "recorded-content": {
+      "dependent_ref_exc": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: Unresolved resource dependencies [MyTopic] in the Resources block of the template",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_conditions.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_conditions.validation.json
@@ -1,6 +1,21 @@
 {
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_dependent_get_att": {
+    "last_validated_date": "2025-09-30T19:25:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.23,
+      "call": 0.36,
+      "teardown": 0.0,
+      "total": 0.59
+    }
+  },
   "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_dependent_ref": {
-    "last_validated_date": "2023-06-26T12:18:26+00:00"
+    "last_validated_date": "2025-09-30T19:03:49+00:00",
+    "durations_in_seconds": {
+      "setup": 0.27,
+      "call": 0.34,
+      "teardown": 0.0,
+      "total": 0.61
+    }
   },
   "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_nested_conditions[prod-bucket-policy]": {
     "last_validated_date": "2023-06-26T12:24:03+00:00"

--- a/tests/aws/templates/conditions/get-att-condition.yml
+++ b/tests/aws/templates/conditions/get-att-condition.yml
@@ -1,0 +1,28 @@
+Parameters:
+  TopicName:
+    Type: String
+  SsmParamName:
+    Type: String
+  OptionParameter:
+    Type: String
+    AllowedValues:
+      - option-a
+      - option-b
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic
+    Condition: ShouldCreateTopic
+    Properties:
+      TopicName: !Ref TopicName
+
+  MySsmParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Name: !Ref SsmParamName
+      Value: !GetAtt MyTopic.TopicName
+
+Conditions:
+  ShouldCreateTopic: !Equals
+    - !Ref OptionParameter
+    - option-a


### PR DESCRIPTION
 ## Motivation
This PR adds a validation that the resource should be deployed when retrieving attributes with Fn::GetAtt


## Changes
- Validate if there is a condition preventing the deployment of a resource before attempting to retrieve an attribute.

## Testing
- AWS validated test.