### PR TITLE
CFn: handle get_template_summary of failed stack deploy

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1421,6 +1421,11 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
             template = template_preparer.parse_template(template_body)
 
         id_summaries = defaultdict(list)
+        if "Resources" not in template:
+            raise ValidationError(
+                "Template format error: At least one Resources member must be defined."
+            )
+
         for resource_id, resource in template["Resources"].items():
             res_type = resource["Type"]
             id_summaries[res_type].append(resource_id)

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -617,6 +617,11 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
             result = change_set_executor.execute()
             change_set.stack.resolved_parameters = change_set.resolved_parameters
             change_set.stack.resolved_resources = result.resources
+            change_set.stack.template = change_set.template
+            change_set.stack.processed_template = change_set.processed_template
+            change_set.stack.template_body = change_set.template_body
+            change_set.stack.description = change_set.template.get("Description")
+
             if not result.failure_message:
                 new_stack_status = StackStatus.UPDATE_COMPLETE
                 if change_set.change_set_type == ChangeSetType.CREATE:
@@ -631,13 +636,6 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
                         change_set.stack.resolved_exports[export_name] = output["OutputValue"]
 
                 change_set.stack.change_set_id = change_set.change_set_id
-
-                # if the deployment succeeded, update the stack's template representation to that
-                # which was just deployed
-                change_set.stack.template = change_set.template
-                change_set.stack.description = change_set.template.get("Description")
-                change_set.stack.processed_template = change_set.processed_template
-                change_set.stack.template_body = change_set.template_body
             else:
                 LOG.error(
                     "Execute change set failed: %s",

--- a/tests/aws/services/cloudformation/api/test_templates.py
+++ b/tests/aws/services/cloudformation/api/test_templates.py
@@ -8,6 +8,7 @@ from botocore.exceptions import ClientError
 from tests.aws.services.cloudformation.conftest import skip_if_legacy_engine
 
 from localstack.testing.pytest import markers
+from localstack.testing.pytest.fixtures import StackDeployError
 from localstack.utils.common import load_file
 from localstack.utils.strings import short_uid, to_bytes
 
@@ -74,6 +75,34 @@ def test_get_template_summary_no_resources(aws_client, snapshot):
     with pytest.raises(ClientError) as exc_info:
         aws_client.cloudformation.get_template_summary(TemplateBody="{}")
     snapshot.match("error", exc_info.value.response)
+
+
+@markers.aws.validated
+@markers.snapshot.skip_snapshot_verify(
+    paths=["$..ResourceIdentifierSummaries..ResourceIdentifiers"]
+)
+@skip_if_legacy_engine()
+def test_get_template_summary_failed_stack(deploy_cfn_template, aws_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+
+    template = {
+        "Resources": {
+            "MyParameter": {
+                "Type": "AWS::SSM::Parameter",
+                "Properties": {
+                    "Type": "String",
+                    # Note: missing Value parameter so the resource provider should fail
+                },
+            },
+        },
+    }
+
+    stack_name = f"stack-{short_uid()}"
+    with pytest.raises(StackDeployError):
+        deploy_cfn_template(template=json.dumps(template), stack_name=stack_name)
+
+    summary = aws_client.cloudformation.get_template_summary(StackName=stack_name)
+    snapshot.match("template-summary", summary)
 
 
 @markers.aws.validated

--- a/tests/aws/services/cloudformation/api/test_templates.py
+++ b/tests/aws/services/cloudformation/api/test_templates.py
@@ -69,6 +69,14 @@ def test_get_template_summary_non_executed_change_set(aws_client, snapshot, clea
 
 
 @markers.aws.validated
+@skip_if_legacy_engine()
+def test_get_template_summary_no_resources(aws_client, snapshot):
+    with pytest.raises(ClientError) as exc_info:
+        aws_client.cloudformation.get_template_summary(TemplateBody="{}")
+    snapshot.match("error", exc_info.value.response)
+
+
+@markers.aws.validated
 @pytest.mark.parametrize("url_style", ["s3_url", "http_path", "http_host", "http_invalid"])
 def test_create_stack_from_s3_template_url(
     url_style, snapshot, s3_create_bucket, aws_client, cleanups

--- a/tests/aws/services/cloudformation/api/test_templates.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_templates.snapshot.json
@@ -200,5 +200,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary_no_resources": {
+    "recorded-date": "07-10-2025, 22:28:52",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: At least one Resources member must be defined.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_templates.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_templates.snapshot.json
@@ -216,5 +216,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary_failed_stack": {
+    "recorded-date": "07-10-2025, 22:44:53",
+    "recorded-content": {
+      "template-summary": {
+        "Parameters": [],
+        "ResourceIdentifierSummaries": [
+          {
+            "LogicalResourceIds": [
+              "MyParameter"
+            ],
+            "ResourceIdentifiers": [
+              "Name"
+            ],
+            "ResourceType": "AWS::SSM::Parameter"
+          }
+        ],
+        "ResourceTypes": [
+          "AWS::SSM::Parameter"
+        ],
+        "Version": "2010-09-09",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_templates.validation.json
+++ b/tests/aws/services/cloudformation/api/test_templates.validation.json
@@ -50,6 +50,15 @@
   "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary": {
     "last_validated_date": "2023-05-24T13:05:00+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary_failed_stack": {
+    "last_validated_date": "2025-10-07T22:44:53+00:00",
+    "durations_in_seconds": {
+      "setup": 1.0,
+      "call": 134.39,
+      "teardown": 0.0,
+      "total": 135.39
+    }
+  },
   "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary_no_resources": {
     "last_validated_date": "2025-10-07T22:28:52+00:00",
     "durations_in_seconds": {

--- a/tests/aws/services/cloudformation/api/test_templates.validation.json
+++ b/tests/aws/services/cloudformation/api/test_templates.validation.json
@@ -50,6 +50,15 @@
   "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary": {
     "last_validated_date": "2023-05-24T13:05:00+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary_no_resources": {
+    "last_validated_date": "2025-10-07T22:28:52+00:00",
+    "durations_in_seconds": {
+      "setup": 1.58,
+      "call": 0.22,
+      "teardown": 0.0,
+      "total": 1.8
+    }
+  },
   "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary_non_executed_change_set": {
     "last_validated_date": "2025-09-10T23:25:47+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

While triaging issues, we found that the error

```
    for resource_id, resource in template[""Resources""].items():
                                 ~~~~~~~~^^^^^^^^^^^^^
localstack.aws.api.core.CommonServiceException: exception while calling cloudformation.GetTemplateSummary: 'NoneType' object is not subscriptable
```


was encountered and shown to be quite common. This occurs because we do not correctly set the change set template on the stack if the stack fails to deploy.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- Raise validation error for get_template_summary if the template body does not include the `Resources` field (discovered as a separate bug while investigating the real bug)
- Handle not setting template after execute_change_set

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
