### PR TITLE
Lambda: Support python3.14 and java25 runtimes

### DIFF
--- a/localstack-core/localstack/services/lambda_/api_utils.py
+++ b/localstack-core/localstack/services/lambda_/api_utils.py
@@ -722,7 +722,9 @@ def validate_layer_runtimes_and_architectures(
         validations.append(validation_msg)
 
     if compatible_architectures and set(compatible_architectures).difference(ARCHITECTURES):
-        constraint = "[Member must satisfy enum value set: [x86_64, arm64]]"
+        constraint = (
+            "[Member must satisfy enum value set: [x86_64, arm64], Member must not be null]"
+        )
         validation_msg = f"Value '[{', '.join(list(compatible_architectures))}]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: {constraint}"
         validations.append(validation_msg)
 

--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -3728,7 +3728,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if not layer_version:
             raise ValidationException(
                 f"1 validation error detected: Value '{arn}' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: "
-                + "(arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+)"
+                + "(arn:(aws[a-zA-Z-]*)?:lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+)"
             )
 
         store = lambda_stores[account_id][region_name]

--- a/localstack-core/localstack/services/lambda_/runtimes.py
+++ b/localstack-core/localstack/services/lambda_/runtimes.py
@@ -23,7 +23,7 @@ from localstack.aws.api.lambda_ import Runtime
 # 5. Run the unit test to check the runtime setup:
 # tests.unit.services.lambda_.test_api_utils.TestApiUtils.test_check_runtime
 # 6. Review special tests including:
-# a) [ext] tests.aws.services.lambda_.test_lambda_endpoint_injection
+# a) [pro] tests.aws.services.lambda_.test_lambda_endpoint_injection
 # 7. Before merging, run the ext integration tests to cover transparent endpoint injection testing.
 # 8. Add the new runtime to the K8 image build: https://github.com/localstack/lambda-images
 # 9. Inform the web team to update the resource browser (consider offering an endpoint in the future)
@@ -40,6 +40,7 @@ IMAGE_MAPPING: dict[Runtime, str] = {
     Runtime.nodejs16_x: "nodejs:16",
     Runtime.nodejs14_x: "nodejs:14",  # deprecated Dec 4, 2023  => Jan 9, 2024  => Feb 8, 2024
     Runtime.nodejs12_x: "nodejs:12",  # deprecated Mar 31, 2023 => Mar 31, 2023 => Apr 30, 2023
+    Runtime.python3_14: "python:3.14",
     Runtime.python3_13: "python:3.13",
     Runtime.python3_12: "python:3.12",
     Runtime.python3_11: "python:3.11",
@@ -47,6 +48,7 @@ IMAGE_MAPPING: dict[Runtime, str] = {
     Runtime.python3_9: "python:3.9",
     Runtime.python3_8: "python:3.8",
     Runtime.python3_7: "python:3.7",  # deprecated Dec 4, 2023 => Jan 9, 2024 => Feb 8, 2024
+    Runtime.java25: "java:25",
     Runtime.java21: "java:21",
     Runtime.java17: "java:17",
     Runtime.java11: "java:11",
@@ -116,6 +118,7 @@ RUNTIMES_AGGREGATED = {
         Runtime.nodejs16_x,
     ],
     "python": [
+        Runtime.python3_14,
         Runtime.python3_13,
         Runtime.python3_12,
         Runtime.python3_11,
@@ -124,6 +127,7 @@ RUNTIMES_AGGREGATED = {
         Runtime.python3_8,
     ],
     "java": [
+        Runtime.java25,
         Runtime.java21,
         Runtime.java17,
         Runtime.java11,
@@ -155,12 +159,13 @@ SNAP_START_SUPPORTED_RUNTIMES = [
     Runtime.java11,
     Runtime.java17,
     Runtime.java21,
+    Runtime.java25,
     Runtime.python3_12,
     Runtime.python3_13,
     Runtime.dotnet8,
 ]
 
 # An ordered list of all Lambda runtimes considered valid by AWS. Matching snapshots in test_create_lambda_exceptions
-VALID_RUNTIMES: str = "[nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]"
+VALID_RUNTIMES: str = "[nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]"
 # An ordered list of all Lambda runtimes for layers considered valid by AWS. Matching snapshots in test_layer_exceptions
-VALID_LAYER_RUNTIMES: str = "[ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java25, java17, nodejs, nodejs4.3, java8.al2, go1.x, dotnet10, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs24.x, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, python3.14, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby3.4, ruby2.5, python3.6, python2.7]"
+VALID_LAYER_RUNTIMES: str = "[ruby3.5, ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java25, java17, nodejs, nodejs4.3, java8.al2, go1.x, dotnet10, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs24.x, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, nodejs26.x, python3.13, python3.14, nodejs16.x, python3.15, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby3.4, ruby2.5, python3.6, python2.7]"

--- a/tests/aws/services/lambda_/test_lambda_api.py
+++ b/tests/aws/services/lambda_/test_lambda_api.py
@@ -11,6 +11,7 @@ Don't add tests for asynchronous, blocking or implicit behavior here.
 
 import base64
 import io
+import itertools
 import json
 import logging
 import re
@@ -6198,7 +6199,7 @@ class TestLambdaLayer:
     @markers.lambda_runtime_update
     @markers.aws.validated
     # AWS only allows a max of 15 compatible runtimes, split runtimes and run two tests
-    @pytest.mark.parametrize("runtimes", [ALL_RUNTIMES[:14], ALL_RUNTIMES[14:]])
+    @pytest.mark.parametrize("runtimes", list(itertools.batched(ALL_RUNTIMES, 15)))
     def test_layer_compatibilities(self, snapshot, dummylayer, cleanups, aws_client, runtimes):
         """Creates a single layer which is compatible with all"""
         layer_name = f"testlayer-{short_uid()}"

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -7853,7 +7853,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "01-04-2025, 13:08:21",
+    "recorded-date": "06-11-2025, 11:54:01",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7868,10 +7868,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7880,10 +7880,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7925,7 +7925,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "01-04-2025, 13:09:51",
+    "recorded-date": "06-11-2025, 11:54:03",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -7940,10 +7940,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -7952,10 +7952,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -8265,7 +8265,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "01-04-2025, 13:19:20",
+    "recorded-date": "06-11-2025, 11:54:14",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8292,7 +8292,7 @@
       "list_layers_exc_compatibleruntime_invalid": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java25, java17, nodejs, nodejs4.3, java8.al2, go1.x, dotnet10, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs24.x, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, python3.13, python3.14, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby3.4, ruby2.5, python3.6, python2.7]"
+          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby3.5, ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, java21, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, dotnet8, java25, java17, nodejs, nodejs4.3, java8.al2, go1.x, dotnet10, nodejs20.x, go1.9, byol, nodejs10.x, provided.al2023, nodejs22.x, python3.10, java8, nodejs12.x, python3.11, nodejs24.x, nodejs8.x, python3.12, nodejs14.x, nodejs8.9, nodejs26.x, python3.13, python3.14, nodejs16.x, python3.15, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby3.3, ruby3.4, ruby2.5, python3.6, python2.7]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8367,7 +8367,7 @@
       "get_layer_version_by_arn_exc_invalidarn": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+)"
+          "Message": "1 validation error detected: Value 'arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>' at 'arn' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+)"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8443,7 +8443,7 @@
       "publish_layer_version_exc_invalid_runtime_arch": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64], Member must not be null]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -8453,7 +8453,7 @@
       "publish_layer_version_exc_partially_invalid_values": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64]]"
+          "Message": "2 validation errors detected: Value '[invalidruntime, invalidruntime2, nodejs20.x]' at 'compatibleRuntimes' failed to satisfy constraint: Member must satisfy enum value set: [nodejs20.x, python3.14, provided.al2023, python3.12, python3.13, nodejs22.x, java17, nodejs16.x, java25, dotnet8, python3.10, java11, python3.11, dotnet6, java21, nodejs18.x, provided.al2, ruby3.3, ruby3.4, java8.al2, ruby3.2, python3.8, python3.9]; Value '[invalidarch, x86_64]' at 'compatibleArchitectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64], Member must not be null]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -12886,7 +12886,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java11]": {
-    "recorded-date": "01-04-2025, 13:30:54",
+    "recorded-date": "06-11-2025, 11:54:16",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -13030,7 +13030,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java17]": {
-    "recorded-date": "01-04-2025, 13:30:58",
+    "recorded-date": "06-11-2025, 11:54:19",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -13527,7 +13527,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "recorded-date": "01-04-2025, 13:12:59",
+    "recorded-date": "06-11-2025, 12:04:49",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13541,6 +13541,7 @@
           "nodejs16.x",
           "nodejs14.x",
           "nodejs12.x",
+          "python3.14",
           "python3.13",
           "python3.12",
           "python3.11",
@@ -13548,7 +13549,7 @@
           "python3.9",
           "python3.8",
           "python3.7",
