### PR TITLE
Update React and ReactDOM versions in CFn deploy.html

### DIFF
--- a/localstack-core/localstack/services/cloudformation/deploy.html
+++ b/localstack-core/localstack/services/cloudformation/deploy.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>LocalStack - CloudFormation Deployment</title>
-    <script src="https://unpkg.com/react/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aws-sdk/2.1015.0/aws-sdk.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css"></link>


### PR DESCRIPTION
Previously-unpinned versions 404'd on React 19

GH Issue: https://github.com/localstack/localstack/issues/13291

<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

CFn deploy page shouldn't be blank on load: http://localhost:4566/_localstack/cloudformation/deploy

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

Pinned versions of React and ReactDOM <19 on unpkg in the CFn deploy page.

