### PR TITLE
Remove verify_ssl = False from in memory localstack test configuration

### DIFF
--- a/localstack-core/localstack/testing/pytest/in_memory_localstack.py
+++ b/localstack-core/localstack/testing/pytest/in_memory_localstack.py
@@ -63,8 +63,6 @@ def pytest_runtestloop(session: Session):
             return
         LOG.info("TEST_FORCE_LOCALSTACK_START is set, a Localstack instance will be created.")
 
-    from localstack.utils.common import safe_requests
-
     if is_aws_cloud():
         localstack_config.DEFAULT_DELAY = 5
         localstack_config.DEFAULT_MAX_ATTEMPTS = 60
@@ -72,8 +70,6 @@ def pytest_runtestloop(session: Session):
     # configure
     os.environ[ENV_INTERNAL_TEST_RUN] = "1"
     localstack_config.INCLUDE_STACK_TRACES_IN_HTTP_RESPONSE = True
-
-    safe_requests.verify_ssl = False
 
     from localstack.runtime import current
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Follow-up from https://github.com/localstack/localstack/pull/13234

The skip of SSL verification was a source of confusion in the past when trying to figure out why a test was failing only on K8s tests pipeline while it was successful in the "in-memory localstack" test execution.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

We remove this configuration. If a test needs to skip SSL validation,this can be done with `verify=False` in the specific `requests` call like it was done in #13234 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
