### PR TITLE
Install build package when running make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ entrypoints:              ## Run plux to build entry points
 	@test -s localstack-core/localstack_core.egg-info/entry_points.txt || (echo "Entrypoints were not correctly created! Aborting!" && exit 1)
 
 dist: entrypoints        ## Build source and built (wheel) distributions of the current version
-	$(VENV_RUN); pip install --upgrade twine; python -m build
+	$(VENV_RUN); pip install --upgrade build twine; python -m build
 
 publish: clean-dist dist  ## Publish the library to the central PyPi repository
 	# make sure the dist archive contains a non-empty entry_points.txt file before uploading


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Fix "Publish dev release" step of CI.

After https://github.com/localstack/localstack/pull/13193 `build` python package is no longer part of `pyproject.toml` dependencies. However, this is needed for `make build` step

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Install `build` before running `python -m build` 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
