### PR TITLE
services/logs: Add ListLogGroups operation

### DIFF
--- a/tests/aws/services/logs/test_logs.py
+++ b/tests/aws/services/logs/test_logs.py
@@ -166,9 +166,9 @@ class TestCloudWatchLogs:
             # TODO 'describe-log-groups' returns different attributes on AWS when using
             #   'logGroupNamePattern' compared to 'logGroupNamePrefix' (for the same log group)
             #    seems like a weird issue on AWS side, we just exclude the paths here for this particular call
-            "$..describe-log-groups-pattern.logGroups..metricFilterCount",
             "$..describe-log-groups-pattern.logGroups..storedBytes",
             "$..describe-log-groups-pattern.nextToken",
+            "$..list-log-groups-pattern-match.nextToken",
         ]
     )
     @markers.aws.validated
@@ -203,6 +203,13 @@ class TestCloudWatchLogs:
                 logGroupNamePattern=logs_log_group, logGroupNamePrefix=logs_log_group
             )
         snapshot.match("error-describe-logs-group", ctx.value.response)
+
+        response = aws_client.logs.list_log_groups(logGroupNamePattern="no-such-group")
+        snapshot.match("list-log-groups-pattern-no-match", response)
+        response = aws_client.logs.list_log_groups(
+            logGroupNamePattern=logs_log_group.split("-")[-1]
+        )
+        snapshot.match("list-log-groups-pattern-match", response)
 
         aws_client.logs.create_log_stream(logGroupName=logs_log_group, logStreamName=test_name)
         log_streams_between = aws_client.logs.describe_log_streams(logGroupName=logs_log_group).get(

--- a/tests/aws/services/logs/test_logs.snapshot.json
+++ b/tests/aws/services/logs/test_logs.snapshot.json
@@ -140,13 +140,15 @@
     }
   },
   "tests/aws/services/logs/test_logs.py::TestCloudWatchLogs::test_create_and_delete_log_stream": {
-    "recorded-date": "06-04-2023, 11:42:42",
+    "recorded-date": "05-11-2025, 17:25:32",
     "recorded-content": {
       "describe-log-groups-prefix": {
         "logGroups": [
           {
             "arn": "arn:<partition>:logs:<region>:111111111111:log-group:<log-group-name:1>:*",
             "creationTime": "timestamp",
+            "logGroupArn": "arn:<partition>:logs:<region>:111111111111:log-group:<log-group-name:1>",
+            "logGroupClass": "STANDARD",
             "logGroupName": "<log-group-name:1>",
             "metricFilterCount": 0,
             "storedBytes": 0
@@ -162,7 +164,10 @@
           {
             "arn": "arn:<partition>:logs:<region>:111111111111:log-group:<log-group-name:1>:*",
             "creationTime": "timestamp",
-            "logGroupName": "<log-group-name:1>"
+            "logGroupArn": "arn:<partition>:logs:<region>:111111111111:log-group:<log-group-name:1>",
+            "logGroupClass": "STANDARD",
+            "logGroupName": "<log-group-name:1>",
+            "metricFilterCount": 0
           }
         ],
         "nextToken": "<next_token>",
@@ -179,6 +184,27 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      },
+      "list-log-groups-pattern-no-match": {
+        "logGroups": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-log-groups-pattern-match": {
+        "logGroups": [
+          {
+            "logGroupArn": "arn:<partition>:logs:<region>:111111111111:log-group:<log-group-name:1>",
+            "logGroupClass": "STANDARD",
+            "logGroupName": "<log-group-name:1>"
+          }
+        ],
+        "nextToken": "<next_token>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "logs_log_group": [

--- a/tests/aws/services/logs/test_logs.validation.json
+++ b/tests/aws/services/logs/test_logs.validation.json
@@ -3,7 +3,13 @@
     "last_validated_date": "2024-05-24T13:57:11+00:00"
   },
   "tests/aws/services/logs/test_logs.py::TestCloudWatchLogs::test_create_and_delete_log_stream": {
-    "last_validated_date": "2023-04-06T09:42:42+00:00"
+    "last_validated_date": "2025-11-05T17:25:41+00:00",
+    "durations_in_seconds": {
+      "setup": 1.91,
+      "call": 3.46,
+      "teardown": 0.16,
+      "total": 5.53
+    }
   },
   "tests/aws/services/logs/test_logs.py::TestCloudWatchLogs::test_filter_log_events_response_header": {
     "last_validated_date": "2024-05-24T13:58:30+00:00"


### PR DESCRIPTION
## Motivation

This was one operation flagged as missing in our parity reports, and seemed like an easy fix.

## Changes

Added a simple implementation, along the lines of that for `DescribeLogGroups`. Note that both operations ignore the optional parameters `accountIdentifiers` and `includeLinkedAccounts`. ~Additionally, Moto does not seem to have a representation of `logGroupClass`, so I have opted to leave that blank: it might be preferable to always return "STANDARD", as captured in the snapshot, but I'm unsure what's best.~

## Tests

Added snapshot tests alongside those for `DescribeLogGroups`.
