### PR TITLE
Change error code from 500 to 501 in case plugin is not available in users license

### DIFF
--- a/localstack-core/localstack/aws/handlers/service.py
+++ b/localstack-core/localstack/aws/handlers/service.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Any
 
 from botocore.model import OperationModel, ServiceModel
+from plux.core.plugin import PluginDisabled
 
 from localstack import config
 from localstack.http import Response
@@ -224,11 +225,12 @@ class ServiceExceptionSerializer(ExceptionHandler):
 
             # Check for license restricted plugin message and set status code to 501
             if (
-                hasattr(exception, "reason")
+                isinstance(exception, PluginDisabled)
                 and "not part of the active license agreement"
                 in str(getattr(exception, "reason", "")).lower()
             ):
                 status_code = 501
+                msg = f"exception while calling {service_name}.{operation.name}: {str(getattr(exception, 'reason', ''))}"
             else:
                 status_code = 501 if config.FAIL_FAST else 500
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Change error code from 500 to 501 in case the plugin is not part of the active license agreement and modify the error message to plugin details. 

Eg: `localstack.aws.api.core.CommonServiceException: exception while calling cloudtrail.CreateTrail: plugin localstack.aws.provider:cloudtrail:pro is disabled, reason: This feature is not part of the active license agreement` should return 501. 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Set status code to `501` if when creating the error response in the handler and error message removes plugin details. 

<!--
Summarise the changes proposed in the PR.
-->

## Tests
This was tested by manually intervening the license activation process in the core repo by not updating, validating and saving the license file.

<!--
Optional: How are the proposed changes tested?
-->

## Related
Fixes [FLC-97](https://linear.app/localstack/issue/FLC-97/change-error-code-from-500-to-501-in-case-plugin-is-not-available-in
)
<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