-          "java21"
+          "java25"
         ],
         "Content": {
           "CodeSha256": "<code-sha256:1>",
@@ -13568,7 +13569,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "recorded-date": "01-04-2025, 13:13:03",
+    "recorded-date": "06-11-2025, 12:04:52",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -13576,6 +13577,7 @@
           "x86_64"
         ],
         "CompatibleRuntimes": [
+          "java21",
           "java17",
           "java11",
           "java8.al2",
@@ -13589,8 +13591,7 @@
           "ruby3.2",
           "ruby2.7",
           "provided.al2023",
-          "provided.al2",
-          "provided"
+          "provided.al2"
         ],
         "Content": {
           "CodeSha256": "<code-sha256:1>",
@@ -13664,7 +13665,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java21]": {
-    "recorded-date": "01-04-2025, 13:31:02",
+    "recorded-date": "06-11-2025, 11:54:21",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -15944,7 +15945,7 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "recorded-date": "01-04-2025, 13:02:29",
+    "recorded-date": "06-11-2025, 11:53:59",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -15961,7 +15962,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "recorded-date": "01-04-2025, 13:02:29",
+    "recorded-date": "06-11-2025, 11:53:59",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -15978,7 +15979,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "recorded-date": "01-04-2025, 13:02:30",
+    "recorded-date": "06-11-2025, 11:53:59",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -15995,7 +15996,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "recorded-date": "01-04-2025, 13:02:30",
+    "recorded-date": "06-11-2025, 11:54:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16012,7 +16013,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "recorded-date": "01-04-2025, 13:02:30",
+    "recorded-date": "06-11-2025, 11:54:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16029,7 +16030,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "recorded-date": "01-04-2025, 13:02:30",
+    "recorded-date": "06-11-2025, 11:54:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16046,7 +16047,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "recorded-date": "01-04-2025, 13:02:31",
+    "recorded-date": "06-11-2025, 11:54:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -16063,7 +16064,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "recorded-date": "01-04-2025, 13:02:31",
+    "recorded-date": "06-11-2025, 11:54:00",
     "recorded-content": {
       "deprecation_error": {
         "Error": {
@@ -17947,7 +17948,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.13]": {
-    "recorded-date": "01-04-2025, 13:31:11",
+    "recorded-date": "06-11-2025, 11:54:28",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18091,7 +18092,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.12]": {
-    "recorded-date": "01-04-2025, 13:31:07",
+    "recorded-date": "06-11-2025, 11:54:26",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18316,7 +18317,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet8]": {
-    "recorded-date": "01-04-2025, 13:31:15",
+    "recorded-date": "06-11-2025, 11:54:31",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18460,7 +18461,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
-    "recorded-date": "01-04-2025, 13:40:26",
+    "recorded-date": "06-11-2025, 11:54:33",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18552,7 +18553,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
-    "recorded-date": "01-04-2025, 13:40:32",
+    "recorded-date": "06-11-2025, 11:54:35",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18644,7 +18645,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java21]": {
-    "recorded-date": "01-04-2025, 13:40:35",
+    "recorded-date": "06-11-2025, 11:54:38",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18736,7 +18737,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.12]": {
-    "recorded-date": "01-04-2025, 13:40:40",
+    "recorded-date": "06-11-2025, 11:54:42",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18828,7 +18829,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.13]": {
-    "recorded-date": "01-04-2025, 13:40:44",
+    "recorded-date": "06-11-2025, 11:54:44",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -18920,7 +18921,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet8]": {
-    "recorded-date": "01-04-2025, 13:40:47",
+    "recorded-date": "06-11-2025, 11:54:47",
     "recorded-content": {
       "create_function_response": {
         "Architectures": [
@@ -19060,6 +19061,270 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java25]": {
+    "recorded-date": "06-11-2025, 11:54:24",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java25",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_function_response_latest": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "echo.Handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 1024,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "java25",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 5,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_version_1": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "version1",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "echo.Handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 1024,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "java25",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 5,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java25]": {
+    "recorded-date": "06-11-2025, 11:54:40",
+    "recorded-content": {
+      "create_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java25",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java25",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes2]": {
+    "recorded-date": "06-11-2025, 12:04:57",
+    "recorded-content": {
+      "publish_result": {
+        "CompatibleArchitectures": [
+          "arm64",
+          "x86_64"
+        ],
+        "CompatibleRuntimes": [
+          "provided"
+        ],
+        "Content": {
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Location": "<layer-location>"
+        },
+        "CreatedDate": "date",
+        "Description": "",
+        "LayerArn": "arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>",
+        "LayerVersionArn": "arn:<partition>:lambda:<region>:111111111111:layer:<resource:1>:1",
+        "Version": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         }
       }
     }

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -75,7 +75,13 @@
     "last_validated_date": "2024-04-10T08:58:47+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "last_validated_date": "2025-04-01T13:08:49+00:00"
+    "last_validated_date": "2025-11-06T11:54:01+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.49,
+      "teardown": 0.01,
+      "total": 0.51
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
     "last_validated_date": "2024-09-12T11:29:32+00:00"
@@ -447,7 +453,13 @@
     "last_validated_date": "2024-09-12T11:29:23+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "last_validated_date": "2025-04-01T13:10:29+00:00"
+    "last_validated_date": "2025-11-06T11:54:03+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.8,
+      "teardown": 0.21,
+      "total": 2.02
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaFunction::test_vpc_config": {
     "last_validated_date": "2024-09-12T11:34:40+00:00"
@@ -465,13 +477,40 @@
     "last_validated_date": "2024-04-10T09:10:37+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes0]": {
-    "last_validated_date": "2025-04-01T13:14:56+00:00"
+    "last_validated_date": "2025-11-06T12:04:49+00:00",
+    "durations_in_seconds": {
+      "setup": 1.1,
+      "call": 4.75,
+      "teardown": 0.08,
+      "total": 5.93
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes1]": {
-    "last_validated_date": "2025-04-01T13:15:00+00:00"
+    "last_validated_date": "2025-11-06T12:04:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.93,
+      "teardown": 0.07,
+      "total": 3.01
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_compatibilities[runtimes2]": {
+    "last_validated_date": "2025-11-06T12:04:57+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 4.57,
+      "teardown": 0.07,
+      "total": 4.65
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "last_validated_date": "2025-04-01T13:19:40+00:00"
+    "last_validated_date": "2025-11-06T11:54:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 9.31,
+      "teardown": 0.1,
+      "total": 9.42
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
     "last_validated_date": "2024-04-10T09:23:18+00:00"
@@ -570,40 +609,130 @@
     "last_validated_date": "2025-03-31T16:15:53+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[dotnet8]": {
-    "last_validated_date": "2025-04-01T13:31:14+00:00"
+    "last_validated_date": "2025-11-06T11:54:31+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.2,
+      "teardown": 0.28,
+      "total": 2.49
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java11]": {
-    "last_validated_date": "2025-04-01T13:30:54+00:00"
+    "last_validated_date": "2025-11-06T11:54:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.29,
+      "teardown": 0.28,
+      "total": 2.58
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java17]": {
-    "last_validated_date": "2025-04-01T13:30:57+00:00"
+    "last_validated_date": "2025-11-06T11:54:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.25,
+      "teardown": 0.29,
+      "total": 2.55
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java21]": {
-    "last_validated_date": "2025-04-01T13:31:02+00:00"
+    "last_validated_date": "2025-11-06T11:54:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.17,
+      "teardown": 0.32,
+      "total": 2.5
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[java25]": {
+    "last_validated_date": "2025-11-06T11:54:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.25,
+      "teardown": 0.27,
+      "total": 2.53
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.12]": {
-    "last_validated_date": "2025-04-01T13:31:06+00:00"
+    "last_validated_date": "2025-11-06T11:54:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.04,
+      "teardown": 0.26,
+      "total": 2.31
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle[python3.13]": {
-    "last_validated_date": "2025-04-01T13:31:10+00:00"
+    "last_validated_date": "2025-11-06T11:54:28+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.02,
+      "teardown": 0.28,
+      "total": 2.31
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[dotnet8]": {
-    "last_validated_date": "2025-04-01T13:42:13+00:00"
+    "last_validated_date": "2025-11-06T11:54:47+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.03,
+      "teardown": 0.25,
+      "total": 2.29
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java11]": {
-    "last_validated_date": "2025-04-01T13:41:52+00:00"
+    "last_validated_date": "2025-11-06T11:54:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.03,
+      "teardown": 0.21,
+      "total": 2.25
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java17]": {
-    "last_validated_date": "2025-04-01T13:41:56+00:00"
+    "last_validated_date": "2025-11-06T11:54:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.1,
+      "teardown": 0.23,
+      "total": 2.34
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java21]": {
-    "last_validated_date": "2025-04-01T13:42:01+00:00"
+    "last_validated_date": "2025-11-06T11:54:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.12,
+      "teardown": 0.25,
+      "total": 2.38
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[java25]": {
+    "last_validated_date": "2025-11-06T11:54:40+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.01,
+      "teardown": 0.27,
+      "total": 2.29
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.12]": {
-    "last_validated_date": "2025-04-01T13:42:04+00:00"
+    "last_validated_date": "2025-11-06T11:54:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.88,
+      "teardown": 0.23,
+      "total": 2.12
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration[python3.13]": {
-    "last_validated_date": "2025-04-01T13:42:08+00:00"
+    "last_validated_date": "2025-11-06T11:54:44+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.87,
+      "teardown": 0.32,
+      "total": 2.2
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaTag::test_create_tag_on_esm_create": {
     "last_validated_date": "2024-10-24T14:16:05+00:00"
@@ -690,27 +819,75 @@
     "last_validated_date": "2024-06-05T11:49:05+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "last_validated_date": "2025-04-01T13:06:04+00:00"
