### PR TITLE
CFn: support nested properties in attribute lookup

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -570,13 +570,13 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
         else:
             arguments_list = arguments
 
-        if len(arguments_list) != 2:
+        if len(arguments_list) < 2:
             raise ValidationError(
                 "Template error: every Fn::GetAtt object requires two non-empty parameters, the resource name and the resource attribute"
             )
 
         logical_name_of_resource = arguments_list[0]
-        attribute_name = arguments_list[1]
+        attribute_name = ".".join(arguments_list[1:])
 
         node_resource = self._get_node_resource_for(
             resource_name=logical_name_of_resource,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

A [member of the community slack pointed out](https://localstack-community.slack.com/archives/CMAFN2KSP/p1761323426145939) that the new CloudFormation engine does not correctly support nested attribute lookups with the `Fn::Sub` intrinsic function. Namely

```yaml
Value:
    Fn::Sub: "my value ${db.Endpoint.Address}"
```

to get the address of an RDS db instance.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes

* If the arguments list in `ChangeSetModelPreproc._resolve_attribute` have more than 2 parts then assume the 1.. items should be joined with a `.` and pass to the resolver function

Fixes UNC-75


## Testing

This change is tested in the Pro repo as it contains the code needed to deploy an RDS db instance

<!-- Optional section: How to test these changes? -->
<!--

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
