### PR TITLE
Change one of the test domains for the DNS tests

### DIFF
--- a/tests/unit/test_dns_server.py
+++ b/tests/unit/test_dns_server.py
@@ -301,19 +301,19 @@ class TestDNSServer:
         """Test adding and deleting aliases"""
         dns_server.add_host("example.org", TargetRecord("122.122.122.122", RecordType.A))
         dns_server.add_alias(
-            source_name="foo.something.org",
+            source_name="foo.example.org",
             record_type=RecordType.A,
             target=AliasTarget(target="example.org"),
         )
-        answer = query_dns("foo.something.org", "A")
+        answer = query_dns("foo.example.org", "A")
         assert answer.answer
         assert "122.122.122.122" in answer.to_text()
 
         # delete alias and try again
         dns_server.delete_alias(
-            source_name="foo.something.org", record_type=RecordType.A, target=AliasTarget(target="")
+            source_name="foo.example.org", record_type=RecordType.A, target=AliasTarget(target="")
         )
-        answer = query_dns("foo.something.org", "A")
+        answer = query_dns("foo.example.org", "A")
         assert not answer.answer
 
         # check if add_host is still available
@@ -420,7 +420,7 @@ class TestDNSServer:
 
         with pytest.raises(ValueError):
             dns_server.delete_alias(
-                source_name="foo.something.org",
+                source_name="foo.example.org",
                 record_type=RecordType.A,
                 target=AliasTarget(target=""),
             )


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Recent test failures showed the `foo.something.org` domain we used for testing resolving to an unexpected IP address. It seems the domain owner, a domain reseller, started resolving this domain to some IP.

Even though this seems to have changed again since, we should not take the risk in the future.

Fixes ENG-104

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Change `something.org` to `example.org` in tests querying the name servers of a domain.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
