### PR TITLE
Skip test test_cfn_apigateway_swagger_import when running in K8s

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_apigateway.py
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.py
@@ -111,6 +111,7 @@ def test_cfn_apigateway_aws_integration(deploy_cfn_template, aws_client):
     assert mappings[0] == "(none)"
 
 
+@markers.requires_in_process  # uses pytest httpserver
 @markers.aws.validated
 @markers.snapshot.skip_snapshot_verify(
     paths=[


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fix failing tests from https://github.com/localstack/localstack-pro/pull/5371

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Adds a marker in `test_cfn_apigateway_swagger_import` as it uses pytest http marker

<!-- Properly ignore SSL validation error in `test_domain_lifecycle` (there is already a comment about this) -->

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
