### PR TITLE
SNS: Fix multi-region test

### DIFF
--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5601,12 +5601,12 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_in_multiple_regions": {
-    "recorded-date": "29-09-2025, 11:34:38",
+    "recorded-date": "08-10-2025, 08:54:10",
     "recorded-content": {
-      "list-east": {
+      "list-primary": {
         "Topics": [
           {
-            "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+            "TopicArn": "arn:<partition>:sns:<region-primary>:111111111111:<resource:1>"
           }
         ],
         "ResponseMetadata": {
@@ -5614,10 +5614,10 @@
           "HTTPStatusCode": 200
         }
       },
-      "list-west": {
+      "list-secondary": {
         "Topics": [
           {
-            "TopicArn": "arn:<partition>:sns:us-west-1:111111111111:<resource:1>"
+            "TopicArn": "arn:<partition>:sns:<region-secondary>:111111111111:<resource:1>"
           }
         ],
         "ResponseMetadata": {
@@ -5666,7 +5666,7 @@
                   "SNS:ListSubscriptionsByTopic",
                   "SNS:Publish"
                 ],
-                "Resource": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
+                "Resource": "arn:<partition>:sns:<region-primary>:111111111111:<resource:1>",
                 "Condition": {
                   "StringEquals": {
                     "AWS:SourceOwner": "111111111111"
@@ -5678,7 +5678,7 @@
           "SubscriptionsConfirmed": "0",
           "SubscriptionsDeleted": "0",
           "SubscriptionsPending": "0",
-          "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>"
+          "TopicArn": "arn:<partition>:sns:<region-primary>:111111111111:<resource:1>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -5726,7 +5726,7 @@
                   "SNS:ListSubscriptionsByTopic",
                   "SNS:Publish"
                 ],
-                "Resource": "arn:<partition>:sns:us-west-1:111111111111:<resource:1>",
+                "Resource": "arn:<partition>:sns:<region-secondary>:111111111111:<resource:1>",
                 "Condition": {
                   "StringEquals": {
                     "AWS:SourceOwner": "111111111111"
@@ -5738,7 +5738,7 @@
           "SubscriptionsConfirmed": "0",
           "SubscriptionsDeleted": "0",
           "SubscriptionsPending": "0",
-          "TopicArn": "arn:<partition>:sns:us-west-1:111111111111:<resource:1>"
+          "TopicArn": "arn:<partition>:sns:<region-secondary>:111111111111:<resource:1>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -306,12 +306,12 @@
     "last_validated_date": "2024-10-03T21:46:17+00:00"
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_in_multiple_regions": {
-    "last_validated_date": "2025-09-29T11:34:38+00:00",
+    "last_validated_date": "2025-10-08T08:54:10+00:00",
     "durations_in_seconds": {
-      "setup": 1.06,
-      "call": 3.66,
+      "setup": 1.29,
+      "call": 5.7,
       "teardown": 0.01,
-      "total": 4.73
+      "total": 7.0
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_name_constraints": {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As per title. `test_create_topic_in_multiple_regions` was not very cleanly written in regards to multiple regions used. Additionally, the snapshots weren't transformed properly, causing flakes in the pipeline.
Context for the flakes: I am unsure what exactly triggers this, but essentially what happened was that only one region was transformed in the snapshots. And for the pipeline, it was "the other" region that was transformed, causing a mismatch.
MA/MR pipeline run can be found [here](https://github.com/localstack/localstack/actions/runs/18339463990)
<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- rewrite `test_create_topic_in_multiple_regions`
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
