### PR TITLE
CFn: fix number parameter types

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -20,6 +20,7 @@ from localstack.services.cloudformation.engine.v2.change_set_model_preproc impor
     PreprocResource,
 )
 from localstack.services.cloudformation.v2.entities import ChangeSet
+from localstack.utils.numbers import is_number
 
 CHANGESET_KNOWN_AFTER_APPLY: Final[str] = "{{changeSet:KNOWN_AFTER_APPLY}}"
 
@@ -95,6 +96,19 @@ class ChangeSetModelDescriber(ChangeSetModelPreproc):
                 value = CHANGESET_KNOWN_AFTER_APPLY
 
         return value
+
+    def visit_node_intrinsic_function(self, node_intrinsic_function: NodeIntrinsicFunction):
+        """
+        Intrinsic function results are always strings when referring to the describe output
+        """
+        # TODO: what about other places?
+        # TODO: should this be put in the preproc?
+        delta = super().visit_node_intrinsic_function(node_intrinsic_function)
+        if is_number(delta.before):
+            delta.before = str(delta.before)
+        if is_number(delta.after):
+            delta.after = str(delta.after)
+        return delta
 
     def visit_node_intrinsic_function_fn_join(
         self, node_intrinsic_function: NodeIntrinsicFunction

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -56,6 +56,7 @@ from localstack.services.cloudformation.stores import (
 from localstack.services.cloudformation.v2.entities import ChangeSet
 from localstack.services.cloudformation.v2.types import ResolvedResource
 from localstack.utils.aws.arns import get_partition
+from localstack.utils.numbers import to_number
 from localstack.utils.objects import get_value_from_path
 from localstack.utils.run import to_str
 from localstack.utils.strings import to_bytes
@@ -1029,6 +1030,9 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             match type_:
                 case "List<String>" | "CommaDelimitedList":
                     return [item.strip() for item in value.split(",")]
+                case "Number":
+                    # TODO: validate the parameter type at template parse time (or whatever is in parity with AWS) so we know this cannot fail
+                    return to_number(value)
             return value
 
         if not is_nothing(after):

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -120,9 +120,10 @@ from localstack.services.cloudformation.v2.entities import (
     StackInstance,
     StackSet,
 )
-from localstack.services.cloudformation.v2.types import EngineParameter
+from localstack.services.cloudformation.v2.types import EngineParameter, engine_parameter_value
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.collections import select_attributes
+from localstack.utils.numbers import is_number
 from localstack.utils.strings import short_uid
 from localstack.utils.threads import start_worker_thread
 
@@ -261,6 +262,12 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
                 default_value=default_value,
                 no_echo=parameter.get("NoEcho"),
             )
+
+            # validate the type
+            if parameter["Type"] == "Number" and not is_number(
+                engine_parameter_value(resolved_parameter)
+            ):
+                raise ValidationError(f"Parameter '{name}' must be a number.")
 
             # TODO: support other parameter types
             if match := SSM_PARAMETER_TYPE_RE.match(parameter["Type"]):

--- a/localstack-core/localstack/utils/numbers.py
+++ b/localstack-core/localstack/utils/numbers.py
@@ -11,6 +11,13 @@ def format_number(number: float, decimals: int = 2):
 
 
 def is_number(s: Any) -> bool:
+    # booleans inherit from int
+    #
+    # >>> a.__class__.__mro__
+    # (<class 'bool'>, <class 'int'>, <class 'object'>)
+    if s is False or s is True:
+        return False
+
     try:
         float(s)  # for int, long and float
         return True

--- a/tests/aws/services/cloudformation/resources/test_logs.py
+++ b/tests/aws/services/cloudformation/resources/test_logs.py
@@ -1,6 +1,7 @@
 import os.path
 
 import pytest
+from tests.aws.services.cloudformation.conftest import skip_if_legacy_engine
 
 from localstack.testing.pytest import markers
 from localstack.testing.pytest.fixtures import StackDeployError
@@ -54,6 +55,7 @@ def test_cfn_handle_log_group_resource(deploy_cfn_template, aws_client, snapshot
 
 
 @markers.aws.validated
+@skip_if_legacy_engine()
 def test_handle_existing_log_group(deploy_cfn_template, aws_client, snapshot, cleanups):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
     snapshot.add_transformer(snapshot.transform.key_value("ParameterValue"))

--- a/tests/aws/services/cloudformation/resources/test_logs.py
+++ b/tests/aws/services/cloudformation/resources/test_logs.py
@@ -1,6 +1,10 @@
 import os.path
 
+import pytest
+
 from localstack.testing.pytest import markers
+from localstack.testing.pytest.fixtures import StackDeployError
+from localstack.utils.strings import short_uid
 
 
 @markers.aws.validated
@@ -47,3 +51,25 @@ def test_cfn_handle_log_group_resource(deploy_cfn_template, aws_client, snapshot
     stack.destroy()
     response = aws_client.logs.describe_log_groups(logGroupNamePrefix=log_group_prefix)
     assert len(response["logGroups"]) == 0
+
+
+@markers.aws.validated
+def test_handle_existing_log_group(deploy_cfn_template, aws_client, snapshot, cleanups):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.key_value("ParameterValue"))
+
+    log_group_name = f"logs-{short_uid()}"
+
+    # create the log group
+    aws_client.logs.create_log_group(logGroupName=log_group_name)
+    cleanups.append(lambda: aws_client.logs.delete_log_group(logGroupName=log_group_name))
+
+    with pytest.raises(StackDeployError) as exc_info:
+        deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../../templates/logs_group.yml"
+            ),
+            parameters={"LogGroupName": log_group_name},
+        )
+
+    snapshot.match("failed-stack-describe", exc_info.value.describe_result)