+    "last_validated_date": "2025-11-06T11:54:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.16,
+      "teardown": 0.01,
+      "total": 0.18
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "last_validated_date": "2025-04-01T13:06:03+00:00"
+    "last_validated_date": "2025-11-06T11:53:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.17,
+      "teardown": 0.01,
+      "total": 0.19
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "last_validated_date": "2025-04-01T13:06:03+00:00"
+    "last_validated_date": "2025-11-06T11:53:59+00:00",
+    "durations_in_seconds": {
+      "setup": 11.88,
+      "call": 0.32,
+      "teardown": 0.01,
+      "total": 12.21
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "last_validated_date": "2025-04-01T13:06:05+00:00"
+    "last_validated_date": "2025-11-06T11:54:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.16,
+      "teardown": 0.01,
+      "total": 0.18
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "last_validated_date": "2025-04-01T13:06:04+00:00"
+    "last_validated_date": "2025-11-06T11:54:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.13,
+      "teardown": 0.01,
+      "total": 0.15
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "last_validated_date": "2025-04-01T13:06:04+00:00"
+    "last_validated_date": "2025-11-06T11:53:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.17,
+      "teardown": 0.01,
+      "total": 0.19
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "last_validated_date": "2025-04-01T13:06:04+00:00"
+    "last_validated_date": "2025-11-06T11:54:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.12,
+      "teardown": 0.01,
+      "total": 0.14
+    }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "last_validated_date": "2025-04-01T13:06:04+00:00"
+    "last_validated_date": "2025-11-06T11:54:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 0.16,
+      "teardown": 0.02,
+      "total": 0.19
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_common.snapshot.json
@@ -1,70 +1,70 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "31-03-2025, 12:14:56",
+    "recorded-date": "06-11-2025, 11:55:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "31-03-2025, 12:15:23",
+    "recorded-date": "06-11-2025, 11:55:47",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "31-03-2025, 12:17:30",
+    "recorded-date": "06-11-2025, 11:56:24",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "31-03-2025, 12:15:42",
+    "recorded-date": "06-11-2025, 11:55:51",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "recorded-date": "31-03-2025, 12:15:54",
+    "recorded-date": "06-11-2025, 11:55:55",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "recorded-date": "31-03-2025, 12:14:05",
+    "recorded-date": "06-11-2025, 11:55:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "recorded-date": "31-03-2025, 12:15:14",
+    "recorded-date": "06-11-2025, 11:55:42",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "31-03-2025, 12:13:11",
+    "recorded-date": "06-11-2025, 11:54:59",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "recorded-date": "31-03-2025, 12:15:05",
+    "recorded-date": "06-11-2025, 11:55:39",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "recorded-date": "31-03-2025, 12:17:17",
+    "recorded-date": "06-11-2025, 11:56:17",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "31-03-2025, 12:14:39",
+    "recorded-date": "06-11-2025, 11:55:26",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "recorded-date": "31-03-2025, 12:14:20",
+    "recorded-date": "06-11-2025, 11:55:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "recorded-date": "31-03-2025, 12:13:57",
+    "recorded-date": "06-11-2025, 11:55:15",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "recorded-date": "31-03-2025, 12:12:59",
+    "recorded-date": "06-11-2025, 11:54:55",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "31-03-2025, 12:16:46",
+    "recorded-date": "06-11-2025, 11:56:07",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "31-03-2025, 12:13:31",
+    "recorded-date": "06-11-2025, 11:55:03",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "17-06-2025, 09:51:26",
+    "recorded-date": "06-11-2025, 11:56:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -135,12 +135,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -151,7 +151,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "handler.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
@@ -179,12 +179,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -195,7 +195,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "handler.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
@@ -205,7 +205,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "17-06-2025, 09:51:40",
+    "recorded-date": "06-11-2025, 11:57:01",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -344,7 +344,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "17-06-2025, 09:52:11",
+    "recorded-date": "06-11-2025, 11:57:28",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -477,7 +477,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "17-06-2025, 09:51:44",
+    "recorded-date": "06-11-2025, 11:57:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -616,7 +616,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "recorded-date": "17-06-2025, 09:51:47",
+    "recorded-date": "06-11-2025, 11:57:06",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -701,7 +701,7 @@
           "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
           "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
-          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.1.3/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
@@ -747,7 +747,7 @@
           "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
           "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
-          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.1.3/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
@@ -761,7 +761,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "recorded-date": "17-06-2025, 09:51:17",
+    "recorded-date": "06-11-2025, 11:56:43",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -902,7 +902,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "recorded-date": "17-06-2025, 09:51:36",
+    "recorded-date": "06-11-2025, 11:56:58",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1037,7 +1037,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "17-06-2025, 09:51:05",
+    "recorded-date": "06-11-2025, 11:56:31",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1178,7 +1178,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "recorded-date": "17-06-2025, 09:51:33",
+    "recorded-date": "06-11-2025, 11:56:55",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1313,7 +1313,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "recorded-date": "17-06-2025, 09:52:07",
+    "recorded-date": "06-11-2025, 11:57:21",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1446,7 +1446,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "17-06-2025, 09:51:23",
+    "recorded-date": "06-11-2025, 11:56:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1587,7 +1587,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "recorded-date": "17-06-2025, 09:51:20",
+    "recorded-date": "06-11-2025, 11:56:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1728,7 +1728,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "recorded-date": "17-06-2025, 09:51:14",
+    "recorded-date": "06-11-2025, 11:56:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1871,7 +1871,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "recorded-date": "17-06-2025, 09:51:01",
+    "recorded-date": "06-11-2025, 11:56:29",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2010,7 +2010,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "17-06-2025, 09:51:57",
+    "recorded-date": "06-11-2025, 11:57:14",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2081,12 +2081,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "DOTNET_ROOT": "/var/lang/bin",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_RUNTIME_NAME": "dotnet6",
@@ -2098,10 +2098,10 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "dotnet::Dotnet.Function::FunctionHandler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3",
+          "_LAMBDA_TELEMETRY_LOG_FD": "62",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
         },
         "packages": []
@@ -2127,12 +2127,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "DOTNET_ROOT": "/var/lang/bin",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_RUNTIME_NAME": "dotnet6",
@@ -2144,10 +2144,10 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "dotnet::Dotnet.Function::FunctionHandler",
-          "_LAMBDA_TELEMETRY_LOG_FD": "3",
+          "_LAMBDA_TELEMETRY_LOG_FD": "62",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
         },
         "packages": []
@@ -2155,7 +2155,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "17-06-2025, 09:51:08",
+    "recorded-date": "06-11-2025, 11:56:34",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2225,12 +2225,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -2242,7 +2242,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "index.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
@@ -2269,12 +2269,12 @@
           "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
           "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
           "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
-          "AWS_LAMBDA_RUNTIME_API": "127.0.0.1:9001",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
           "AWS_REGION": "<region>",
           "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
           "AWS_SESSION_TOKEN": "<aws-session-token:1>",
           "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
-          "AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129:2000",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
           "LAMBDA_RUNTIME_DIR": "/var/runtime",
           "LAMBDA_TASK_ROOT": "/var/task",
           "LANG": "en_US.UTF-8",
@@ -2286,7 +2286,7 @@
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
-          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.79.129",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
           "_AWS_XRAY_DAEMON_PORT": "2000",
           "_HANDLER": "index.handler",
           "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
