### PR TITLE
Increase DNS server startup priority

### DIFF
--- a/localstack-core/localstack/dns/plugins.py
+++ b/localstack-core/localstack/dns/plugins.py
@@ -11,8 +11,12 @@ DNS_SHUTDOWN_PRIORITY = -30
 """Make sure the DNS server is shut down after the ON_AFTER_SERVICE_SHUTDOWN_HANDLERS, which in turn is after
 SERVICE_SHUTDOWN_PRIORITY. Currently this value needs to be less than -20"""
 
+DNS_START_PRIORITY = 20
+"""Make sure the DNS server is started before the pro activation, to ensure proper DNS resolution for the activate call,
+if the resolv.conf is set to localhost from outside the container"""
 
-@hooks.on_infra_start(priority=10)
+
+@hooks.on_infra_start(priority=DNS_START_PRIORITY)
 def start_dns_server():
     try:
         from localstack.dns import server


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

When the LocalStack Pro image starts it may make an external network request to the license server to fetch a new license. This process requires working DNS to be able to resolve `api.localstack.cloud` correctly.

When running in Kubernetes we configure the LocalStack pod to use itself as the DNS resolver, which in turn forwards unknown DNS requests to its configured upstream.

Currently both the license check and DNS server are started as plugins with the same priority, meaning that the order they start is unspecified - at least within the LocalStack code base. This has led to issues in Kubernetes where the license check starts first without a valid DNS server.



<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

* Increase the priority of the DNS server so that it starts before the license check

<!--
Summarise the changes proposed in the PR.
-->

## Related

Related to UNC-48
<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