--- a/tests/aws/services/cloudformation/resources/test_logs.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_logs.snapshot.json
@@ -38,5 +38,37 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/resources/test_logs.py::test_handle_existing_log_group": {
+    "recorded-date": "06-10-2025, 16:24:57",
+    "recorded-content": {
+      "failed-stack-describe": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "LogGroupName",
+            "ParameterValue": "<parameter-value:1>"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "ROLLBACK_COMPLETE",
+        "Tags": []
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_logs.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_logs.validation.json
@@ -2,6 +2,15 @@
   "tests/aws/services/cloudformation/resources/test_logs.py::test_cfn_handle_log_group_resource": {
     "last_validated_date": "2024-06-20T16:15:47+00:00"
   },
+  "tests/aws/services/cloudformation/resources/test_logs.py::test_handle_existing_log_group": {
+    "last_validated_date": "2025-10-06T16:24:57+00:00",
+    "durations_in_seconds": {
+      "setup": 0.81,
+      "call": 10.58,
+      "teardown": 0.22,
+      "total": 11.61
+    }
+  },
   "tests/aws/services/cloudformation/resources/test_logs.py::test_logstream": {
     "last_validated_date": "2022-07-29T11:22:53+00:00"
   }

--- a/tests/aws/services/cloudformation/test_change_set_parameters.py
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import pytest
@@ -126,6 +127,33 @@ class TestChangeSetParameters:
         }
         capture_update_process(
             snapshot, template_1, template_2, p1={"TopicName": name1}, p2={"TopicName": name2}
+        )
+
+    @markers.aws.validated
+    def test_parameter_type_change(self, snapshot, capture_update_process):
+        snapshot.add_transformer(snapshot.transform.key_value("PhysicalResourceId"))
+
+        template1 = {
+            "Parameters": {
+                "Value": {
+                    "Type": "Number",
+                },
+            },
+            "Resources": {
+                "MyParameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": {"Ref": "Value"},
+                    },
+                },
+            },
+        }
+        template2 = copy.deepcopy(template1)
+        template2["Parameters"]["Value"]["Type"] = "String"
+
+        capture_update_process(
+            snapshot, template1, template2, p1={"Value": "123"}, p2={"Value": "456"}
         )
 
     @markers.aws.validated

--- a/tests/aws/services/cloudformation/test_change_set_parameters.py
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.py
@@ -1,8 +1,12 @@
+import json
+
+import pytest
+from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 from tests.aws.services.cloudformation.conftest import skip_if_legacy_engine
 
 from localstack.testing.pytest import markers
-from localstack.utils.strings import long_uid
+from localstack.utils.strings import long_uid, short_uid
 
 
 @skip_if_legacy_engine()
@@ -123,3 +127,37 @@ class TestChangeSetParameters:
         capture_update_process(
             snapshot, template_1, template_2, p1={"TopicName": name1}, p2={"TopicName": name2}
         )
+
+    @markers.aws.validated
+    def test_invalid_parameter_type(self, snapshot, aws_client):
+        template = {
+            "Parameters": {
+                "Value": {
+                    "Type": "Number",
+                },
+            },
+            "Resources": {
+                "MyParameter": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Type": "String",
+                        "Value": short_uid(),
+                    },
+                },
+            },
+        }
+
+        stack_name = f"stack-{short_uid()}"
+        cs_name = f"cs-{short_uid()}"
+        with pytest.raises(ClientError) as exc_info:
+            aws_client.cloudformation.create_change_set(
+                ChangeSetName=cs_name,
+                StackName=stack_name,
+                ChangeSetType="CREATE",
+                TemplateBody=json.dumps(template),
+                Parameters=[
+                    {"ParameterKey": "Value", "ParameterValue": "not-a-number"},
+                ],
+            )
+
+        snapshot.match("error", exc_info.value.response)

