### PR TITLE
fix asf updates by avoiding pip 25.3

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -26,7 +26,7 @@ jobs:
           python-version-file: '.python-version'
 
       - name: Install release helper dependencies
-        run: pip install --upgrade setuptools setuptools_scm uv
+        run: python3 -m pip install --upgrade setuptools setuptools_scm uv
 
       - name: Cache LocalStack community dependencies (venv)
         uses: actions/cache@v4
@@ -93,8 +93,8 @@ jobs:
           bin/release-helper.sh set-dep-ver awscli "==$AWSCLI_VERSION"
 
           # upgrade the requirements files only for the botocore package
-          # FIXME remove pin on pip-tools when https://github.com/jazzband/pip-tools/issues/2215 us resolved
-          pip install "pip-tools<7.5.0"
+          # TODO: Avoid pip 25.3 for now due to https://github.com/jazzband/pip-tools/issues/2252
+          python3 -m pip install --upgrade "pip!=25.3" pip-tools
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra runtime -o requirements-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra test -o requirements-test.txt pyproject.toml


### PR DESCRIPTION
## Motivation
Our weekly ASF update failed today because of an issue with `pip-compile`.
Turns out the latest version of `pip-compile` is not compatible with `pip==25.3`: https://github.com/jazzband/pip-tools/issues/2252
This PR avoids `pip==25.3` for now and unblocks `pip-tools`, hoping that with the next release of `pip` `pip-tools` will be compatible again.

## Changes
- Unpins `pip-tools`, which was pinned in #12947 (https://github.com/jazzband/pip-tools/issues/2215 was fixed in `pip-tools==7.5.1`).
- Explicitly avoids `pip==25.3` for now. 

## ToDo
- [x] Verify that the ASF updates are working again on this PR branch. Tested [with this action run](https://github.com/localstack/localstack/actions/runs/18836019766).
  - Test run was successful and created https://github.com/localstack/localstack/pull/13306.