@@ -2296,7 +2296,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "31-03-2025, 12:22:12",
+    "recorded-date": "06-11-2025, 11:57:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2358,7 +2358,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "31-03-2025, 12:22:27",
+    "recorded-date": "06-11-2025, 11:58:02",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2420,7 +2420,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "31-03-2025, 12:26:16",
+    "recorded-date": "06-11-2025, 11:58:27",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2481,7 +2481,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "31-03-2025, 12:22:31",
+    "recorded-date": "06-11-2025, 11:58:05",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2543,7 +2543,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "recorded-date": "31-03-2025, 12:22:34",
+    "recorded-date": "06-11-2025, 11:58:08",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2605,7 +2605,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "recorded-date": "31-03-2025, 12:22:04",
+    "recorded-date": "06-11-2025, 11:57:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2668,7 +2668,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "recorded-date": "31-03-2025, 12:22:24",
+    "recorded-date": "06-11-2025, 11:57:59",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2730,7 +2730,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "31-03-2025, 12:21:54",
+    "recorded-date": "06-11-2025, 11:57:34",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2792,7 +2792,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "recorded-date": "31-03-2025, 12:22:21",
+    "recorded-date": "06-11-2025, 11:57:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2854,7 +2854,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "recorded-date": "31-03-2025, 12:26:03",
+    "recorded-date": "06-11-2025, 11:58:23",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2915,7 +2915,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "31-03-2025, 12:22:09",
+    "recorded-date": "06-11-2025, 11:57:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2978,7 +2978,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "recorded-date": "31-03-2025, 12:22:07",
+    "recorded-date": "06-11-2025, 11:57:47",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3041,7 +3041,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "recorded-date": "31-03-2025, 12:22:02",
+    "recorded-date": "06-11-2025, 11:57:43",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3104,7 +3104,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "recorded-date": "31-03-2025, 12:21:51",
+    "recorded-date": "06-11-2025, 11:57:32",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3166,7 +3166,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "31-03-2025, 12:22:49",
+    "recorded-date": "06-11-2025, 11:58:15",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3228,7 +3228,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "31-03-2025, 12:21:57",
+    "recorded-date": "06-11-2025, 11:57:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3290,7 +3290,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "recorded-date": "31-03-2025, 12:26:39",
+    "recorded-date": "06-11-2025, 11:58:48",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3343,7 +3343,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "recorded-date": "31-03-2025, 12:26:57",
+    "recorded-date": "06-11-2025, 11:58:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3396,7 +3396,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "recorded-date": "31-03-2025, 12:27:11",
+    "recorded-date": "06-11-2025, 11:58:33",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3449,7 +3449,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "recorded-date": "31-03-2025, 12:26:45",
+    "recorded-date": "06-11-2025, 11:58:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3502,7 +3502,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "recorded-date": "31-03-2025, 12:26:19",
+    "recorded-date": "06-11-2025, 11:59:02",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3555,7 +3555,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "recorded-date": "31-03-2025, 12:26:29",
+    "recorded-date": "06-11-2025, 11:59:17",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3608,7 +3608,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "31-03-2025, 12:26:41",
+    "recorded-date": "06-11-2025, 11:58:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3661,7 +3661,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "recorded-date": "31-03-2025, 12:27:07",
+    "recorded-date": "06-11-2025, 11:58:38",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3714,7 +3714,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "recorded-date": "31-03-2025, 12:27:16",
+    "recorded-date": "06-11-2025, 11:59:14",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3767,7 +3767,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "recorded-date": "31-03-2025, 12:27:14",
+    "recorded-date": "06-11-2025, 11:59:06",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3820,7 +3820,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "recorded-date": "31-03-2025, 12:27:00",
+    "recorded-date": "06-11-2025, 11:58:52",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3873,7 +3873,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "recorded-date": "31-03-2025, 12:26:50",
+    "recorded-date": "06-11-2025, 11:58:43",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3926,7 +3926,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "recorded-date": "31-03-2025, 12:26:33",
+    "recorded-date": "06-11-2025, 11:58:57",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -3979,7 +3979,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "31-03-2025, 12:26:25",
+    "recorded-date": "06-11-2025, 11:59:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4032,47 +4032,47 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "recorded-date": "31-03-2025, 17:43:04",
+    "recorded-date": "06-11-2025, 12:00:25",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "recorded-date": "31-03-2025, 17:42:22",
+    "recorded-date": "06-11-2025, 12:00:35",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "recorded-date": "31-03-2025, 17:44:41",
+    "recorded-date": "06-11-2025, 12:00:47",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "recorded-date": "31-03-2025, 17:43:58",
+    "recorded-date": "06-11-2025, 12:00:33",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "recorded-date": "31-03-2025, 17:44:04",
+    "recorded-date": "06-11-2025, 12:01:14",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "recorded-date": "31-03-2025, 17:42:25",
+    "recorded-date": "06-11-2025, 12:00:55",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "recorded-date": "31-03-2025, 17:43:22",
+    "recorded-date": "06-11-2025, 12:00:50",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "recorded-date": "31-03-2025, 17:44:01",
+    "recorded-date": "06-11-2025, 12:00:37",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "recorded-date": "31-03-2025, 17:43:19",
+    "recorded-date": "06-11-2025, 12:00:22",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "recorded-date": "31-03-2025, 12:17:03",
+    "recorded-date": "06-11-2025, 11:56:11",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "recorded-date": "17-06-2025, 09:52:01",
+    "recorded-date": "06-11-2025, 11:57:17",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4219,7 +4219,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "recorded-date": "31-03-2025, 12:22:56",
+    "recorded-date": "06-11-2025, 11:58:17",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4281,7 +4281,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "recorded-date": "31-03-2025, 12:27:03",
+    "recorded-date": "06-11-2025, 11:58:55",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4334,35 +4334,35 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "recorded-date": "31-03-2025, 17:42:41",
+    "recorded-date": "06-11-2025, 12:01:26",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "recorded-date": "31-03-2025, 17:43:01",
+    "recorded-date": "06-11-2025, 12:00:19",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "recorded-date": "31-03-2025, 17:44:31",
+    "recorded-date": "06-11-2025, 11:59:37",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "recorded-date": "31-03-2025, 17:43:50",
+    "recorded-date": "06-11-2025, 12:00:03",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "recorded-date": "31-03-2025, 17:43:15",
+    "recorded-date": "06-11-2025, 12:00:44",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "recorded-date": "31-03-2025, 17:43:54",
+    "recorded-date": "06-11-2025, 12:00:41",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "recorded-date": "31-03-2025, 12:16:02",
+    "recorded-date": "06-11-2025, 11:55:59",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "recorded-date": "17-06-2025, 09:51:50",
+    "recorded-date": "06-11-2025, 11:57:09",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4447,7 +4447,7 @@
           "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
           "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
-          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.1.3/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
@@ -4493,7 +4493,7 @@
           "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
           "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
-          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.1.3/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
@@ -4507,7 +4507,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "recorded-date": "31-03-2025, 12:22:37",
+    "recorded-date": "06-11-2025, 11:58:10",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4569,7 +4569,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "recorded-date": "31-03-2025, 12:26:22",
+    "recorded-date": "06-11-2025, 11:58:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4622,15 +4622,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "recorded-date": "31-03-2025, 17:44:35",
+    "recorded-date": "06-11-2025, 12:00:30",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
-    "recorded-date": "31-03-2025, 12:13:46",
+    "recorded-date": "06-11-2025, 11:55:11",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
-    "recorded-date": "17-06-2025, 09:51:11",
+    "recorded-date": "06-11-2025, 11:56:38",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4773,7 +4773,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
-    "recorded-date": "31-03-2025, 12:21:59",
+    "recorded-date": "06-11-2025, 11:57:41",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4836,7 +4836,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
-    "recorded-date": "31-03-2025, 12:26:53",
+    "recorded-date": "06-11-2025, 11:59:19",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -4889,15 +4889,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
-    "recorded-date": "31-03-2025, 17:44:38",
+    "recorded-date": "06-11-2025, 12:01:28",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
-    "recorded-date": "31-03-2025, 12:12:50",
+    "recorded-date": "06-11-2025, 11:54:51",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs22.x]": {
-    "recorded-date": "17-06-2025, 09:50:58",
+    "recorded-date": "06-11-2025, 11:56:27",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5036,7 +5036,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs22.x]": {
-    "recorded-date": "31-03-2025, 12:21:49",
+    "recorded-date": "06-11-2025, 11:57:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5098,7 +5098,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs22.x]": {
-    "recorded-date": "31-03-2025, 12:26:36",
+    "recorded-date": "06-11-2025, 11:58:36",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5151,15 +5151,15 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
-    "recorded-date": "31-03-2025, 17:42:44",
+    "recorded-date": "06-11-2025, 12:00:06",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.4]": {
-    "recorded-date": "31-03-2025, 12:16:24",
+    "recorded-date": "06-11-2025, 11:56:03",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.4]": {
-    "recorded-date": "17-06-2025, 09:51:54",
+    "recorded-date": "06-11-2025, 11:57:11",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5244,7 +5244,7 @@
           "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
           "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
-          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.1.3/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
@@ -5290,7 +5290,7 @@
           "LD_LIBRARY_PATH": "/var/lang/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
           "PATH": "/var/lang/bin:/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
           "PWD": "/var/task",
-          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.0.0/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
+          "RUBYLIB": "/var/runtime/gems/aws_lambda_ric-3.1.3/lib:/var/task:/var/runtime/lib:/opt/ruby/lib",
           "SHLVL": "0",
           "TEST_KEY": "TEST_VAL",
           "TZ": ":UTC",
