### PR TITLE
Simplify new_tmp_dir

### DIFF
--- a/localstack-core/localstack/utils/files.py
+++ b/localstack-core/localstack/utils/files.py
@@ -297,6 +297,13 @@ def new_tmp_file(suffix: str | None = None, dir: str | None = None) -> str:
 
 
 def new_tmp_dir(dir: str | None = None, mode: int = 0o777) -> str:
+    """
+    Create a new temporary directory with the specified permissions. The directory is added to the tracked temporary
+    files.
+    :param dir: parent directory for the temporary directory to be created. Systems's default otherwise.
+    :param mode: file permission for the directory (default: 0o777)
+    :return: the absolute path of the created directory
+    """
     folder = tempfile.mkdtemp(dir=dir)
     TMP_FILES.append(folder)
     idempotent_chmod(folder, mode=mode)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR attempts to simplify the logic of the `new_tmp_dir` utility functions.
The original implementation uses `tempfile.mkstemp` and first closes the file descriptor of the created file, then removes the created directory, and finally, re-creates it.

The new implementation relies on `tempfile.mkdtemp`. It also preserves the original behavior by changing the permissions (`tempfile.mkdtemp` would come with `0o700` while `mkdir` has `0o777`).

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Rewrite the `new_tmp_dir` function with `tempfile.mkdtemp`, as explained above.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
