### PR TITLE
S3: clean up leftover legacy code

### DIFF
--- a/localstack-core/localstack/services/s3/constants.py
+++ b/localstack-core/localstack/services/s3/constants.py
@@ -10,8 +10,6 @@ from localstack.aws.api.s3 import (
 )
 from localstack.aws.api.s3 import Type as GranteeType
 
-S3_VIRTUAL_HOST_FORWARDED_HEADER = "x-s3-vhost-forwarded-for"
-
 S3_UPLOAD_PART_MIN_SIZE = 5242880
 """
 This is minimum size allowed by S3 when uploading more than one part for a Multipart Upload, except for the last part

--- a/localstack-core/localstack/services/s3/notifications.py
+++ b/localstack-core/localstack/services/s3/notifications.py
@@ -105,7 +105,7 @@ class S3EventNotificationContext:
     key_storage_class: StorageClass | None
 
     @classmethod
-    def from_request_context_native(
+    def from_request_context(
         cls,
         request_context: RequestContext,
         s3_bucket: S3Bucket,

--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -384,7 +384,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         """
         if s3_bucket.notification_configuration:
             if not s3_notif_ctx:
-                s3_notif_ctx = S3EventNotificationContext.from_request_context_native(
+                s3_notif_ctx = S3EventNotificationContext.from_request_context(
                     context,
                     s3_bucket=s3_bucket,
                     s3_object=s3_object,
@@ -1271,7 +1271,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             delete_marker_id = generate_version_id(s3_bucket.versioning_status)
             delete_marker = S3DeleteMarker(key=key, version_id=delete_marker_id)
             s3_bucket.objects.set(key, delete_marker)
-            s3_notif_ctx = S3EventNotificationContext.from_request_context_native(
+            s3_notif_ctx = S3EventNotificationContext.from_request_context(
                 context,
                 s3_bucket=s3_bucket,
                 s3_object=delete_marker,
@@ -1374,7 +1374,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 delete_marker_id = generate_version_id(s3_bucket.versioning_status)
                 delete_marker = S3DeleteMarker(key=object_key, version_id=delete_marker_id)
                 s3_bucket.objects.set(object_key, delete_marker)
-                s3_notif_ctx = S3EventNotificationContext.from_request_context_native(
+                s3_notif_ctx = S3EventNotificationContext.from_request_context(
                     context,
                     s3_bucket=s3_bucket,
                     s3_object=delete_marker,
@@ -2202,7 +2202,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # TODO: add a way to transition from ongoing-request=true to false? for now it is instant
         s3_object.restore = f'ongoing-request="false", expiry-date="{restore_expiration_date}"'
 
-        s3_notif_ctx_initiated = S3EventNotificationContext.from_request_context_native(
+        s3_notif_ctx_initiated = S3EventNotificationContext.from_request_context(
             context,
             s3_bucket=s3_bucket,
             s3_object=s3_object,

--- a/localstack-core/localstack/services/s3/utils.py
+++ b/localstack-core/localstack/services/s3/utils.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 import zlib
+from collections.abc import Mapping
 from enum import StrEnum
 from secrets import token_bytes
 from typing import Any, Literal, NamedTuple, Protocol
@@ -63,7 +64,6 @@ from localstack.services.s3.constants import (
     AUTHENTICATED_USERS_ACL_GRANTEE,
     CHECKSUM_ALGORITHMS,
     LOG_DELIVERY_ACL_GRANTEE,
-    S3_VIRTUAL_HOST_FORWARDED_HEADER,
     SIGNATURE_V2_PARAMS,
     SIGNATURE_V4_PARAMS,
     SYSTEM_METADATA_SETTABLE_HEADERS,
@@ -522,7 +522,7 @@ def is_valid_canonical_id(canonical_id: str) -> bool:
         return False
 
 
-def uses_host_addressing(headers: dict[str, str]) -> str | None:
+def uses_host_addressing(headers: Mapping[str, str]) -> str | None:
     """
     Determines if the request is targeting S3 with virtual host addressing
     :param headers: the request headers
@@ -549,15 +549,6 @@ def get_system_metadata_from_request(request: dict) -> Metadata:
             metadata[system_metadata_field] = field_value
 
     return metadata
-
-
-def forwarded_from_virtual_host_addressed_request(headers: dict[str, str]) -> bool:
-    """
-    Determines if the request was forwarded from a v-host addressing style into a path one
-    """
-    # we can assume that the host header we are receiving here is actually the header we originally received
-    # from the client (because the edge service is forwarding the request in memory)
-    return S3_VIRTUAL_HOST_FORWARDED_HEADER in headers
 
 
 def extract_bucket_name_and_key_from_headers_and_path(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While working on #13250, I noticed some legacy code that isn't used anymore and is a remnant that wasn't cleaned up when removing the legacy S3 provider (in #11746)

This PR cleans up a bit 🧹 

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- clean up and remove legacy code related to removed Virtual Host proxying logic
- rename a method to not talk about "native" anymore which was used to make a distinction between pure LocalStack implement vs Moto

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