@@ -5304,7 +5304,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.4]": {
-    "recorded-date": "31-03-2025, 12:22:40",
+    "recorded-date": "06-11-2025, 11:58:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5366,7 +5366,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.4]": {
-    "recorded-date": "31-03-2025, 12:26:47",
+    "recorded-date": "06-11-2025, 11:59:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -5419,7 +5419,536 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.4]": {
-    "recorded-date": "31-03-2025, 17:43:08",
+    "recorded-date": "06-11-2025, 12:01:11",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs24.x]": {
+    "recorded-date": "06-11-2025, 11:48:56",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java25]": {
+    "recorded-date": "06-11-2025, 11:55:34",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.14]": {
+    "recorded-date": "06-11-2025, 11:55:07",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.14]": {
+    "recorded-date": "06-11-2025, 11:56:36",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.14",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_python3.14",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LC_CTYPE": "C.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "PYTHONPATH": "/var/runtime",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "handler.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:1>"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_python3.14",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LC_CTYPE": "C.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "PWD": "/var/task",
+          "PYTHONPATH": "/var/runtime",
+          "SHLVL": "0",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "handler.handler",
+          "_X_AMZN_TRACE_ID": "<x-amzn-trace-id:2>"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java25]": {
+    "recorded-date": "06-11-2025, 11:56:52",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "TEST_KEY": "TEST_VAL"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java25",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "invocation_result_payload": {
+        "ctx": {
+          "aws_request_id": "<uuid:2>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_java25",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "echo.Handler",
+          "_LAMBDA_TELEMETRY_LOG_FD": "62"
+        },
+        "packages": []
+      },
+      "invocation_result_payload_qualified": {
+        "ctx": {
+          "aws_request_id": "<uuid:3>",
+          "function_name": "<function-name:1>",
+          "function_version": "$LATEST",
+          "invoked_function_arn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
+          "log_group_name": "/aws/lambda/<function-name:1>",
+          "log_stream_name": "<log-stream-name:1>",
+          "memory_limit_in_mb": "1024",
+          "remaining_time_in_millis": "<remaining-time-in-millis>"
+        },
+        "environment": {
+          "AWS_ACCESS_KEY_ID": "<aws-access-key-id:1>",
+          "AWS_DEFAULT_REGION": "<region>",
+          "AWS_EXECUTION_ENV": "AWS_Lambda_java25",
+          "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
+          "AWS_LAMBDA_FUNCTION_NAME": "<function-name:1>",
+          "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+          "AWS_LAMBDA_INITIALIZATION_TYPE": "on-demand",
+          "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/<function-name:1>",
+          "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
+          "AWS_LAMBDA_RUNTIME_API": "169.254.100.1:9001",
+          "AWS_REGION": "<region>",
+          "AWS_SECRET_ACCESS_KEY": "<aws-secret-access-key:1>",
+          "AWS_SESSION_TOKEN": "<aws-session-token:1>",
+          "AWS_XRAY_CONTEXT_MISSING": "LOG_ERROR",
+          "AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1:2000",
+          "LAMBDA_RUNTIME_DIR": "/var/runtime",
+          "LAMBDA_TASK_ROOT": "/var/task",
+          "LANG": "en_US.UTF-8",
+          "LD_LIBRARY_PATH": "/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib",
+          "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin",
+          "TEST_KEY": "TEST_VAL",
+          "TZ": ":UTC",
+          "_AWS_XRAY_DAEMON_ADDRESS": "169.254.100.1",
+          "_AWS_XRAY_DAEMON_PORT": "2000",
+          "_HANDLER": "echo.Handler",
+          "_LAMBDA_TELEMETRY_LOG_FD": "62"
+        },
+        "packages": []
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.14]": {
+    "recorded-date": "06-11-2025, 11:57:39",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.14",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "Failed: some_error_msg",
+          "errorType": "Exception",
+          "requestId": "<uuid:2>",
+          "stackTrace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java25]": {
+    "recorded-date": "06-11-2025, 11:57:54",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java25",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "error_result": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "Error: some_error_msg",
+          "errorType": "java.lang.RuntimeException",
+          "stackTrace": "<stack-trace>"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.14]": {
+    "recorded-date": "06-11-2025, 11:59:04",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/var/task/environment_wrapper"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.14",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java25]": {
+    "recorded-date": "06-11-2025, 11:59:09",
+    "recorded-content": {
+      "create_function_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/var/task/environment_wrapper"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "echo.Handler",
+        "LastModified": "date",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+          "LogGroup": "/aws/lambda/<function-name:1>"
+        },
+        "MemorySize": 1024,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+        "Runtime": "java25",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.14]": {
+    "recorded-date": "06-11-2025, 12:00:52",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java25]": {
+    "recorded-date": "06-11-2025, 12:01:07",
     "recorded-content": {}
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_common.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_common.validation.json
@@ -1,431 +1,1001 @@
 {
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet6]": {
-    "last_validated_date": "2025-03-31T17:43:14+00:00"
+    "last_validated_date": "2025-11-06T12:00:44+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.33,
+      "teardown": 0.26,
+      "total": 3.6
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[dotnet8]": {
-    "last_validated_date": "2025-03-31T17:43:54+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
-    "last_validated_date": "2025-03-31T17:44:30+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
-    "last_validated_date": "2025-03-31T17:42:41+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
-    "last_validated_date": "2025-03-31T17:43:00+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
-    "last_validated_date": "2025-03-31T17:43:49+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
-    "last_validated_date": "2025-03-31T17:44:41+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
-    "last_validated_date": "2025-03-31T17:42:21+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
-    "last_validated_date": "2025-03-31T17:43:04+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
-    "last_validated_date": "2025-03-31T17:42:44+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
-    "last_validated_date": "2025-03-31T17:42:24+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
-    "last_validated_date": "2025-03-31T17:43:21+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
-    "last_validated_date": "2025-03-31T17:44:00+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
-    "last_validated_date": "2025-03-31T17:44:37+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
-    "last_validated_date": "2025-03-31T17:43:57+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
-    "last_validated_date": "2025-03-31T17:44:04+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
-    "last_validated_date": "2025-03-31T17:43:18+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
-    "last_validated_date": "2025-03-31T17:44:34+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.4]": {
-    "last_validated_date": "2025-03-31T17:43:07+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "last_validated_date": "2025-03-31T12:16:46+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
-    "last_validated_date": "2025-03-31T12:17:03+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "last_validated_date": "2025-03-31T12:15:22+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
-    "last_validated_date": "2025-03-31T12:15:13+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
-    "last_validated_date": "2025-03-31T12:15:05+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "last_validated_date": "2025-03-31T12:15:42+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "last_validated_date": "2025-03-31T12:13:31+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "last_validated_date": "2025-03-31T12:13:11+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
-    "last_validated_date": "2025-03-31T12:12:59+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
-    "last_validated_date": "2025-03-31T12:12:50+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
-    "last_validated_date": "2025-03-31T12:17:17+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "last_validated_date": "2025-03-31T12:17:30+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
-    "last_validated_date": "2025-03-31T12:14:20+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
-    "last_validated_date": "2025-03-31T12:14:05+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
-    "last_validated_date": "2025-03-31T12:13:57+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
-    "last_validated_date": "2025-03-31T12:13:45+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "last_validated_date": "2025-03-31T12:14:56+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "last_validated_date": "2025-03-31T12:14:39+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
-    "last_validated_date": "2025-03-31T12:15:53+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
-    "last_validated_date": "2025-03-31T12:16:02+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.4]": {
-    "last_validated_date": "2025-03-31T12:16:24+00:00"
-  },
-  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "last_validated_date": "2025-06-17T09:54:42+00:00",
+    "last_validated_date": "2025-11-06T12:00:41+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 2.97,
-      "teardown": 0.37,
-      "total": 3.34
+      "call": 3.15,
+      "teardown": 0.24,
+      "total": 3.39
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java11]": {
+    "last_validated_date": "2025-11-06T11:59:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 18.03,
+      "teardown": 0.52,
+      "total": 18.55
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java17]": {
+    "last_validated_date": "2025-11-06T12:01:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 11.81,
+      "teardown": 0.26,
+      "total": 12.07
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java21]": {
+    "last_validated_date": "2025-11-06T12:00:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 12.94,
+      "teardown": 0.26,
+      "total": 13.21
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java25]": {
+    "last_validated_date": "2025-11-06T12:01:07+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 12.05,
+      "teardown": 0.32,
+      "total": 12.38
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[java8.al2]": {
+    "last_validated_date": "2025-11-06T12:00:03+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 25.34,
+      "teardown": 0.29,
+      "total": 25.64
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs16.x]": {
+    "last_validated_date": "2025-11-06T12:00:47+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.39,
+      "teardown": 0.3,
+      "total": 2.7
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs18.x]": {
+    "last_validated_date": "2025-11-06T12:00:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.19,
+      "teardown": 0.27,
+      "total": 2.46
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs20.x]": {
+    "last_validated_date": "2025-11-06T12:00:25+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.23,
+      "teardown": 0.28,
+      "total": 2.52
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[nodejs22.x]": {
+    "last_validated_date": "2025-11-06T12:00:06+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.23,
+      "teardown": 0.32,
+      "total": 2.56
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.10]": {
+    "last_validated_date": "2025-11-06T12:00:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.31,
+      "teardown": 0.25,
+      "total": 2.57
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.11]": {
+    "last_validated_date": "2025-11-06T12:00:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.22,
+      "teardown": 0.25,
+      "total": 2.48
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.12]": {
+    "last_validated_date": "2025-11-06T12:00:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.22,
+      "teardown": 0.27,
+      "total": 2.5
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.13]": {
+    "last_validated_date": "2025-11-06T12:01:29+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.3,
+      "teardown": 1.32,
+      "total": 3.62
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.14]": {
+    "last_validated_date": "2025-11-06T12:00:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.23,
+      "teardown": 0.27,
+      "total": 2.5
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.8]": {
+    "last_validated_date": "2025-11-06T12:00:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.26,
+      "teardown": 0.31,
+      "total": 2.58
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[python3.9]": {
+    "last_validated_date": "2025-11-06T12:01:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.19,
+      "teardown": 0.28,
+      "total": 2.48
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.2]": {
+    "last_validated_date": "2025-11-06T12:00:22+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.4,
+      "teardown": 0.29,
+      "total": 3.69
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.3]": {
+    "last_validated_date": "2025-11-06T12:00:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 4.53,
+      "teardown": 0.34,
+      "total": 4.88
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaCallingLocalstack::test_manual_endpoint_injection[ruby3.4]": {
+    "last_validated_date": "2025-11-06T12:01:11+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.73,
+      "teardown": 0.28,
+      "total": 4.01
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
+    "last_validated_date": "2025-11-06T11:56:07+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.82,
+      "teardown": 0.2,
+      "total": 4.02
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet8]": {
+    "last_validated_date": "2025-11-06T11:56:11+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.94,
+      "teardown": 0.21,
+      "total": 4.15
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
+    "last_validated_date": "2025-11-06T11:55:47+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.92,
+      "teardown": 0.22,
+      "total": 4.15
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java17]": {
+    "last_validated_date": "2025-11-06T11:55:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.61,
+      "teardown": 0.26,
+      "total": 3.87
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java21]": {
+    "last_validated_date": "2025-11-06T11:55:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.9,
+      "teardown": 0.2,
+      "total": 4.11
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java25]": {
+    "last_validated_date": "2025-11-06T11:55:34+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.8,
+      "teardown": 0.21,
+      "total": 4.01
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
+    "last_validated_date": "2025-11-06T11:55:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.86,
+      "teardown": 0.2,
+      "total": 4.07
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
+    "last_validated_date": "2025-11-06T11:55:03+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.62,
+      "teardown": 0.22,
+      "total": 3.84
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
+    "last_validated_date": "2025-11-06T11:54:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.83,
+      "teardown": 0.2,
+      "total": 4.04
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs20.x]": {
+    "last_validated_date": "2025-11-06T11:54:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.67,
+      "teardown": 0.21,
+      "total": 3.89
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs22.x]": {
+    "last_validated_date": "2025-11-06T11:54:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.8,
+      "teardown": 0.22,
+      "total": 4.03
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2023]": {
+    "last_validated_date": "2025-11-06T11:56:17+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 5.54,
+      "teardown": 0.22,
+      "total": 5.77
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
+    "last_validated_date": "2025-11-06T11:56:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 7.42,
+      "teardown": 0.21,
+      "total": 7.63
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.10]": {
+    "last_validated_date": "2025-11-06T11:55:22+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.51,
+      "teardown": 0.21,
+      "total": 3.73
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.11]": {
+    "last_validated_date": "2025-11-06T11:55:18+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.68,
+      "teardown": 0.23,
+      "total": 3.91
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.12]": {
+    "last_validated_date": "2025-11-06T11:55:15+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.51,
+      "teardown": 0.2,
+      "total": 3.72
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.13]": {
+    "last_validated_date": "2025-11-06T11:55:11+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.64,
+      "teardown": 0.29,
+      "total": 3.93
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.14]": {
+    "last_validated_date": "2025-11-06T11:55:07+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 4.08,
+      "teardown": 0.2,
+      "total": 4.28
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
+    "last_validated_date": "2025-11-06T11:55:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 4.15,
+      "teardown": 0.22,
+      "total": 4.38
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
+    "last_validated_date": "2025-11-06T11:55:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.61,
+      "teardown": 0.2,
+      "total": 3.82
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.2]": {
+    "last_validated_date": "2025-11-06T11:55:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.78,
+      "teardown": 0.19,
+      "total": 3.97
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.3]": {
+    "last_validated_date": "2025-11-06T11:55:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 3.95,
+      "teardown": 0.21,
+      "total": 4.16
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby3.4]": {
+    "last_validated_date": "2025-11-06T11:56:03+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.79,
+      "teardown": 0.23,
+      "total": 4.03
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
+    "last_validated_date": "2025-11-06T11:57:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.38,
+      "teardown": 0.23,
+      "total": 2.62
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet8]": {
-    "last_validated_date": "2025-06-17T09:54:45+00:00",
+    "last_validated_date": "2025-11-06T11:57:17+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 3.14,
-      "teardown": 0.35,
-      "total": 3.49
+      "setup": 0.01,
+      "call": 2.64,
+      "teardown": 0.33,
+      "total": 2.98
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "last_validated_date": "2025-06-17T09:54:24+00:00",
+    "last_validated_date": "2025-11-06T11:57:01+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 3.48,
-      "teardown": 0.38,
-      "total": 3.86
+      "call": 2.66,
+      "teardown": 0.21,
+      "total": 2.87
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java17]": {
-    "last_validated_date": "2025-06-17T09:54:20+00:00",
+    "last_validated_date": "2025-11-06T11:56:58+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 3.21,
-      "teardown": 0.4,
-      "total": 3.61
+      "setup": 0.01,
+      "call": 2.44,
+      "teardown": 0.2,
+      "total": 2.65
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java21]": {
-    "last_validated_date": "2025-06-17T09:54:17+00:00",
+    "last_validated_date": "2025-11-06T11:56:55+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 3.45,
-      "teardown": 0.36,
-      "total": 3.81
+      "setup": 0.01,
+      "call": 2.56,
+      "teardown": 0.22,
+      "total": 2.79
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java25]": {
+    "last_validated_date": "2025-11-06T11:56:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.65,
+      "teardown": 0.27,
+      "total": 2.93
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "last_validated_date": "2025-06-17T09:54:28+00:00",
+    "last_validated_date": "2025-11-06T11:57:04+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 3.87,
-      "teardown": 0.37,
-      "total": 4.24
+      "setup": 0.01,
+      "call": 2.85,
+      "teardown": 0.2,
+      "total": 3.06
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "last_validated_date": "2025-06-17T09:53:53+00:00",
+    "last_validated_date": "2025-11-06T11:56:34+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.92,
-      "teardown": 0.34,
-      "total": 3.26
+      "setup": 0.01,
+      "call": 2.2,
+      "teardown": 0.21,
+      "total": 2.42
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "last_validated_date": "2025-06-17T09:53:50+00:00",
+    "last_validated_date": "2025-11-06T11:56:31+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.9,
-      "teardown": 0.34,
-      "total": 3.24
+      "setup": 0.01,
+      "call": 2.06,
+      "teardown": 0.2,
+      "total": 2.27
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs20.x]": {
-    "last_validated_date": "2025-06-17T09:53:47+00:00",
+    "last_validated_date": "2025-11-06T11:56:29+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.91,
-      "teardown": 0.37,
-      "total": 3.28
+      "setup": 0.01,
+      "call": 2.06,
+      "teardown": 0.2,
+      "total": 2.27
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs22.x]": {
-    "last_validated_date": "2025-06-17T09:53:44+00:00",
+    "last_validated_date": "2025-11-06T11:56:27+00:00",
     "durations_in_seconds": {
-      "setup": 11.98,
-      "call": 3.16,
-      "teardown": 0.35,
-      "total": 15.49
+      "setup": 0.01,
+      "call": 2.04,
+      "teardown": 0.23,
+      "total": 2.28
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2023]": {
-    "last_validated_date": "2025-06-17T09:54:51+00:00",
+    "last_validated_date": "2025-11-06T11:57:21+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 5.57,
-      "teardown": 0.4,
-      "total": 5.97
+      "setup": 0.01,
+      "call": 4.15,
+      "teardown": 0.28,
+      "total": 4.44
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "last_validated_date": "2025-06-17T09:54:58+00:00",
+    "last_validated_date": "2025-11-06T11:57:28+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 5.13,
-      "teardown": 1.61,
-      "total": 6.74
+      "setup": 0.01,
+      "call": 6.3,
+      "teardown": 0.23,
+      "total": 6.54
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.10]": {
-    "last_validated_date": "2025-06-17T09:54:06+00:00",
+    "last_validated_date": "2025-11-06T11:56:45+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.9,
-      "teardown": 0.35,
-      "total": 3.25
+      "setup": 0.01,
+      "call": 1.95,
+      "teardown": 0.19,
+      "total": 2.15
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.11]": {
-    "last_validated_date": "2025-06-17T09:54:03+00:00",
+    "last_validated_date": "2025-11-06T11:56:43+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 2.67,
-      "teardown": 0.42,
-      "total": 3.09
+      "call": 1.97,
+      "teardown": 0.19,
+      "total": 2.16
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.12]": {
-    "last_validated_date": "2025-06-17T09:54:00+00:00",
+    "last_validated_date": "2025-11-06T11:56:41+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.83,
-      "teardown": 0.38,
-      "total": 3.21
+      "setup": 0.01,
+      "call": 1.97,
+      "teardown": 0.21,
+      "total": 2.19
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.13]": {
-    "last_validated_date": "2025-06-17T09:53:57+00:00",
+    "last_validated_date": "2025-11-06T11:56:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.06,
+      "teardown": 0.27,
+      "total": 2.34
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.14]": {
+    "last_validated_date": "2025-11-06T11:56:36+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 2.83,
-      "teardown": 0.35,
-      "total": 3.18
+      "call": 2.11,
+      "teardown": 0.2,
+      "total": 2.31
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "last_validated_date": "2025-06-17T09:54:13+00:00",
+    "last_validated_date": "2025-11-06T11:56:49+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.97,
-      "teardown": 0.34,
-      "total": 3.31
+      "setup": 0.01,
+      "call": 2.04,
+      "teardown": 0.23,
+      "total": 2.28
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "last_validated_date": "2025-06-17T09:54:09+00:00",
+    "last_validated_date": "2025-11-06T11:56:47+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.82,
-      "teardown": 0.36,
-      "total": 3.18
+      "setup": 0.01,
+      "call": 2.03,
+      "teardown": 0.23,
+      "total": 2.27
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.2]": {
-    "last_validated_date": "2025-06-17T09:54:31+00:00",
+    "last_validated_date": "2025-11-06T11:57:06+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 2.85,
-      "teardown": 0.36,
-      "total": 3.21
+      "call": 2.25,
+      "teardown": 0.25,
+      "total": 2.5
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.3]": {
-    "last_validated_date": "2025-06-17T09:54:35+00:00",
+    "last_validated_date": "2025-11-06T11:57:09+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 3.02,
-      "teardown": 0.36,
-      "total": 3.38
+      "setup": 0.01,
+      "call": 2.2,
+      "teardown": 0.22,
+      "total": 2.43
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby3.4]": {
-    "last_validated_date": "2025-06-17T09:54:38+00:00",
+    "last_validated_date": "2025-11-06T11:57:11+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 2.97,
-      "teardown": 0.35,
-      "total": 3.32
+      "setup": 0.01,
+      "call": 2.25,
+      "teardown": 0.2,
+      "total": 2.46
     }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet6]": {
