### PR TITLE
feat(utils/sync): Add sync.Once utility functions

### DIFF
--- a/localstack-core/localstack/utils/sync.py
+++ b/localstack-core/localstack/utils/sync.py
@@ -218,24 +218,31 @@ class Once:
                     self._is_done = True
 
 
-def once(fn: Callable[..., T]) -> Callable[..., T | None]:
+def once_func(fn: Callable[..., T]) -> Callable[..., T | None]:
     """
-    A decorator that ensures a function is over ever executed once.
+    Wraps and returns a function that can only ever execute once.
 
-    The first call to decorated function will permanently set results.
+    The first call to the returned function will permanently set the result.
+    If the wrapped function raises an exception, this will be re-raised on each subsequent call.
 
-    If the decorated function rasies an exception, this will be re-raised on each subsequent call.
+    This function can be used either as a decorator or called directly.
 
+    Direct usage:
     ```python
-    @once
+    delete_file = once_func(os.remove)
+
+    delete_file("myfile.txt")  # deletes the file
+    delete_file("myfile.txt")  # does nothing
+    ```
+
+    As a decorator:
+    ```python
+    @once_func
     def delete_file():
         os.remove("myfile.txt")
 
-    # deletes the file
-    delete_file()
-    # already called, so does nothing
-    delete_file()
-
+    delete_file()  # deletes the file
+    delete_file()  # does nothing
     ```
     """
     once = Once()

--- a/tests/unit/utils/test_sync.py
+++ b/tests/unit/utils/test_sync.py
@@ -2,7 +2,7 @@ import threading
 
 import pytest
 
-from localstack.utils.sync import Once, SynchronizedDefaultDict, once
+from localstack.utils.sync import Once, SynchronizedDefaultDict, once_func
 
 
 def test_synchronized_defaultdict():
@@ -70,7 +70,7 @@ class TestOnceDecorator:
     def test_executes_only_once(self):
         counter = []
 
-        @once
+        @once_func
         def increment():
             counter.append(1)
             return sum(counter)
@@ -87,7 +87,7 @@ class TestOnceDecorator:
     def test_with_arguments(self):
         calls = []
 
-        @once
+        @once_func
         def add(a, b):
             calls.append((a, b))
             return a + b
@@ -105,7 +105,7 @@ class TestOnceDecorator:
     def test_exception_reraises(self):
         call_count = []
 
-        @once
+        @once_func
         def failing_function():
             call_count.append(1)
             raise ValueError("Something went wrong")
@@ -124,7 +124,7 @@ class TestOnceDecorator:
     def test_none_return_value(self):
         calls = []
 
-        @once
+        @once_func
         def returns_none():
             calls.append(1)
             return None
@@ -137,7 +137,7 @@ class TestOnceDecorator:
         assert result2 is None
 
     def test_preserves_function_metadata(self):
-        @once
+        @once_func
         def documented_function():
             """This is a docstring."""
             return 42
@@ -149,12 +149,12 @@ class TestOnceDecorator:
         counter1 = []
         counter2 = []
 
-        @once
+        @once_func
         def function1():
             counter1.append(1)
             return "func1"
 
-        @once
+        @once_func
         def function2():
             counter2.append(1)
             return "func2"
@@ -170,7 +170,7 @@ class TestOnceDecorator:
     def test_with_kwargs(self):
         calls = []
 
-        @once
+        @once_func
         def with_kwargs(a, b=10, **kwargs):
             calls.append((a, b, kwargs))
             return "result"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

## Motivation

A repeated pattern across the codebase is ensuring idempotent execution of some function/method, where multiple calls can be expensive, result in exceptions, or have unintende side-affects, making it inappropriate for repeated invocations.

To address the above, this PR proposes a port of the Golang `sync.Once` functionality -- introducing some utilities for thread-safe and at-most-once execution.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Adds a new `sync.Once` utility that allows us to atomically execute some functionality once-and-only-once, with subsequent executions being no-ops.
- Adds a `sync.once` decorator that can be used to guard an arbitrary function against multiple executions, with prior results being cached and returned each time the guarded function is run.


## Example Usage

### File creation and teardown.

A file should only ever be created OR removed once. This prevents the need to track internal state (i.e `is_removed: bool`) or run some `os.exists()` functionality prior to each remove operation.

```python
class Service:
   @sync.once
   def start(self):
      with open("myfile.txt", "x") as file:
         file.write("write the file")
   
   @sync.once
   def close(self):
      os.remove("myfile.txt")
```

### Managing container creation and teardown.

Here, we expose multiple ways of starting the redis container `Service` (i.e with some config or with default values), but need to ensure that not both operations can be called.

```python
class Service:
    container: Container
    
    def __init__(self):
        self.container = Container("redis:latest")
        self.start_once = sync.Once()
    
   def start_with_defaults(self):
       self.start_once.do(self.container.start)

   def start_from_config(self):
       self.initialize_config_for_redis()
       self.start_once.do(self.container.start)
    
    @sync.once
    def close(self):
        self.container.destroy()
```


<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