--- a/tests/aws/services/cloudformation/test_change_set_parameters.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.snapshot.json
@@ -1942,5 +1942,445 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_change_set_parameters.py::TestChangeSetParameters::test_parameter_type_change": {
+    "recorded-date": "06-10-2025, 20:55:52",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "<physical-resource-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "123",
+                  "Type": "String"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "MyParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "123"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "MyParameter",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "123"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "123"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "<physical-resource-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "Value": "456",
+                  "Type": "String"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "Value": "123",
+                  "Type": "String"
+                }
+              },
+              "Details": [
+                {
+                  "CausingEntity": "Value",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "456",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "123",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "AfterValue": "456",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "123",
+                    "Name": "Value",
+                    "Path": "/Properties/Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "MyParameter",
+              "PhysicalResourceId": "<physical-resource-id:1>",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "456"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "CausingEntity": "Value",
+                  "ChangeSource": "ParameterReference",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                },
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Dynamic",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "Value",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "MyParameter",
+              "PhysicalResourceId": "<physical-resource-id:1>",
+              "Replacement": "False",
+              "ResourceType": "AWS::SSM::Parameter",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "456"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "456"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "delete-describe": {
+        "Capabilities": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM",
+          "CAPABILITY_AUTO_EXPAND"
+        ],
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "Value",
+            "ParameterValue": "456"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "<physical-resource-id:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "MyParameter": [
+          {
+            "LogicalResourceId": "MyParameter",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MyParameter",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MyParameter",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MyParameter",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MyParameter",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "MyParameter",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SSM::Parameter",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Stack": [
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          },
+          {
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "<physical-resource-id:2>",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_parameters.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.snapshot.json
@@ -1926,5 +1926,21 @@
         "Tags": []
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_change_set_parameters.py::TestChangeSetParameters::test_invalid_parameter_type": {
+    "recorded-date": "06-10-2025, 20:45:59",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Parameter 'Value' must be a number.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_parameters.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.validation.json
@@ -8,6 +8,15 @@
       "total": 1.26
     }
   },
+  "tests/aws/services/cloudformation/test_change_set_parameters.py::TestChangeSetParameters::test_parameter_type_change": {
+    "last_validated_date": "2025-10-06T20:55:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.99,
+      "call": 27.31,
+      "teardown": 0.17,
+      "total": 28.47
+    }
+  },
   "tests/aws/services/cloudformation/test_change_set_parameters.py::TestChangeSetParameters::test_update_parameter_default_value": {
     "last_validated_date": "2025-04-17T15:35:43+00:00"
   },

--- a/tests/aws/services/cloudformation/test_change_set_parameters.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_parameters.validation.json
@@ -1,4 +1,13 @@
 {
+  "tests/aws/services/cloudformation/test_change_set_parameters.py::TestChangeSetParameters::test_invalid_parameter_type": {
+    "last_validated_date": "2025-10-06T20:45:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.92,
+      "call": 0.33,
+      "teardown": 0.01,
+      "total": 1.26
+    }
+  },
   "tests/aws/services/cloudformation/test_change_set_parameters.py::TestChangeSetParameters::test_update_parameter_default_value": {
     "last_validated_date": "2025-04-17T15:35:43+00:00"
   },

--- a/tests/aws/templates/logs_group.yml
+++ b/tests/aws/templates/logs_group.yml
@@ -1,11 +1,16 @@
+Parameters:
+  LogGroupName:
+    Type: String
+    Default: AWS::NoValue
+
 Resources:
   logGroup68A52FBE:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: !Ref LogGroupName
       RetentionInDays: 731
 
 Outputs:
   LogGroupNameOutput:
     Value:
       Ref: logGroup68A52FBE
-

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -95,8 +95,20 @@ class TestCommon:
         test = datetime.now(UTC).timestamp()
         assert test == pytest.approx(env, 1)
 
-    def test_is_number(self):
-        assert common.is_number(5)
+    @pytest.mark.parametrize(
+        "value,is_number",
+        [
+            (5, True),
+            (-12.1, True),
+            (2e15, True),
+            ("test", False),
+            (False, False),
+            (True, False),
+            (None, False),
+        ],
+    )
+    def test_is_number(self, value, is_number):
+        assert common.is_number(value) == is_number
 
     def test_is_ip_address(self):
         assert common.is_ip_address("10.0.0.1")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A customer raised an issue with deploying their stack which contains a `Number` Parameter type. Specifically they were using it in a condition:

```yaml
Parameters:
  Foo:
    Type: Number
Conditions:
  ShouldFrobble:
    Fn::Equals:
      - !Ref Foo
      - 1
Resources:
  MyConditionalResource:
    Condition: ShouldFrobble
    # ...
```

When supplied with the input `[{"ParameterKey": "Value", "ParameterValue": "1"}]` (all parameter values passed in are strings) the `1` was treated as a string, then compared to the integer `1` (i.e. `"1" == 1`), which is falsy and as such the condition evaluates to `False`.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

TBD

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
