### PR TITLE
fix json.assign_to_path with non nested path

### DIFF
--- a/localstack-core/localstack/utils/json.py
+++ b/localstack-core/localstack/utils/json.py
@@ -169,7 +169,16 @@ def extract_jsonpath(value, path):
     return result
 
 
-def assign_to_path(target, path: str, value, delimiter: str = "."):
+def assign_to_path(target: dict, path: str, value: any, delimiter: str = ".") -> dict:
+    """Assign the given value to a dict. If the path doesn't exist in the target dict, it will be created.
+    The delimiter can be used to provide a path with a different delimiter.
+
+    Examples:
+     - assign_to_path({}, "a", "b") => {"a": "b"}
+     - assign_to_path({}, "a.b.c", "d") => {"a": {"b": {"c": "d"}}}
+     - assign_to_path({}, "a.b/c", "d", delimiter="/") => {"a.b": {"c": "d"}}
+
+    """
     parts = path.strip(delimiter).split(delimiter)
 
     if len(parts) == 1:
@@ -177,7 +186,7 @@ def assign_to_path(target, path: str, value, delimiter: str = "."):
         return target
 
     path_to_parent = delimiter.join(parts[:-1])
-    parent = extract_from_jsonpointer_path(target, path_to_parent, auto_create=True)
+    parent = extract_from_jsonpointer_path(target, path_to_parent, delimiter, auto_create=True)
     if not isinstance(parent, dict):
         LOG.debug(
             'Unable to find parent (type %s) for path "%s" in object: %s',

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -11,5 +11,17 @@ def test_json_encoder():
 
 def test_assign_to_path_single_path():
     target = {}
-    assign_to_path(target, "foo", "bar")
-    assert target == {"foo": "bar"}
+    assign_to_path(target, "a", "bar")
+    assert target == {"a": "bar"}
+
+
+def test_assign_multi_nested_path():
+    target = {}
+    assign_to_path(target, "a.b.foo", "bar")
+    assert target == {"a": {"b": {"foo": "bar"}}}
+
+
+def test_assign_to_path_mixed_delimiters():
+    target = {}
+    assign_to_path(target, "a.b/c", "d", delimiter="/")
+    assert target == {"a.b": {"c": "d"}}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This pr aims to fix an issue where attempting to assign a non-nested path, would result in a blank string key added to the dict. For example `assign_to_path({}, "key", "value")` would return `{"": {"key": "value"}}`. Instead of requiring consumer of the util to strip and split to verify if the path is indeed nested, it seems more appropriate to return the expected value `{"key", "value"}`.

part of UNC-17

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

- update `assign_to_path` to return early if the path is not nested.
- added test

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
