### PR TITLE
Fix visibility check in _pre_delete_checks to use is_visible attribute

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -1053,7 +1053,7 @@ class FifoQueue(SqsQueue):
             message.delay_seconds = value
 
     def _pre_delete_checks(self, message: SqsMessage, receipt_handle: str) -> None:
-        if not message.is_visible:
+        if message.is_visible:
             raise InvalidParameterValueException(
                 f"Value {receipt_handle} for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired."
             )

--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -1053,8 +1053,7 @@ class FifoQueue(SqsQueue):
             message.delay_seconds = value
 
     def _pre_delete_checks(self, message: SqsMessage, receipt_handle: str) -> None:
-        _, _, _, last_received = extract_receipt_handle_info(receipt_handle)
-        if time.time() - float(last_received) > message.visibility_timeout:
+        if not message.is_visible:
             raise InvalidParameterValueException(
                 f"Value {receipt_handle} for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired."
             )

--- a/tests/aws/services/sqs/test_sqs.snapshot.json
+++ b/tests/aws/services/sqs/test_sqs.snapshot.json
@@ -4219,5 +4219,55 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_approximate_number_of_messages_not_visible[sqs_query]": {
     "recorded-date": "25-09-2025, 21:54:43",
     "recorded-content": {}
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout_extended[sqs]": {
+    "recorded-date": "05-10-2025, 14:42:35",
+    "recorded-content": {
+      "received_sqs_message": {
+        "Messages": [
+          {
+            "Body": "foobar",
+            "MD5OfBody": "3858f62230ac3c915f300c664312c63f",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_after_timeout_fifo_extended": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout_extended[sqs_query]": {
+    "recorded-date": "05-10-2025, 14:42:37",
+    "recorded-content": {
+      "received_sqs_message": {
+        "Messages": [
+          {
+            "Body": "foobar",
+            "MD5OfBody": "3858f62230ac3c915f300c664312c63f",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_after_timeout_fifo_extended": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sqs/test_sqs.validation.json
+++ b/tests/aws/services/sqs/test_sqs.validation.json
@@ -248,6 +248,24 @@
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout[sqs_query]": {
     "last_validated_date": "2025-03-28T13:37:13+00:00"
   },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout_extended[sqs]": {
+    "last_validated_date": "2025-10-05T14:42:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.23,
+      "call": 2.01,
+      "teardown": 0.09,
+      "total": 2.33
+    }
+  },
+  "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_delete_after_visibility_timeout_extended[sqs_query]": {
+    "last_validated_date": "2025-10-05T14:42:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.0,
+      "teardown": 0.1,
+      "total": 2.1
+    }
+  },
   "tests/aws/services/sqs/test_sqs.py::TestSqsProvider::test_fifo_empty_message_groups_added_back_to_queue[sqs]": {
     "last_validated_date": "2024-04-30T13:46:32+00:00"
   },


### PR DESCRIPTION
## Motivation
Fix issue https://github.com/localstack/localstack/issues/12954

This pull request updates the logic for validating SQS message receipt handles before deletion. The main change is to use the `is_visible` property of the message instead of calculating expiration based on the last received timestamp and visibility timeout.

## Changes
* Updated the `_pre_delete_checks` method in `localstack-core/localstack/services/sqs/models.py` to check the `is_visible` property of a message when validating receipt handles, rather than computing expiration from the last received time and visibility timeout. This simplifies and potentially improves the accuracy of message deletion checks.

## Testing
* Added `test_fifo_delete_after_visibility_timeout_extended`
* Validated `SNAPSHOT_UPDATE=1 TEST_TARGET=AWS_CLOUD TEST_PATH="tests/aws/services/sqs" make test`
* Validated `TEST_PATH="tests/aws/services/sqs" make test`
