### PR TITLE
Add marker for skipping k8s tests

### DIFF
--- a/localstack-core/localstack/testing/pytest/marking.py
+++ b/localstack-core/localstack/testing/pytest/marking.py
@@ -78,6 +78,8 @@ class Markers:
     """Tests to execute when updating snapshots for a new Lambda runtime"""
     k8s_always_run = pytest.mark.k8s_always_run
     """This tests will always run against k8s environment"""
+    skip_k8s = pytest.mark.skip_k8s
+    """This test will be skipped in k8s environment"""
 
 
 # pytest plugin


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Some tests may not be able to run in the Kubernetes test pipeline. We should be able to use a marker to skip them.

## Changes

Introduces a new marker that will be used to skip some tests when running the Kubernetes test pipeline.

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
