### PR TITLE
Correct casing for x-amzn-RequestId header

### DIFF
--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -1504,7 +1504,7 @@ class JSONResponseSerializer(QueryCompatibleProtocolMixin, ResponseSerializer):
     def _prepare_additional_traits_in_response(
         self, response: Response, operation_model: OperationModel, request_id: str
     ):
-        response.headers["x-amzn-RequestId"] = request_id
+        response.headers.setdefault("x-amzn-RequestId", request_id)
         response = super()._prepare_additional_traits_in_response(
             response, operation_model, request_id
         )

--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -1228,6 +1228,15 @@ class QueryResponseSerializer(BaseXMLResponseSerializer):
         request_id_element = ETree.SubElement(response_metadata, "RequestId")
         request_id_element.text = request_id
 
+    def _prepare_additional_traits_in_response(
+        self, response: Response, operation_model: OperationModel, request_id: str
+    ):
+        response.headers["x-amzn-RequestId"] = request_id
+        response = super()._prepare_additional_traits_in_response(
+            response, operation_model, request_id
+        )
+        return response
+
 
 class EC2ResponseSerializer(QueryResponseSerializer):
     """
@@ -1495,7 +1504,7 @@ class JSONResponseSerializer(QueryCompatibleProtocolMixin, ResponseSerializer):
     def _prepare_additional_traits_in_response(
         self, response: Response, operation_model: OperationModel, request_id: str
     ):
-        response.headers["x-amzn-requestid"] = request_id
+        response.headers["x-amzn-RequestId"] = request_id
         response = super()._prepare_additional_traits_in_response(
             response, operation_model, request_id
         )
@@ -1921,7 +1930,7 @@ class CBORResponseSerializer(BaseCBORResponseSerializer):
     def _prepare_additional_traits_in_response(
         self, response: Response, operation_model: OperationModel, request_id: str
     ) -> Response:
-        response.headers["x-amzn-requestid"] = request_id
+        response.headers["x-amzn-RequestId"] = request_id
         response = super()._prepare_additional_traits_in_response(
             response, operation_model, request_id
         )
@@ -2015,7 +2024,7 @@ class RpcV2CBORResponseSerializer(
     def _prepare_additional_traits_in_response(
         self, response: Response, operation_model: OperationModel, request_id: str
     ):
-        response.headers["x-amzn-requestid"] = request_id
+        response.headers["x-amzn-RequestId"] = request_id
         response.headers["Smithy-Protocol"] = "rpc-v2-cbor"
         response = super()._prepare_additional_traits_in_response(
             response, operation_model, request_id

--- a/tests/aws/services/cloudwatch/test_cloudwatch.py
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.py
@@ -2975,6 +2975,8 @@ class TestCloudWatchMultiProtocol:
                 payload=input_values,
             )
             assert response.status_code == 200
+            # Check if x-amzn-RequestId is in the response headers - case-sensitive check
+            assert "x-amzn-RequestId" in dict(response.headers)
 
         get_metric_input = {
             "MetricDataQueries": [

--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -43,7 +43,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_basic_operations_multiple_protocols[json]": {
-    "recorded-date": "18-09-2025, 13:56:03",
+    "recorded-date": "06-10-2025, 14:45:54",
     "recorded-content": {
       "describe-alarms": {
         "CompositeAlarms": [],
@@ -76,7 +76,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_basic_operations_multiple_protocols[smithy-rpc-v2-cbor]": {
-    "recorded-date": "18-09-2025, 13:56:06",
+    "recorded-date": "06-10-2025, 14:45:56",
     "recorded-content": {
       "describe-alarms": {
         "CompositeAlarms": [],
@@ -109,7 +109,7 @@
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_basic_operations_multiple_protocols[query]": {
-    "recorded-date": "18-09-2025, 13:56:09",
+    "recorded-date": "06-10-2025, 14:45:59",
     "recorded-content": {
       "describe-alarms": {
         "DescribeAlarmsResponse": {

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -1,29 +1,29 @@
 {
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_basic_operations_multiple_protocols[json]": {
-    "last_validated_date": "2025-09-18T13:56:03+00:00",
+    "last_validated_date": "2025-10-06T14:45:54+00:00",
     "durations_in_seconds": {
-      "setup": 0.48,
-      "call": 3.45,
-      "teardown": 0.0,
-      "total": 3.93
+      "setup": 0.82,
+      "call": 2.64,
+      "teardown": 0.01,
+      "total": 3.47
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_basic_operations_multiple_protocols[query]": {
-    "last_validated_date": "2025-09-18T13:56:09+00:00",
+    "last_validated_date": "2025-10-06T14:45:59+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 3.05,
-      "teardown": 0.0,
-      "total": 3.05
+      "setup": 0.01,
+      "call": 2.39,
+      "teardown": 0.02,
+      "total": 2.42
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_basic_operations_multiple_protocols[smithy-rpc-v2-cbor]": {
-    "last_validated_date": "2025-09-18T13:56:06+00:00",
+    "last_validated_date": "2025-10-06T14:45:56+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 3.05,
-      "teardown": 0.0,
-      "total": 3.05
+      "call": 2.4,
+      "teardown": 0.02,
+      "total": 2.42
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudWatchMultiProtocol::test_exception_serializing_with_no_shape_in_spec[json]": {

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -97,8 +97,11 @@ def _botocore_serializer_integration_test(
 
     # Use the parser from botocore to parse the serialized response
     response_parser = create_parser(service_protocol)
+    # Properly use HeadersDict from botocore to properly parse headers
+    response_dict = serialized_response.to_readonly_response_dict()
+    response_dict["headers"] = HeadersDict(response_dict.get("headers", {}))
     parsed_response = response_parser.parse(
-        serialized_response.to_readonly_response_dict(),
+        response_dict,
         service.operation_model(action).output_shape,
     )
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Even though [RFC 7230] states that header field names should be considered case insensitive, some clients to not conform to this specification.
Especially, the fluent bit cloudwatch client will assert the `x-amzn-RequestId` header - case sensitive.
To support this client, we need to return the correct casing for this response header.

This change not only changes the header (and has an AWS validated test to confirms it), but also adds the header to the `query` protocol, something I confirmed for cloudwatch in the test, and manually for EC2.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Add `x-amzn-RequestId` header for `query` protocol services
* Correct casing for `x-amzn-RequestId` header for `json` and `cbor` (based) protocols

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
