### PR TITLE
Add support for recipient for KMS Decrypt

### DIFF
--- a/localstack-core/localstack/services/kms/provider.py
+++ b/localstack-core/localstack/services/kms/provider.py
@@ -4,11 +4,12 @@ import datetime
 import logging
 import os
 
-from cbor2._decoder import loads as cbor2_loads
+from cbor2 import loads as cbor2_loads
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, keywrap
 from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 
 from localstack.aws.api import CommonServiceException, RequestContext, handler
@@ -1588,7 +1589,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                     f" constraint: [Member must satisfy enum value set: {VALID_OPERATIONS}]"
                 )
 
-    def _extract_attestation_pubkey(self, attestation_document: bytes):
+    def _extract_attestation_pubkey(self, attestation_document: bytes) -> RSAPublicKey:
         # The attestation document comes as a COSE (CBOR Object Signing and Encryption) object: the CBOR
         # attestation is signed and then the attestation and signature are again CBOR-encoded.  For now
         # we don't bother validating the signature, though in the future we could.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "dnspython>=1.16.0",
     "plux>=1.10",
     "psutil>=5.4.8",
-    "pycryptodome>=3.19.0",
     "python-dotenv>=0.19.1",
     "pyyaml>=5.1",
     "rich>=12.3.0",

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -129,8 +129,6 @@ psutil==7.1.2
     # via localstack-core (pyproject.toml)
 pycparser==2.23
     # via cffi
-pycryptodome==3.23.0
-    # via localstack-core (pyproject.toml)
 pygments==2.19.2
     # via rich
 pyopenssl==25.3.0

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -36,8 +36,6 @@ psutil==7.1.2
     # via localstack-core (pyproject.toml)
 pycparser==2.23
     # via cffi
-pycryptodome==3.23.0
-    # via localstack-core (pyproject.toml)
 pygments==2.19.2
     # via rich
 python-dotenv==1.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -344,10 +344,6 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pycryptodome==3.23.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 pydantic==2.12.3
     # via
     #   aws-sam-translator

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -241,10 +241,6 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pycryptodome==3.23.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 pydantic==2.12.3
     # via
     #   aws-sam-translator

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -303,10 +303,6 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pycryptodome==3.23.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 pydantic==2.12.3
     # via
     #   aws-sam-translator

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -554,10 +554,6 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.23
     # via cffi
-pycryptodome==3.23.0
-    # via
-    #   localstack-core
-    #   localstack-core (pyproject.toml)
 pydantic==2.12.3
     # via
     #   aws-sam-translator


### PR DESCRIPTION
## Motivation

Add support for the KMS Decrypt `Recipient` field.  This is used by Nitro Enclaves to decrypt sensitive without their host being able to read it, by KMS re-encrypting the decrypted data to the provided RSA key before it is returned to the caller.  This flow is described [here](https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html#KMS-Decrypt-request-Recipient).

## Changes

I've added basic support to the KMS Decrypt command for the Recipient field by looking for the attestation, parsing it to extract the recipient public key, and returning `CiphertextForRecipient` instead of `Plaintext`.  It's not clear to me how to simulate verifying the attestation (which involves a signature from AWS that the PCR values are correct) without a significant effort to add proper support for Nitro to Localstack, and I think this PR as-is provides valuable functionality by allowing systems that use Nitro and KMS to be tested against Localstack without having to special-case their calls to Localstack's KMS implementation.  So, I don't attempt to do any validation on the provided attestation document beyond what is required to extract the recipient public key.

I've unfortunately had to do a significant amount of manual crypto operations here with `asn1crypto` and `PyCryptoDome` because `cryptography.hazmat` doesn't appear to support the exact algorithms that AWS uses; I apologize for the verbosity and am happy to change it to `cryptography.hazmat` if there is a way to use it. 

I've taken a compromise approach to ensuring that this change is backwards-compatible; if callers pass in a nonsense value to `Recipient` it will be logged and ignored and `Plaintext` will be returned, but if an attestation with a valid public key is passed in then `CiphertextForRecipient` instead of `Plaintext` will be returned.  It is more to spec to error if a nonsense value is passed in for `Recipient` but that feels a bit more breaking.  I'm happy to change to erroring if the maintainers would prefer that now, or it could be done as part of the next major release or similar.

## Tests

I've added basic tests for the functionality.  I've had to mark them as `only_localstack` because it is quite complex to call AWS to set up an actual Nitro Enclave, and until Localstack has broader Nitro support I think this will suffice to test.  They do test that the flow works end to end.  In addition, I have manually tested that this implementation produces a PKCS7 envelope similar to what actual AWS produces for an actual Nitro Enclave, and I have manually tested that my application that works on actual Nitro and KMS works against this PR.

## Related

Addresses https://github.com/localstack/localstack/issues/12901.
