### PR TITLE
dependabot: update labels and cleanup config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,11 @@ updates:
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "eclipse-temurin"
-        update-types: ["version-update:semver-major"]
     labels:
       - "area: dependencies"
       - "semver: patch"
-      - "skip-docs"
+      - "docs: skip"
+      - "notes: skip"
     groups:
       docker-base-images:
         patterns:
@@ -24,7 +23,8 @@ updates:
     labels:
       - "area: dependencies"
       - "semver: patch"
-      - "skip-docs"
+      - "docs: skip"
+      - "notes: skip"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13189 we switched to new labels for release notes and documentation.
This PR fixes the config for Dependabot by setting the new labels, and removes some config which we do not need anymore (we do not use the Docker image of Eclipse Temurin anymore, so no need to configure the update).

## Changes
- Set the proper `notes` and `docs` labels.
- Remove obsolete config for the Eclipse Temurin Docker image.