-    "last_validated_date": "2025-03-31T12:26:32+00:00"
+    "last_validated_date": "2025-11-06T11:58:57+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.47,
+      "teardown": 0.21,
+      "total": 2.69
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[dotnet8]": {
-    "last_validated_date": "2025-03-31T12:27:03+00:00"
+    "last_validated_date": "2025-11-06T11:58:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.31,
+      "teardown": 0.2,
+      "total": 2.52
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java11]": {
-    "last_validated_date": "2025-03-31T12:26:57+00:00"
+    "last_validated_date": "2025-11-06T11:58:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.55,
+      "teardown": 0.23,
+      "total": 2.79
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java17]": {
-    "last_validated_date": "2025-03-31T12:26:29+00:00"
+    "last_validated_date": "2025-11-06T11:59:17+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.43,
+      "teardown": 0.21,
+      "total": 2.65
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java21]": {
-    "last_validated_date": "2025-03-31T12:27:06+00:00"
+    "last_validated_date": "2025-11-06T11:58:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.41,
+      "teardown": 0.26,
+      "total": 2.68
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java25]": {
+    "last_validated_date": "2025-11-06T11:59:09+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.78,
+      "teardown": 0.21,
+      "total": 3.0
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[java8.al2]": {
-    "last_validated_date": "2025-03-31T12:27:10+00:00"
+    "last_validated_date": "2025-11-06T11:58:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.93,
+      "teardown": 0.19,
+      "total": 3.13
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "last_validated_date": "2025-03-31T12:26:24+00:00"
+    "last_validated_date": "2025-11-06T11:59:00+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.05,
+      "teardown": 0.24,
+      "total": 2.3
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "last_validated_date": "2025-03-31T12:26:41+00:00"
+    "last_validated_date": "2025-11-06T11:58:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.97,
+      "teardown": 0.22,
+      "total": 2.19
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs20.x]": {
-    "last_validated_date": "2025-03-31T12:26:50+00:00"
+    "last_validated_date": "2025-11-06T11:58:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.02,
+      "teardown": 0.22,
+      "total": 2.25
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs22.x]": {
-    "last_validated_date": "2025-03-31T12:26:35+00:00"
+    "last_validated_date": "2025-11-06T11:58:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.07,
+      "teardown": 0.21,
+      "total": 2.28
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.10]": {
-    "last_validated_date": "2025-03-31T12:27:13+00:00"
+    "last_validated_date": "2025-11-06T11:59:06+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.99,
+      "teardown": 0.22,
+      "total": 2.22
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.11]": {
-    "last_validated_date": "2025-03-31T12:26:18+00:00"
+    "last_validated_date": "2025-11-06T11:59:02+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.96,
+      "teardown": 0.21,
+      "total": 2.18
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.12]": {
-    "last_validated_date": "2025-03-31T12:27:00+00:00"
+    "last_validated_date": "2025-11-06T11:58:52+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.97,
+      "teardown": 0.23,
+      "total": 2.2
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.13]": {
-    "last_validated_date": "2025-03-31T12:26:53+00:00"
+    "last_validated_date": "2025-11-06T11:59:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.89,
+      "teardown": 0.21,
+      "total": 2.11
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.14]": {
+    "last_validated_date": "2025-11-06T11:59:04+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.09,
+      "teardown": 0.23,
+      "total": 2.33
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.8]": {
-    "last_validated_date": "2025-03-31T12:26:38+00:00"
+    "last_validated_date": "2025-11-06T11:58:48+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.03,
+      "teardown": 0.19,
+      "total": 2.23
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[python3.9]": {
-    "last_validated_date": "2025-03-31T12:27:16+00:00"
+    "last_validated_date": "2025-11-06T11:59:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.94,
+      "teardown": 0.21,
+      "total": 2.16
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.2]": {
-    "last_validated_date": "2025-03-31T12:26:44+00:00"
+    "last_validated_date": "2025-11-06T11:58:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.16,
+      "teardown": 0.23,
+      "total": 2.4
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.3]": {
-    "last_validated_date": "2025-03-31T12:26:21+00:00"
+    "last_validated_date": "2025-11-06T11:58:45+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.19,
+      "teardown": 0.23,
+      "total": 2.43
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[ruby3.4]": {
-    "last_validated_date": "2025-03-31T12:26:47+00:00"
+    "last_validated_date": "2025-11-06T11:59:12+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.2,
+      "teardown": 0.23,
+      "total": 2.44
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "last_validated_date": "2025-03-31T12:22:48+00:00"
+    "last_validated_date": "2025-11-06T11:58:15+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.14,
+      "teardown": 0.2,
+      "total": 2.35
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet8]": {
-    "last_validated_date": "2025-03-31T12:22:56+00:00"
+    "last_validated_date": "2025-11-06T11:58:17+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.25,
+      "teardown": 0.21,
+      "total": 2.47
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "last_validated_date": "2025-03-31T12:22:27+00:00"
+    "last_validated_date": "2025-11-06T11:58:02+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.53,
+      "teardown": 0.22,
+      "total": 2.76
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java17]": {
-    "last_validated_date": "2025-03-31T12:22:23+00:00"
+    "last_validated_date": "2025-11-06T11:57:59+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.27,
+      "teardown": 0.24,
+      "total": 2.51
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java21]": {
-    "last_validated_date": "2025-03-31T12:22:21+00:00"
+    "last_validated_date": "2025-11-06T11:57:57+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.66,
+      "teardown": 0.22,
+      "total": 2.88
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java25]": {
+    "last_validated_date": "2025-11-06T11:57:54+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.52,
+      "teardown": 0.18,
+      "total": 2.71
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "last_validated_date": "2025-03-31T12:22:31+00:00"
+    "last_validated_date": "2025-11-06T11:58:05+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.92,
+      "teardown": 0.21,
+      "total": 3.14
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "last_validated_date": "2025-03-31T12:21:56+00:00"
+    "last_validated_date": "2025-11-06T11:57:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.02,
+      "teardown": 0.2,
+      "total": 2.23
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "last_validated_date": "2025-03-31T12:21:54+00:00"
+    "last_validated_date": "2025-11-06T11:57:34+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.92,
+      "teardown": 0.26,
+      "total": 2.18
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs20.x]": {
-    "last_validated_date": "2025-03-31T12:21:51+00:00"
+    "last_validated_date": "2025-11-06T11:57:32+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.84,
+      "teardown": 0.21,
+      "total": 2.05
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs22.x]": {
-    "last_validated_date": "2025-03-31T12:21:48+00:00"
+    "last_validated_date": "2025-11-06T11:57:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.87,
+      "teardown": 0.19,
+      "total": 2.07
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2023]": {
-    "last_validated_date": "2025-03-31T12:26:02+00:00"
+    "last_validated_date": "2025-11-06T11:58:23+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 6.17,
+      "teardown": 0.21,
+      "total": 6.39
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "last_validated_date": "2025-03-31T12:26:16+00:00"
+    "last_validated_date": "2025-11-06T11:58:27+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 3.71,
+      "teardown": 0.24,
+      "total": 3.96
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.10]": {
-    "last_validated_date": "2025-03-31T12:22:07+00:00"
+    "last_validated_date": "2025-11-06T11:57:47+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.87,
+      "teardown": 0.22,
+      "total": 2.09
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.11]": {
-    "last_validated_date": "2025-03-31T12:22:04+00:00"
+    "last_validated_date": "2025-11-06T11:57:45+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.8,
+      "teardown": 0.2,
+      "total": 2.0
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.12]": {
-    "last_validated_date": "2025-03-31T12:22:02+00:00"
+    "last_validated_date": "2025-11-06T11:57:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.84,
+      "teardown": 0.21,
+      "total": 2.06
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.13]": {
-    "last_validated_date": "2025-03-31T12:21:59+00:00"
+    "last_validated_date": "2025-11-06T11:57:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.82,
+      "teardown": 0.23,
+      "total": 2.06
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.14]": {
+    "last_validated_date": "2025-11-06T11:57:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.16,
+      "teardown": 0.2,
+      "total": 2.37
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "last_validated_date": "2025-03-31T12:22:12+00:00"
+    "last_validated_date": "2025-11-06T11:57:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.94,
+      "teardown": 0.2,
+      "total": 2.14
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "last_validated_date": "2025-03-31T12:22:09+00:00"
+    "last_validated_date": "2025-11-06T11:57:49+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.8,
+      "teardown": 0.19,
+      "total": 2.0
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.2]": {
-    "last_validated_date": "2025-03-31T12:22:34+00:00"
+    "last_validated_date": "2025-11-06T11:58:08+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.16,
+      "teardown": 0.21,
+      "total": 2.38
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.3]": {
-    "last_validated_date": "2025-03-31T12:22:37+00:00"
+    "last_validated_date": "2025-11-06T11:58:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.0,
+      "teardown": 0.23,
+      "total": 2.24
+    }
   },
   "tests/aws/services/lambda_/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby3.4]": {
-    "last_validated_date": "2025-03-31T12:22:40+00:00"
+    "last_validated_date": "2025-11-06T11:58:12+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.23,
+      "teardown": 0.2,
+      "total": 2.44
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.snapshot.json
@@ -377,7 +377,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java21]": {
-    "recorded-date": "26-11-2024, 09:43:11",
+    "recorded-date": "06-11-2025, 12:22:33",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -391,7 +391,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java17]": {
-    "recorded-date": "26-11-2024, 09:43:14",
+    "recorded-date": "06-11-2025, 12:22:35",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -405,7 +405,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "recorded-date": "26-11-2024, 09:43:17",
+    "recorded-date": "06-11-2025, 12:22:38",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -419,7 +419,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:43:20",
+    "recorded-date": "06-11-2025, 12:22:41",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -433,7 +433,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java21]": {
-    "recorded-date": "26-11-2024, 09:43:37",
+    "recorded-date": "06-11-2025, 12:23:21",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -500,7 +500,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java17]": {
-    "recorded-date": "26-11-2024, 09:43:52",
+    "recorded-date": "06-11-2025, 12:23:32",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -567,7 +567,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "recorded-date": "26-11-2024, 09:44:07",
+    "recorded-date": "06-11-2025, 12:23:43",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -634,7 +634,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "recorded-date": "26-11-2024, 09:44:22",
+    "recorded-date": "06-11-2025, 12:23:54",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -966,43 +966,43 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.12]": {
-    "recorded-date": "26-11-2024, 09:45:27",
+    "recorded-date": "06-11-2025, 12:20:13",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.11]": {
-    "recorded-date": "26-11-2024, 09:45:30",
+    "recorded-date": "06-11-2025, 12:20:16",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "recorded-date": "26-11-2024, 09:45:32",
+    "recorded-date": "06-11-2025, 12:20:18",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "recorded-date": "26-11-2024, 09:45:35",
+    "recorded-date": "06-11-2025, 12:20:21",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "recorded-date": "26-11-2024, 09:45:38",
+    "recorded-date": "06-11-2025, 12:20:24",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.12]": {
-    "recorded-date": "26-11-2024, 09:45:42",
+    "recorded-date": "06-11-2025, 12:20:31",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.11]": {
-    "recorded-date": "26-11-2024, 09:45:45",
+    "recorded-date": "06-11-2025, 12:20:33",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "recorded-date": "26-11-2024, 09:45:47",
+    "recorded-date": "06-11-2025, 12:20:36",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "recorded-date": "26-11-2024, 09:45:49",
+    "recorded-date": "06-11-2025, 12:20:38",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "recorded-date": "26-11-2024, 09:45:51",
+    "recorded-date": "06-11-2025, 12:20:40",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestGoProvidedRuntimes::test_uncaught_exception_invoke[provided.al2023]": {
@@ -1136,11 +1136,11 @@
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.13]": {
-    "recorded-date": "26-11-2024, 09:45:25",
+    "recorded-date": "06-11-2025, 12:20:10",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.13]": {
-    "recorded-date": "26-11-2024, 09:45:40",
+    "recorded-date": "06-11-2025, 12:20:28",
     "recorded-content": {}
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs22.x]": {
@@ -1270,6 +1270,95 @@
           "eventId": "event-id"
         }
       ]
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.14]": {
+    "recorded-date": "06-11-2025, 12:20:08",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.14]": {
+    "recorded-date": "06-11-2025, 12:20:26",
+    "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java25]": {
+    "recorded-date": "06-11-2025, 12:22:30",
+    "recorded-content": {
+      "invoke_result": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {},
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java25]": {
+    "recorded-date": "06-11-2025, 12:23:11",
+    "recorded-content": {
+      "create-result": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<<code-sha-256>:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:<partition>:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.awssdkv1.sample.SerializedInputLambdaHandler",
+          "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
+          "Runtime": "java25",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invoke-result": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "bucket": "test_bucket",
+          "key": "test_key",
+          "validated": true
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
     }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_runtimes.validation.json
@@ -30,28 +30,94 @@
     "last_validated_date": "2024-11-26T09:43:07+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "last_validated_date": "2024-11-26T09:44:07+00:00"
+    "last_validated_date": "2025-11-06T12:23:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 10.14,
+      "teardown": 0.36,
+      "total": 10.5
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java17]": {
-    "last_validated_date": "2024-11-26T09:43:52+00:00"
+    "last_validated_date": "2025-11-06T12:23:32+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 10.69,
+      "teardown": 0.38,
+      "total": 11.08
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java21]": {
-    "last_validated_date": "2024-11-26T09:43:37+00:00"
+    "last_validated_date": "2025-11-06T12:23:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 10.05,
+      "teardown": 0.35,
+      "total": 10.41
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java25]": {
+    "last_validated_date": "2025-11-06T12:23:11+00:00",
+    "durations_in_seconds": {
+      "setup": 12.53,
+      "call": 11.05,
+      "teardown": 0.36,
+      "total": 23.94
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:44:22+00:00"
+    "last_validated_date": "2025-11-06T12:23:55+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 10.66,
+      "teardown": 1.41,
+      "total": 12.07
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "last_validated_date": "2024-11-26T09:43:16+00:00"
+    "last_validated_date": "2025-11-06T12:22:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.59,
+      "teardown": 0.37,
+      "total": 2.96
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java17]": {
-    "last_validated_date": "2024-11-26T09:43:13+00:00"
+    "last_validated_date": "2025-11-06T12:22:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.54,
+      "teardown": 0.35,
+      "total": 2.9
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java21]": {
-    "last_validated_date": "2024-11-26T09:43:11+00:00"
+    "last_validated_date": "2025-11-06T12:22:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.4,
+      "teardown": 0.4,
+      "total": 2.8
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java25]": {
+    "last_validated_date": "2025-11-06T12:22:30+00:00",
+    "durations_in_seconds": {
+      "setup": 12.45,
+      "call": 2.86,
+      "teardown": 0.35,
+      "total": 15.66
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "last_validated_date": "2024-11-26T09:43:19+00:00"
+    "last_validated_date": "2025-11-06T12:22:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.56,
+      "teardown": 1.09,
+      "total": 3.65
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs16.x]": {
     "last_validated_date": "2024-11-26T09:42:54+00:00"
