### PR TITLE
Update localstack.dev.kubernetes script to expose DNS port

### DIFF
--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -305,8 +305,7 @@ def generate_k8s_helm_overrides(
         },
         "dnsService": {
             "enabled": True,
-            "nodePortTcp": EDGE_SERVICE_DNS_PORT,
-            "nodePortUdp": EDGE_SERVICE_DNS_PORT,
+            "nodePort": EDGE_SERVICE_DNS_PORT,
         },
     }
     overrides = {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

We want to be able to expose the DNS port when running localstack on k8s for development. 
Companion helm-charts PR https://github.com/localstack/helm-charts/pull/146

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

* Modifies the `localstack.dev.kubernetes` script to create blocks for the DNS port configuration.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

Tested with the changed helm-charts.

<!--
Optional: How are the proposed changes tested?
-->

## Related

related to UNC-69

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
