### PR TITLE
K8s tests: Add requires_in_process marker in only_localstack tests where needed

### DIFF
--- a/tests/aws/services/acm/test_acm.py
+++ b/tests/aws/services/acm/test_acm.py
@@ -85,6 +85,7 @@ class TestACM:
         result = aws_client.acm.describe_certificate(CertificateArn=certificate_arn)
         snapshot.match("describe-certificate", result)
 
+    @markers.requires_in_process
     @markers.aws.needs_fixing
     def test_boto_wait_for_certificate_validation(
         self, acm_request_certificate, aws_client, monkeypatch

--- a/tests/aws/services/apigateway/test_apigateway_basic.py
+++ b/tests/aws/services/apigateway/test_apigateway_basic.py
@@ -301,6 +301,7 @@ class TestAPIGateway:
     @pytest.mark.parametrize("disable_custom_cors", [True, False])
     @pytest.mark.parametrize("origin", ["http://allowed", "http://denied"])
     @markers.aws.only_localstack
+    @markers.requires_in_process
     def test_invoke_endpoint_cors_headers(
         self, url_type, disable_custom_cors, origin, monkeypatch, aws_client
     ):

--- a/tests/aws/services/apigateway/test_apigateway_custom_ids.py
+++ b/tests/aws/services/apigateway/test_apigateway_custom_ids.py
@@ -16,6 +16,7 @@ API_KEY_ID = "ApiKeyId"
 
 # Custom ids can't be set on aws.
 @markers.aws.only_localstack
+@markers.requires_in_process
 def test_apigateway_custom_ids(
     aws_client, set_resource_custom_id, create_rest_apigw, account_id, region_name, cleanups
 ):

--- a/tests/aws/services/cloudformation/api/test_stacks.py
+++ b/tests/aws/services/cloudformation/api/test_stacks.py
@@ -462,6 +462,7 @@ class TestStacksApi:
         ]
         assert len(updated_resources) == length_expected
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_create_stack_with_custom_id(
         self, aws_client, cleanups, account_id, region_name, set_resource_custom_id

--- a/tests/aws/services/cloudformation/resources/test_lambda.py
+++ b/tests/aws/services/cloudformation/resources/test_lambda.py
@@ -549,6 +549,7 @@ def test_lambda_cfn_run_with_empty_string_replacement_deny_list(
     )
 
 
+@markers.requires_in_process
 @markers.aws.only_localstack(reason="This is functionality specific to Localstack")
 def test_lambda_cfn_run_with_non_empty_string_replacement_deny_list(
     deploy_cfn_template, aws_client, get_function_envars, monkeypatch

--- a/tests/aws/services/ec2/test_ec2.py
+++ b/tests/aws/services/ec2/test_ec2.py
@@ -668,6 +668,7 @@ class TestEc2Integrations:
         assert subnet["Tags"][0]["Key"] == TAG_KEY_CUSTOM_ID
         assert subnet["Tags"][0]["Value"] == custom_subnet_id
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @pytest.mark.parametrize("strategy", ["tag", "id_manager"])
     @pytest.mark.parametrize("default_vpc", [True, False])
@@ -1006,6 +1007,7 @@ def test_pickle_ec2_backend(pickle_backends, aws_client):
     assert pickle_backends(ec2_backends)
 
 
+@markers.requires_in_process
 @markers.aws.only_localstack
 def test_create_specific_vpc_id(account_id, region_name, create_vpc, set_resource_custom_id):
     cidr_block = "10.0.0.0/16"

--- a/tests/aws/services/events/test_events_targets.py
+++ b/tests/aws/services/events/test_events_targets.py
@@ -41,6 +41,7 @@ from tests.aws.services.lambda_.test_lambda import (
 
 class TestEventsTargetApiDestination:
     # TODO validate against AWS & use common fixtures
+    @markers.requires_in_process  # uses pytest httpserver
     @markers.aws.only_localstack
     @pytest.mark.skipif(is_old_provider(), reason="not supported by the old provider")
     @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)

--- a/tests/aws/services/firehose/test_firehose.py
+++ b/tests/aws/services/firehose/test_firehose.py
@@ -38,6 +38,7 @@ TEST_MESSAGE = "Test-message-2948294kdlsie"
 
 @pytest.mark.parametrize("lambda_processor_enabled", [True, False])
 @markers.aws.unknown
+@markers.requires_in_process  # uses pytest httpserver
 def test_kinesis_firehose_http(
     aws_client,
     lambda_processor_enabled: bool,

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -264,6 +264,7 @@ class TestLambdaBaseFeatures:
 
         retry(_check_print_in_logs, retries=10)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_lambda_too_large_response_but_with_custom_limit(
         self, caplog, create_lambda_function, aws_client, monkeypatch
@@ -1970,6 +1971,7 @@ class TestLambdaErrors:
         )
         snapshot.match("invocation_error", result)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack(
         reason="Can only induce Lambda-internal Docker error in LocalStack"
     )
@@ -1999,6 +2001,7 @@ class TestLambdaErrors:
             r"retries: \d\): \[[^]]*\] Timeout while starting up lambda environment .*"
         )
 
+    @markers.requires_in_process
     @markers.aws.only_localstack(
         reason="Can only induce Lambda-internal Docker error in LocalStack"
     )

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -4799,6 +4799,7 @@ class TestLambdaUrl:
         # region changes, https vs http, etc
         assert f"://{custom_id_value}.lambda-url." in url_config_created["FunctionUrl"]
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_create_url_config_custom_id_tag_invalid_id(
         self, create_lambda_function, aws_client, caplog
@@ -6855,6 +6856,7 @@ class TestLambdaLayer:
             "get_layer_version_policy_postdeletes2", get_layer_version_policy_postdeletes2
         )
 
+    @markers.requires_in_process
     @markers.aws.only_localstack(reason="Deterministic id generation is LS only")
     def test_layer_deterministic_version(
         self, dummylayer, cleanups, aws_client, account_id, region_name, set_resource_custom_id

--- a/tests/aws/services/lambda_/test_lambda_developer_tools.py
+++ b/tests/aws/services/lambda_/test_lambda_developer_tools.py
@@ -36,6 +36,7 @@ class TestHotReloading:
         ids=["nodejs20.x", "python3.12"],
     )
     @markers.aws.only_localstack
+    @markers.requires_in_process
     def test_hot_reloading(
         self,
         create_lambda_function_aws,
@@ -165,6 +166,7 @@ class TestHotReloading:
                 Runtime=Runtime.python3_12,
             )
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_hot_reloading_environment_placeholder(
         self, create_lambda_function_aws, lambda_su_role, cleanups, aws_client, monkeypatch
@@ -198,6 +200,7 @@ class TestHotReloading:
 
 
 class TestDockerFlags:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_additional_docker_flags(self, create_lambda_function, monkeypatch, aws_client):
         env_value = short_uid()
@@ -214,6 +217,7 @@ class TestDockerFlags:
         result_data = json.load(result["Payload"])
         assert {"Hello": env_value} == result_data
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_lambda_docker_networks(self, lambda_su_role, monkeypatch, aws_client, cleanups):
         function_name = f"test-network-{short_uid()}"

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -640,6 +640,7 @@ class TestOpensearchProvider:
             f"search unsuccessful({response.status_code}): {response.text}"
         )
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_endpoint_strategy_path(self, monkeypatch, opensearch_create_domain, aws_client):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
@@ -653,6 +654,7 @@ class TestOpensearchProvider:
         endpoint = status["Endpoint"]
         assert endpoint.endswith(f"/{domain_name}")
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_endpoint_strategy_port(self, monkeypatch, opensearch_create_domain, aws_client):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
@@ -688,6 +690,7 @@ class TestOpensearchProvider:
 
 @markers.skip_offline
 class TestEdgeProxiedOpensearchCluster:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_route_through_edge(self):
         cluster_id = f"domain-{short_uid()}"
@@ -784,6 +787,7 @@ class TestEdgeProxiedOpensearchCluster:
 
 @markers.skip_offline
 class TestMultiClusterManager:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_multi_cluster(self, account_id, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "domain")
@@ -832,6 +836,7 @@ class TestMultiClusterManager:
 
 @markers.skip_offline
 class TestMultiplexingClusterManager:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_multiplexing_cluster(self, account_id, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "domain")
@@ -880,6 +885,7 @@ class TestMultiplexingClusterManager:
 
 @markers.skip_offline
 class TestSingletonClusterManager:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_endpoint_strategy_port_singleton_cluster(self, account_id, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
@@ -926,6 +932,7 @@ class TestSingletonClusterManager:
 
 @markers.skip_offline
 class TestCustomBackendManager:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_custom_backend(self, account_id, httpserver, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "domain")
@@ -992,6 +999,7 @@ class TestCustomBackendManager:
 
         httpserver.check()
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_custom_backend_with_custom_endpoint(
         self,

--- a/tests/aws/services/s3/test_s3.py
+++ b/tests/aws/services/s3/test_s3.py
@@ -6312,6 +6312,7 @@ class TestS3PresignedUrl:
         finally:
             s3_presigned_client.meta.events.unregister("before-sign.s3.GetObject", add_query_param)
 
+    @markers.requires_in_process  # Patches skip signature validation
     @markers.aws.only_localstack
     def test_presign_check_signature_validation_for_port_permutation(
         self, s3_bucket, patch_s3_skip_signature_validation_false, aws_client
@@ -6354,6 +6355,7 @@ class TestS3PresignedUrl:
         assert response["Body"].read() == b"something"
         snapshot.match("get_object", response)
 
+    @markers.requires_in_process  # Patches skip signature validation
     @markers.aws.only_localstack
     def test_get_request_expires_ignored_if_validation_disabled(
         self, s3_bucket, monkeypatch, patch_s3_skip_signature_validation_false, aws_client
@@ -6917,6 +6919,7 @@ class TestS3PresignedUrl:
         exception["StatusCode"] = response.status_code
         snapshot.match("override-signed-qs", exception)
 
+    @markers.requires_in_process  # Patches skip signature validation
     @markers.aws.validated
     @pytest.mark.parametrize("signature_version", ["s3", "s3v4"])
     def test_s3_put_presigned_url_missing_sig_param(
@@ -6992,6 +6995,7 @@ class TestS3PresignedUrl:
 
     @pytest.mark.skipif(condition=TEST_S3_IMAGE, reason="STS not enabled in S3 image")
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     def test_presigned_url_with_session_token(
         self,
         s3_create_bucket_with_client,
@@ -7031,6 +7035,7 @@ class TestS3PresignedUrl:
 
     @pytest.mark.skipif(condition=TEST_S3_IMAGE, reason="STS not enabled in S3 image")
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     def test_presigned_url_with_different_user_credentials(
         self,
         aws_client,
@@ -7102,6 +7107,7 @@ class TestS3PresignedUrl:
         assert response._content == b"test-value"
 
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     @pytest.mark.parametrize("signature_version", ["s3", "s3v4"])
     def test_s3_get_response_header_overrides(
         self, s3_bucket, signature_version, patch_s3_skip_signature_validation_false, aws_client
@@ -7358,6 +7364,7 @@ class TestS3PresignedUrl:
         ],
     )
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     def test_presigned_url_signature_authentication_multi_part(
         self,
         s3_create_bucket,
@@ -7622,6 +7629,7 @@ class TestS3PresignedUrl:
         ["s3", "s3v4"],
     )
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     def test_s3_presign_url_encoding(
         self, aws_client, s3_bucket, signature_version, patch_s3_skip_signature_validation_false
     ):
@@ -10651,6 +10659,7 @@ class TestS3PresignedPost:
         "signature_version",
         ["s3", "s3v4"],
     )
+    @markers.requires_in_process  # Patches skip signature validation
     def test_post_request_malformed_policy(
         self,
         s3_bucket,
@@ -10693,6 +10702,7 @@ class TestS3PresignedPost:
         assert exception["Error"]["StringToSign"] == presigned_request["fields"]["policy"]
 
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     @pytest.mark.parametrize(
         "signature_version",
         ["s3", "s3v4"],
@@ -10734,6 +10744,7 @@ class TestS3PresignedPost:
         snapshot.match("exception-missing-signature", exception)
 
     @markers.aws.validated
+    @markers.requires_in_process  # Patches skip signature validation
     @pytest.mark.parametrize(
         "signature_version",
         ["s3", "s3v4"],

--- a/tests/aws/services/secretsmanager/test_secretsmanager.py
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.py
@@ -2535,6 +2535,7 @@ class TestSecretsManager:
         )
         sm_snapshot.match("secret_value_http_response", json_response)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_create_secret_with_custom_id(
         self, account_id, region_name, create_secret, set_resource_custom_id

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -1036,6 +1036,7 @@ class TestSES:
 
 @pytest.mark.usefixtures("openapi_validate")
 class TestSESRetrospection:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_send_email_can_retrospect(self, aws_client):
         # Test that sent emails can be retrospected through saved file and API access
@@ -1116,6 +1117,7 @@ class TestSESRetrospection:
         assert requests.delete(emails_url + f"?id={message2_id}").status_code == 204
         assert requests.get(emails_url).json() == {"messages": []}
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_send_templated_email_can_retrospect(self, create_template, aws_client):
         # Test that sent emails can be retrospected through saved file and API access

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -3571,6 +3571,7 @@ class TestSNSSubscriptionSQSFifo:
 
 
 class TestSNSSubscriptionSES:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_topic_email_subscription_confirmation(
@@ -3604,6 +3605,7 @@ class TestSNSSubscriptionSES:
 
         retry(check_subscription, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_email_sender(
@@ -3650,6 +3652,7 @@ class TestSNSSubscriptionSES:
 
 
 class TestSNSPlatformEndpoint:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_subscribe_platform_endpoint(
@@ -3808,6 +3811,7 @@ class TestSNSPlatformEndpoint:
             )
         assert ex.value.response["Error"]["Code"] == "InvalidParameter"
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_publish_to_platform_endpoint_is_dispatched(
@@ -3872,6 +3876,7 @@ class TestSNSPlatformEndpoint:
 
 
 class TestSNSSMS:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_publish_sms(self, aws_client, account_id, region_name):
@@ -3909,6 +3914,7 @@ class TestSNSSMS:
         )
         snapshot.match("subscribe-sms-attrs", sub_attrs)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_publish_sms_endpoint(
@@ -4055,6 +4061,7 @@ class TestSNSSubscriptionHttp:
         )
         snapshot.match("subscription-with-arn", subscription_with_arn)
 
+    @markers.requires_in_process  # uses pytest httpserver
     @markers.aws.manual_setup_required
     @skip_if_sns_v2
     def test_redrive_policy_http_subscription(
@@ -4104,6 +4111,7 @@ class TestSNSSubscriptionHttp:
         assert message["Type"] == "Notification"
         assert json.loads(message["Message"])["message"] == "test_redrive_policy"
 
+    @markers.requires_in_process  # uses pytest httpserver
     @markers.aws.manual_setup_required
     @skip_if_sns_v2
     def test_multiple_subscriptions_http_endpoint(
@@ -4190,6 +4198,7 @@ class TestSNSSubscriptionHttp:
             for server in servers:
                 server.stop()
 
+    @markers.requires_in_process  # uses pytest httpserver
     @markers.aws.manual_setup_required
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     @markers.snapshot.skip_snapshot_verify(
@@ -4373,6 +4382,7 @@ class TestSNSSubscriptionHttp:
         )
         snapshot.match("unsubscribe-request", payload)
 
+    @markers.requires_in_process  # uses pytest httpserver
     @markers.aws.manual_setup_required
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     @skip_if_sns_v2
@@ -4460,6 +4470,7 @@ class TestSNSSubscriptionHttp:
         # AWS doesn't send to the DLQ if the UnsubscribeConfirmation fails to be delivered
         assert "Messages" not in response or response["Messages"] == []
 
+    @markers.requires_in_process  # uses pytest httpserver
     @markers.aws.manual_setup_required
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     @markers.snapshot.skip_snapshot_verify(
@@ -5332,6 +5343,7 @@ class TestSNSPublishDelivery:
 
 
 class TestSNSCertEndpoint:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @pytest.mark.parametrize("cert_host", ["", "sns.us-east-1.amazonaws.com"])
     @skip_if_sns_v2
@@ -5379,6 +5391,7 @@ class TestSNSCertEndpoint:
 
 @pytest.mark.usefixtures("openapi_validate")
 class TestSNSRetrospectionEndpoints:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_publish_to_platform_endpoint_can_retrospect(
@@ -5536,6 +5549,7 @@ class TestSNSRetrospectionEndpoints:
         ).json()
         assert not msg_with_region["platform_endpoint_messages"]
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_publish_sms_can_retrospect(
@@ -5640,6 +5654,7 @@ class TestSNSRetrospectionEndpoints:
         msg_with_region = requests.get(msgs_url, params={"region": region_name}).json()
         assert not msg_with_region["sms_messages"]
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @skip_if_sns_v2
     def test_subscription_tokens_can_retrospect(

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -82,6 +82,7 @@ def aws_sqs_client(aws_client, request: str) -> "SQSClient":
 
 
 class TestSqsProvider:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_get_queue_url_contains_localstack_host(
         self,
@@ -228,6 +229,7 @@ class TestSqsProvider:
             "You must wait 60 seconds after deleting a queue before you can create another with the same name."
         )
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_create_queue_recently_deleted_cache(
         self,
@@ -1642,6 +1644,7 @@ class TestSqsProvider:
         bodies = {message["Body"] for message in messages}
         assert bodies == {"0", "1", "2", "3", "4", "5", "6", "7", "8"}
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_external_endpoint(self, monkeypatch, sqs_create_queue, aws_sqs_client):
         external_host = "external-host"
@@ -1662,6 +1665,7 @@ class TestSqsProvider:
         receive_result = aws_sqs_client.receive_message(QueueUrl=queue_url)
         assert receive_result["Messages"][0]["Body"] == message_body
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_external_hostname_via_host_header(self, monkeypatch, sqs_create_queue, region_name):
         """test making a request with a different external hostname/port being returned"""
@@ -4122,6 +4126,7 @@ class TestSqsProvider:
         )
         assert int(approx_nr_of_messages["Attributes"]["ApproximateNumberOfMessages"]) == 0
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_list_queues_multi_region_without_endpoint_strategy(
         self, aws_client_factory, cleanups, monkeypatch
@@ -5325,6 +5330,7 @@ class TestSqsQueryApi:
         assert response.ok
         assert "foobar" in response.text
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_queue_url_format_path_strategy(
         self, sqs_create_queue, account_id, region_name, monkeypatch

--- a/tests/aws/services/stepfunctions/v2/mocking/test_aws_scenarios.py
+++ b/tests/aws/services/stepfunctions/v2/mocking/test_aws_scenarios.py
@@ -10,6 +10,7 @@ from tests.aws.services.stepfunctions.templates.mocked.mocked_templates import M
 
 
 class TestBaseScenarios:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_lambda_sqs_integration_happy_path(
         self,
@@ -46,6 +47,7 @@ class TestBaseScenarios:
         event_last = events[-1]
         assert event_last["type"] == "ExecutionSucceeded"
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_lambda_sqs_integration_retry_path(
         self,
@@ -103,6 +105,7 @@ class TestBaseScenarios:
         event_last = events[-1]
         assert event_last["type"] == "ExecutionSucceeded"
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_lambda_sqs_integration_hybrid_path(
         self,

--- a/tests/aws/test_error_injection.py
+++ b/tests/aws/test_error_injection.py
@@ -11,6 +11,7 @@ from .test_integration import PARTITION_KEY
 
 
 class TestErrorInjection:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_kinesis_error_injection(
         self, monkeypatch, wait_for_stream_ready, aws_client, aws_client_factory
@@ -34,6 +35,7 @@ class TestErrorInjection:
         finally:
             aws_client.kinesis.delete_stream(StreamName=stream_name)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_dynamodb_error_injection(self, monkeypatch, aws_client, dynamodb_create_table):
         table_name = dynamodb_create_table()["TableDescription"]["TableName"]
@@ -51,6 +53,7 @@ class TestErrorInjection:
             )
         exc.match("ProvisionedThroughputExceededException")
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_dynamodb_read_error_injection(self, monkeypatch, aws_client, dynamodb_create_table):
         table_name = dynamodb_create_table()["TableDescription"]["TableName"]
@@ -68,6 +71,7 @@ class TestErrorInjection:
             )
         exc.match("ProvisionedThroughputExceededException")
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_dynamodb_write_error_injection(self, monkeypatch, aws_client, dynamodb_create_table):
         table_name = dynamodb_create_table()["TableDescription"]["TableName"]

--- a/tests/aws/test_network_configuration.py
+++ b/tests/aws/test_network_configuration.py
@@ -27,6 +27,7 @@ class TestOpenSearch:
     OpenSearch does not respect any customisations and just returns a domain with localhost.localstack.cloud in.
     """
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_default_strategy(
         self, opensearch_create_domain, assert_host_customisation, aws_client
@@ -60,6 +61,7 @@ class TestOpenSearch:
 
         assert_host_customisation(endpoint)
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_path_strategy(
         self,
@@ -81,6 +83,7 @@ class TestOpenSearch:
 
 class TestS3:
     @markers.aws.only_localstack
+    @markers.requires_in_process
     def test_non_us_east_1_location(
         self, s3_empty_bucket, cleanups, assert_host_customisation, aws_client_factory
     ):
@@ -101,6 +104,7 @@ class TestS3:
 
         assert_host_customisation(res["Location"])
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_multipart_upload(self, s3_bucket, assert_host_customisation, aws_client):
         key_name = f"key-{short_uid()}"
@@ -119,6 +123,7 @@ class TestS3:
 
         assert_host_customisation(res["Location"])
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_201_response(self, s3_bucket, assert_host_customisation, aws_client):
         key_name = f"key-{short_uid()}"
@@ -150,6 +155,7 @@ class TestSQS:
     * LOCALSTACK_HOST
     """
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_off_strategy_without_external_port(
         self, monkeypatch, sqs_create_queue, assert_host_customisation
@@ -162,6 +168,7 @@ class TestSQS:
         assert_host_customisation(queue_url)
         assert queue_name in queue_url
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_off_strategy_with_external_port(
         self, monkeypatch, sqs_create_queue, assert_host_customisation
@@ -181,6 +188,7 @@ class TestSQS:
         assert queue_name in queue_url
         assert f":{external_port}" in queue_url
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     @pytest.mark.parametrize("strategy", ["standard", "domain"])
     def test_domain_based_strategies(
@@ -194,6 +202,7 @@ class TestSQS:
         assert_host_customisation(queue_url)
         assert queue_name in queue_url
 
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_path_strategy(self, monkeypatch, sqs_create_queue, assert_host_customisation):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "path")
@@ -206,6 +215,7 @@ class TestSQS:
 
 
 class TestLambda:
+    @markers.requires_in_process
     @markers.aws.only_localstack
     def test_function_url(self, assert_host_customisation, create_lambda_function, aws_client):
         function_name = f"function-{short_uid()}"
@@ -226,6 +236,7 @@ class TestLambda:
 
         assert_host_customisation(function_url)
 
+    @markers.requires_in_process
     @pytest.mark.skip(reason="Not implemented for new provider (was tested for old provider)")
     @markers.aws.only_localstack
     def test_http_api_for_function_url(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We want to run more of our tests in Kubernetes. Adding the marker `requires_in_process` to tests that require to run in the same process with LocalStack to be successful will allow us to exclude them from the Kubernetes test suite.

related to UNC-69


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* Adds `markers.requires_in_process` in all tests that are failing when running against LS in K8s. These tests are using `monkeypatch` or `httpserver` fixtures or trying to access internal state of services which is not possible when running LS in a container.

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
