### PR TITLE
OpenSearch: Disable SSL validation for unsupported regions

### DIFF
--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -99,6 +99,21 @@ def try_cluster_health(cluster_url: str):
     ], "expected cluster state to be in a valid state"
 
 
+@pytest.fixture(autouse=True)
+def disable_ssl_validation_for_unsupported_regions(region_name, monkeypatch):
+    # list of regions supported in our certificate
+    # prevents SSL verification for regional hostnames not present in the SAN list of the certificate
+    if region_name not in {
+        "eu-central-1",
+        "eu-west-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+    }:
+        monkeypatch.setattr(requests, "verify_ssl", False)
+
+
 @markers.skip_offline
 class TestOpensearchProvider:
     """


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
With #13275, we generally enabled SSL certificate validation for our requests clients.
However, this leads to an issue with non-default-region tests ([example](https://github.com/localstack/localstack/actions/runs/19121814278/job/54666984653)), with regional endpoints for regions not present in our `localhost.localstack.cloud` certificates SAN list.

This leads to flakes in our pipeline, every time an `ap-southeast-*` region is used.

With this fix, we disable certificate validation _only_ for opensearch and the regions not supported by the certificate.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Disable certificate validation for opensearch tests in regions not present in our certificate

<!--
Summarise the changes proposed in the PR.
-->

## Tests
* Run `test_opensearch.py` using `TEST_AWS_REGION_NAME=ap-northeast-1`

<!--
Optional: How are the proposed changes tested?
-->

## Related
Fixes ENG-112
Fixes FLC-152

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
