### PR TITLE
APIGW: fix Integration connectionId not being returned

### DIFF
--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -2158,6 +2158,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             raise NotFoundException("Invalid Integration identifier specified")
 
         integration = method.method_integration
+        # TODO: validate the patch operations
         patch_api_gateway_entity(integration, patch_operations)
 
         # fix data types
@@ -2166,8 +2167,12 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if skip_verification := (integration.tls_config or {}).get("insecureSkipVerification"):
             integration.tls_config["insecureSkipVerification"] = str_to_bool(skip_verification)
 
-        integration_dict: Integration = integration.to_json()
-        return integration_dict
+        response: Integration = integration.to_json()
+
+        if connection_id := getattr(integration, "connection_id", None):
+            response["connectionId"] = connection_id
+
+        return response
 
     def delete_integration(
         self,

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -4137,3 +4137,24 @@ class TestApigatewayIntegration:
             httpMethod="GET",
         )
         snapshot.match("get-integration-vpc-link", get_integration)
+
+        update_integration = aws_client.apigateway.update_integration(
+            restApiId=rest_api_id,
+            resourceId=root_resource_id,
+            httpMethod="GET",
+            patchOperations=[
+                {
+                    "op": "replace",
+                    "path": "/connectionId",
+                    "value": "${stageVariables.vpcLinkIdBeta}",
+                }
+            ],
+        )
+        snapshot.match("update-integration-vpc-link", update_integration)
+
+        get_integration_update = aws_client.apigateway.get_integration(
+            restApiId=rest_api_id,
+            resourceId=root_resource_id,
+            httpMethod="GET",
+        )
+        snapshot.match("get-integration-update-vpc-link", get_integration_update)

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -4910,7 +4910,7 @@
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_create_integration_with_vpc_link": {
-    "recorded-date": "06-10-2025, 18:07:40",
+    "recorded-date": "08-10-2025, 09:05:56",
     "recorded-content": {
       "put-integration-vpc-link": {
         "cacheKeyParameters": [],
@@ -4931,6 +4931,36 @@
         "cacheKeyParameters": [],
         "cacheNamespace": "<cache-namespace:1>",
         "connectionId": "${stageVariables.vpcLinkId}",
+        "connectionType": "VPC_LINK",
+        "httpMethod": "GET",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP_PROXY",
+        "uri": "http://my-vpclink-test-nlb-1234567890abcdef.<region>.amazonaws.com",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-integration-vpc-link": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "connectionId": "${stageVariables.vpcLinkIdBeta}",
+        "connectionType": "VPC_LINK",
+        "httpMethod": "GET",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP_PROXY",
+        "uri": "http://my-vpclink-test-nlb-1234567890abcdef.<region>.amazonaws.com",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-integration-update-vpc-link": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "connectionId": "${stageVariables.vpcLinkIdBeta}",
         "connectionType": "VPC_LINK",
         "httpMethod": "GET",
         "passthroughBehavior": "WHEN_NO_MATCH",

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -4908,5 +4908,40 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_create_integration_with_vpc_link": {
+    "recorded-date": "06-10-2025, 18:07:40",
+    "recorded-content": {
+      "put-integration-vpc-link": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "connectionId": "${stageVariables.vpcLinkId}",
+        "connectionType": "VPC_LINK",
+        "httpMethod": "GET",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP_PROXY",
+        "uri": "http://my-vpclink-test-nlb-1234567890abcdef.<region>.amazonaws.com",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-integration-vpc-link": {
+        "cacheKeyParameters": [],
+        "cacheNamespace": "<cache-namespace:1>",
+        "connectionId": "${stageVariables.vpcLinkId}",
+        "connectionType": "VPC_LINK",
+        "httpMethod": "GET",
+        "passthroughBehavior": "WHEN_NO_MATCH",
+        "timeoutInMillis": 29000,
+        "type": "HTTP_PROXY",
+        "uri": "http://my-vpclink-test-nlb-1234567890abcdef.<region>.amazonaws.com",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -246,12 +246,12 @@
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_create_integration_with_vpc_link": {
-    "last_validated_date": "2025-10-06T18:07:40+00:00",
+    "last_validated_date": "2025-10-08T09:05:56+00:00",
     "durations_in_seconds": {
-      "setup": 0.82,
-      "call": 1.1,
-      "teardown": 0.68,
-      "total": 2.6
+      "setup": 0.84,
+      "call": 1.59,
+      "teardown": 0.63,
+      "total": 3.06
     }
   },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_delete_integration_response_errors": {

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -245,6 +245,15 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayGatewayResponse::test_update_gateway_response": {
     "last_validated_date": "2024-04-15T20:47:11+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_create_integration_with_vpc_link": {
+    "last_validated_date": "2025-10-06T18:07:40+00:00",
+    "durations_in_seconds": {
+      "setup": 0.82,
+      "call": 1.1,
+      "teardown": 0.68,
+      "total": 2.6
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApigatewayIntegration::test_delete_integration_response_errors": {
     "last_validated_date": "2025-08-21T17:53:19+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This has been reported with #13218

We are forwarding calls to `PutIntegration` to moto, but it doesn't save the `connectionId` parameter when the integration is of type `VPC_LINK`. 

The linked issue is a bigger one, as LocalStack does not support NLB yet, so we technically don't fully support APIGW Private Integration with VPC Links, as it requires a link to the NLB via `targetArns`, but are not validating this as of now. 

See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-api-with-vpclink-cli.html

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- attach the `connectionId` to the moto model to be able to retrieve in `get_integration`
- add validated test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
