### PR TITLE
fix ASF update linting removing unused import across the codebase

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source .venv/bin/activate
           # explicitly perform an unsafe fix to remove unused imports in the generated ASF APIs
-          ruff check --select F401 --unsafe-fixes --fix . --config "lint.preview = true"
+          ruff check --select F401 --unsafe-fixes --fix localstack-core/localstack/aws/api/ --config "lint.preview = true"
           make format-modified
 
       - name: Check for changes


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
The #13252 ASF updates contained removed imports across the codebase, because the unsafe ruff manual lint was removing them. The ASF update linting step should only concern the API upgrade, so this command is now scoped to the API directory. 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- make the lint step scoped to the API directory

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
