### PR TITLE
chore(lambda/rie): Update RIE to v1.36.0-pre

### DIFF
--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -12,7 +12,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.35-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.36-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Updates the RIE to include fix for https://github.com/localstack/localstack/issues/12680

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
- Updates to the RIE binary from `v1.35.0-pre` to `v1.36.0-pre`, shipping https://github.com/localstack/lambda-runtime-init/pull/42

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
