### PR TITLE
Sns/v2 sms attribute operations

### DIFF
--- a/localstack-core/localstack/services/sns/v2/models.py
+++ b/localstack-core/localstack/services/sns/v2/models.py
@@ -36,6 +36,15 @@ SnsProtocols = Literal[
 SnsApplicationPlatforms = Literal[
     "APNS", "APNS_SANDBOX", "ADM", "FCM", "Baidu", "GCM", "MPNS", "WNS"
 ]
+SMS_ATTRIBUTE_NAMES = [
+    "DeliveryStatusIAMRole",
+    "DeliveryStatusSuccessSamplingRate",
+    "DefaultSenderID",
+    "DefaultSMSType",
+    "UsageReportS3Bucket",
+]
+SMS_TYPES = ["Promotional", "Transactional"]
+SMS_DEFAULT_SENDER_REGEX = r"^(?=[A-Za-z0-9]{1,11}$)(?=.*[A-Za-z])[A-Za-z0-9]+$"
 SnsMessageProtocols = Literal[SnsProtocols, SnsApplicationPlatforms]
 
 
@@ -142,6 +151,9 @@ class SnsStore(BaseStore):
 
     # maps confirmation token to subscription ARN
     subscription_tokens: dict[str, str] = LocalAttribute(default=dict)
+
+    # topic/subscription independent default values for sending sms messages
+    sms_attributes: dict[str, str] = LocalAttribute(default=dict)
 
     TAGS: TaggingService = CrossRegionAttribute(default=TaggingService)
 

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5942,5 +5942,110 @@
         }
       }
     }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_get_sms_attributes": {
+    "recorded-date": "13-10-2025, 10:30:42",
+    "recorded-content": {
+      "get-sms-all-attributes": {
+        "attributes": {
+          "DefaultSMSType": "Promotional",
+          "DefaultSenderID": "LSTest",
+          "DeliveryStatusSuccessSamplingRate": "100",
+          "MonthlySpendLimit": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-sms-some-attributes": {
+        "attributes": {
+          "DefaultSMSType": "Promotional",
+          "DefaultSenderID": "LSTest"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[InvalidAttributeName]": {
+    "recorded-date": "13-10-2025, 10:43:41",
+    "recorded-content": {
+      "invalid-attribute": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "InvalidAttribute is not a valid attribute",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[TooLongID]": {
+    "recorded-date": "13-10-2025, 10:43:45",
+    "recorded-content": {
+      "invalid-attribute": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "DefaultSendID is not a valid attribute",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[NoLetterID]": {
+    "recorded-date": "13-10-2025, 10:43:52",
+    "recorded-content": {
+      "invalid-attribute": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "DefaultSendID is not a valid attribute",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[InvalidSMSType]": {
+    "recorded-date": "13-10-2025, 10:43:57",
+    "recorded-content": {
+      "invalid-attribute": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "DefaultSMSType is invalid",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_get_sms_attributes_from_unmodified_region": {
+    "recorded-date": "13-10-2025, 11:12:33",
+    "recorded-content": {
+      "get-sms-attributes_unmodified_region": {
+        "attributes": {
+          "MonthlySpendLimit": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -53,8 +53,98 @@
   "tests/aws/services/sns/test_sns.py::TestSNSPublishDelivery::test_delivery_lambda": {
     "last_validated_date": "2023-11-07T10:11:37+00:00"
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_get_sms_attributes_from_unmodified_region": {
+    "last_validated_date": "2025-10-15T12:02:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.67,
+      "call": 2.07,
+      "teardown": 0.0,
+      "total": 2.74
+    }
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_publish_wrong_phone_format": {
     "last_validated_date": "2023-08-24T22:20:12+00:00"
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_get_sms_attributes": {
+    "last_validated_date": "2025-10-13T10:30:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.69,
+      "call": 1.27,
+      "teardown": 0.01,
+      "total": 1.97
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[InvalidAttributeName]": {
+    "last_validated_date": "2025-10-15T12:14:04+00:00",
+    "durations_in_seconds": {
+      "setup": 1.45,
+      "call": 1.32,
+      "teardown": 0.0,
+      "total": 2.77
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[InvalidSMSType]": {
+    "last_validated_date": "2025-10-15T12:14:12+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.24,
+      "teardown": 0.0,
+      "total": 2.24
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[NoLetterID]": {
+    "last_validated_date": "2025-10-15T12:14:09+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.39,
+      "teardown": 0.0,
+      "total": 3.4
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[TooLongID]": {
+    "last_validated_date": "2025-10-15T12:14:06+00:00",
+    "durations_in_seconds": {
+      "setup": 0.1,
+      "call": 1.78,
+      "teardown": 0.0,
+      "total": 1.88
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[attribute_key_value0]": {
+    "last_validated_date": "2025-10-13T10:41:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.84,
+      "call": 1.05,
+      "teardown": 0.06,
+      "total": 1.95
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[attribute_key_value1]": {
+    "last_validated_date": "2025-10-13T10:41:12+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.69,
+      "teardown": 0.01,
+      "total": 2.7
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[attribute_key_value2]": {
+    "last_validated_date": "2025-10-13T10:41:15+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.86,
+      "teardown": 0.01,
+      "total": 2.87
+    }
+  },
+  "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_set_invalid_sms_attributes[attribute_key_value3]": {
+    "last_validated_date": "2025-10-13T10:41:18+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.55,
+      "teardown": 0.01,
+      "total": 2.56
+    }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSSMS::test_subscribe_sms_endpoint": {
     "last_validated_date": "2024-05-14T19:34:11+00:00"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Adds SMS attributes, with the following restrictions:
- both DeliveryStatusIAMRole and UsageReportS3Bucket have checks on AWS to ensure everything is as expected, with all the permission management headache that IAM brings. This is not yet implemented

closes PNX-84

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- add set_sms_attributes, get_sms_attributes
- add validity checks for values passed
- add tests to cover validity and behaviour
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] 
- [ ] ...
-->
