### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@ Optional: How are the proposed changes tested?
 ## Related
 
 <!--
-Optional: Links to related issues and references.
+Optional: Links to related issues and references (e.g., Linear IDs).
 -->


### PR DESCRIPTION
## Changes

This PR proposes following changes to our GitHub PR template:
- Lines are broken to fit GitHub's narrow text box
- Guidelines are moved into the sections they relate to
- The optional Todo section is removed because it's rarely used
- A new related section is added to link issues and related pages. This will systematise Linear IDs.

## Related

Related to PNX-388