### PR TITLE
CFn: validate conditions exist in Fn::If

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -677,6 +677,13 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             node_condition = self._get_node_condition_if_exists(
                 condition_name=condition_delta.before
             )
+            if is_nothing(node_condition):
+                # TODO: I don't think this is a possible state since for us to be evaluating the before state,
+                #  we must have successfully deployed the stack and as such this case was not reached before
+                raise ValidationError(
+                    f"Template error: unresolved condition dependency {condition_delta.before} in Fn::If"
+                )
+
             condition_value = self.visit(node_condition).before
             if condition_value:
                 arg_delta = self.visit(node_intrinsic_function.arguments.array[1])
@@ -688,6 +695,11 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             node_condition = self._get_node_condition_if_exists(
                 condition_name=condition_delta.after
             )
+            if is_nothing(node_condition):
+                raise ValidationError(
+                    f"Template error: unresolved condition dependency {condition_delta.after} in Fn::If"
+                )
+
             condition_value = self.visit(node_condition).after
             if condition_value:
                 arg_delta = self.visit(node_intrinsic_function.arguments.array[1])

--- a/tests/aws/services/cloudformation/test_change_set_conditions.py
+++ b/tests/aws/services/cloudformation/test_change_set_conditions.py
@@ -1,8 +1,12 @@
+import json
+
+import pytest
+from botocore.exceptions import ClientError
 from localstack_snapshot.snapshots.transformer import RegexTransformer
 from tests.aws.services.cloudformation.conftest import skip_if_legacy_engine
 
 from localstack.testing.pytest import markers
-from localstack.utils.strings import long_uid
+from localstack.utils.strings import long_uid, short_uid
 
 
 @skip_if_legacy_engine()
@@ -166,3 +170,33 @@ class TestChangeSetConditions:
             },
         }
         capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_missing_condition(self, snapshot, aws_client):
+        template = {
+            "Resources": {
+                "MyVpc": {
+                    "Type": "AWS::EC2::VPC",
+                    "Properties": {
+                        "CidrBlock": "10.0.0.0/24",
+                        "Tags": [
+                            {
+                                "Fn::If": ["MissingCondition", "AWS::NoValue", "AWS::NoValue"],
+                            },
+                        ],
+                    },
+                },
+            }
+        }
+
+        cs_name = f"cs-{short_uid()}"
+        stack_name = f"stack-{short_uid()}"
+        with pytest.raises(ClientError) as exc_info:
+            aws_client.cloudformation.create_change_set(
+                StackName=stack_name,
+                ChangeSetName=cs_name,
+                ChangeSetType="CREATE",
+                TemplateBody=json.dumps(template),
+            )
+
+        snapshot.match("error", exc_info.value.response)

--- a/tests/aws/services/cloudformation/test_change_set_conditions.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_conditions.snapshot.json
@@ -1532,5 +1532,21 @@
         "Tags": []
       }
     }
+  },
+  "tests/aws/services/cloudformation/test_change_set_conditions.py::TestChangeSetConditions::test_missing_condition": {
+    "recorded-date": "08-10-2025, 15:58:18",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template error: unresolved condition dependency MissingCondition in Fn::If",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/test_change_set_conditions.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_conditions.validation.json
@@ -10,5 +10,14 @@
   },
   "tests/aws/services/cloudformation/test_change_set_conditions.py::TestChangeSetConditions::test_condition_update_removes_resource": {
     "last_validated_date": "2025-04-15T13:51:50+00:00"
+  },
+  "tests/aws/services/cloudformation/test_change_set_conditions.py::TestChangeSetConditions::test_missing_condition": {
+    "last_validated_date": "2025-10-08T15:58:18+00:00",
+    "durations_in_seconds": {
+      "setup": 0.96,
+      "call": 0.3,
+      "teardown": 0.0,
+      "total": 1.26
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

When deploying templates, sometimes the `Fn::If` condition refers to conditions that don't exist. This is an error with the AWS CFn engine.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Handle this case, where if the condition node is `Nothing` then raise a validation error
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
