### PR TITLE
CIFix: Update Opensearch version for bootstrap test

### DIFF
--- a/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
+++ b/tests/bootstrap/cdk_templates/LocalStackHostBootstrap/ClusterStack.json
@@ -27,7 +27,7 @@
         "EncryptionAtRestOptions": {
           "Enabled": false
         },
-        "EngineVersion": "OpenSearch_2.3",
+        "EngineVersion": "OpenSearch_2.19",
         "LogPublishingOptions": {},
         "NodeToNodeEncryptionOptions": {
           "Enabled": false

--- a/tests/bootstrap/test_cosmetic_configuration.py
+++ b/tests/bootstrap/test_cosmetic_configuration.py
@@ -155,7 +155,7 @@ class TestLocalStackHost:
             stack,
             "Domain",
             domain_name=domain_name,
-            version=cdk.aws_opensearchservice.EngineVersion.OPENSEARCH_2_3,
+            version=cdk.aws_opensearchservice.EngineVersion.OPENSEARCH_2_19,
         )
         cdk.CfnOutput(stack, "DomainEndpoint", value=domain.domain_endpoint)
 


### PR DESCRIPTION
## Motivation
Currently our bootstrap CI check is not passing  due to an error with the Opensearch setup processes when using older OpenSearch versions. I confirmed that it happens with 2.3 and 2.5. This PR updates the bootstrap test to use the latest version with the objective to fix our pipeline ASAP.  

## Changes
- Update Opensearch version used in test

## Testing
Bootstrap check should be green.


cc/ @alexrashed @silv-io as service owners of opensearch.