@@ -66,39 +132,129 @@
     "last_validated_date": "2024-11-26T09:42:29+00:00"
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.10]": {
-    "last_validated_date": "2024-11-26T09:45:32+00:00"
+    "last_validated_date": "2025-11-06T12:20:18+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.3,
+      "teardown": 0.32,
+      "total": 2.62
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.11]": {
-    "last_validated_date": "2024-11-26T09:45:29+00:00"
+    "last_validated_date": "2025-11-06T12:20:16+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.44,
+      "teardown": 0.39,
+      "total": 2.84
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.12]": {
-    "last_validated_date": "2024-11-26T09:45:27+00:00"
+    "last_validated_date": "2025-11-06T12:20:13+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.19,
+      "teardown": 0.38,
+      "total": 2.58
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.13]": {
-    "last_validated_date": "2024-11-26T09:45:24+00:00"
+    "last_validated_date": "2025-11-06T12:20:10+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 2.24,
+      "teardown": 0.35,
+      "total": 2.6
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.14]": {
+    "last_validated_date": "2025-11-06T12:20:08+00:00",
+    "durations_in_seconds": {
+      "setup": 11.97,
+      "call": 2.45,
+      "teardown": 0.38,
+      "total": 14.8
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "last_validated_date": "2024-11-26T09:45:37+00:00"
+    "last_validated_date": "2025-11-06T12:20:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.2,
+      "teardown": 0.4,
+      "total": 2.6
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "last_validated_date": "2024-11-26T09:45:35+00:00"
+    "last_validated_date": "2025-11-06T12:20:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.16,
+      "teardown": 0.34,
+      "total": 2.5
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.10]": {
-    "last_validated_date": "2024-11-26T09:45:47+00:00"
+    "last_validated_date": "2025-11-06T12:20:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.03,
+      "teardown": 0.37,
+      "total": 2.4
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.11]": {
-    "last_validated_date": "2024-11-26T09:45:44+00:00"
+    "last_validated_date": "2025-11-06T12:20:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.01,
+      "call": 1.97,
+      "teardown": 0.53,
+      "total": 2.51
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.12]": {
-    "last_validated_date": "2024-11-26T09:45:42+00:00"
+    "last_validated_date": "2025-11-06T12:20:31+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 1.97,
+      "teardown": 0.37,
+      "total": 2.34
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.13]": {
-    "last_validated_date": "2024-11-26T09:45:40+00:00"
+    "last_validated_date": "2025-11-06T12:20:28+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.04,
+      "teardown": 0.35,
+      "total": 2.39
+    }
+  },
+  "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.14]": {
+    "last_validated_date": "2025-11-06T12:20:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.08,
+      "teardown": 0.26,
+      "total": 2.34
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "last_validated_date": "2024-11-26T09:45:51+00:00"
+    "last_validated_date": "2025-11-06T12:20:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.08,
+      "teardown": 1.03,
+      "total": 3.11
+    }
   },
   "tests/aws/services/lambda_/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "last_validated_date": "2024-11-26T09:45:49+00:00"
+    "last_validated_date": "2025-11-06T12:20:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 2.07,
+      "teardown": 0.37,
+      "total": 2.44
+    }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
AWS will, according to their Lambda Runtime Documentation (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-future) soon release the python3.14 and java25 runtimes.

This PR adds those runtimes to LocalStack, so we can support them from the start.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Add `python3.14` runtime
* Add `java25` runtime

<!--
Summarise the changes proposed in the PR.
-->

## Tests
* Updated using new snapshots
* Pro test run: https://github.com/localstack/localstack-pro/actions/runs/19136089184

<!--
Optional: How are the proposed changes tested?
-->

## Related
* Fixes UNC-87
* Also requires localstack/lambda-images#17

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
