### PR TITLE
avoid pip 25.3 to fix dependency updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ freeze:                   ## Run pip freeze -l in the virtual environment
 	@$(VENV_RUN); pip freeze -l
 
 upgrade-pinned-dependencies: venv
-	# FIXME remove pin on pip-tools when https://github.com/jazzband/pip-tools/issues/2215 us resolved
-	$(VENV_RUN); $(PIP_CMD) install --upgrade "pip-tools<7.5.0" pre-commit
+	# TODO: Avoid pip 25.3 for now due to https://github.com/jazzband/pip-tools/issues/2252
+	$(VENV_RUN); $(PIP_CMD) install --upgrade "pip!=25.3" pip-tools pre-commit
 	$(VENV_RUN); pip-compile --strip-extras --upgrade -o requirements-basic.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra runtime -o requirements-runtime.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra test -o requirements-test.txt pyproject.toml


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13305 we fixed the ASF updates in order to mitigate https://github.com/jazzband/pip-tools/issues/2252/. However, I forgot to update the command for the actual dependency update which failed today in the morning ([this run](https://github.com/localstack/localstack/actions/runs/18864681191)).
This PR follows up on that and fixes the dependency updates by again avoiding the latest version of `pip` for now.

## Changes
- Migrate the fix from #13305 to the make target updating the dependency pins.