### PR TITLE
Logs: harden dict view iterations

### DIFF
--- a/localstack-core/localstack/services/logs/provider.py
+++ b/localstack-core/localstack/services/logs/provider.py
@@ -105,7 +105,7 @@ class LogsProvider(LogsApi, ServiceLifecycleHook):
                 "LogGroup name prefix and LogGroup name pattern are mutually exclusive parameters."
             )
 
-        copy_groups = copy.deepcopy(region_backend.groups)
+        copy_groups = copy.deepcopy(dict(region_backend.groups))
 
         groups = [
             group.to_describe_dict()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

The following issue came up when looking in telemetry for issues with the new Batch service. Batch provider calls the DescribeLogGroups API when creating a new task.

```
exception while calling logs.DescribeLogGroups: dictionary changed size during iterationTraceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/rolo/gateway/chain.py", line 166, in handle
    handler(self, self.context, response)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/handlers/service.py", line 116, in __call__
    handler(chain, context, response)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/handlers/service.py", line 86, in __call__
    skeleton_response = self.skeleton.invoke(context)
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/skeleton.py", line 155, in invoke
    return self.dispatch_request(serializer, context, instance)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/skeleton.py", line 169, in dispatch_request
    result = handler(context, instance) or {}
             ~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/forwarder.py", line 137, in _call
    return handler(context, req)
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/skeleton.py", line 117, in __call__
    return self.fn(*args, **kwargs)
           ~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/aws/api/core.py", line 181, in operation_marker
    return fn(*args, **kwargs)
  File "/opt/code/localstack/.venv/lib/python3.13/site-packages/localstack/services/logs/provider.py", line 108, in describe_log_groups
    copy_groups = copy.deepcopy(region_backend.groups)
  File "/usr/local/lib/python3.13/copy.py", line 137, in deepcopy
    y = copier(x, memo)
  File "/usr/local/lib/python3.13/copy.py", line 222, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ~~~~~~~~^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/copy.py", line 163, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/local/lib/python3.13/copy.py", line 260, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/local/lib/python3.13/copy.py", line 137, in deepcopy
    y = copier(x, memo)
  File "/usr/local/lib/python3.13/copy.py", line 222, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ~~~~~~~~^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/copy.py", line 137, in deepcopy
    y = copier(x, memo)
  File "/usr/local/lib/python3.13/copy.py", line 221, in _deepcopy_dict
    for key, value in x.items():
                      ~~~~~~~^^
localstack.aws.api.core.CommonServiceException: exception while calling logs.DescribeLogGroups: dictionary changed size during iteration
```

The error occurs because the dictionary region_backend.groups is being modified by another thread while `copy.deepcopy()` is trying to iterate over it. This is a classic race condition where concurrent modifications to the dictionary cause the "dictionary changed size during iteration" error.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Fixes the race condition, by creating a shallow copy first to avoid the race condition, then do the deep copy:

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
