### PR TITLE
S3: fix `aws-global` as location constraint

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -502,7 +502,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 raise MalformedXML()
 
             if context.region == AWS_REGION_US_EAST_1:
-                if bucket_region == "us-east-1":
+                if bucket_region in ("us-east-1", "aws-global"):
                     raise InvalidLocationConstraint(
                         "The specified location-constraint is not valid",
                         LocationConstraint=bucket_region,

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -18335,5 +18335,36 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_constraint_aws_global[us-east-1]": {
+    "recorded-date": "07-11-2025, 16:16:25",
+    "recorded-content": {
+      "aws-global-constraint": {
+        "Error": {
+          "Code": "InvalidLocationConstraint",
+          "LocationConstraint": "aws-global",
+          "Message": "The specified location-constraint is not valid"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_constraint_aws_global[us-west-1]": {
+    "recorded-date": "07-11-2025, 16:16:26",
+    "recorded-content": {
+      "aws-global-constraint": {
+        "Error": {
+          "Code": "IllegalLocationConstraintException",
+          "Message": "The aws-global location constraint is incompatible for the region specific endpoint this request was sent to."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -2,6 +2,24 @@
   "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_availability": {
     "last_validated_date": "2025-01-21T18:30:41+00:00"
   },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_constraint_aws_global[us-east-1]": {
+    "last_validated_date": "2025-11-07T16:16:25+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 0.46,
+      "teardown": 0.01,
+      "total": 0.94
+    }
+  },
+  "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_constraint_aws_global[us-west-1]": {
+    "last_validated_date": "2025-11-07T16:16:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.67,
+      "teardown": 0.01,
+      "total": 0.68
+    }
+  },
   "tests/aws/services/s3/test_s3.py::TestS3::test_bucket_does_not_exist": {
     "last_validated_date": "2025-01-21T18:34:13+00:00"
   },


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
As a result of our parity report, we still got an issue when SDKs would set the `LocationConstraint` property to `aws-global` leading to unhandled exceptions (using `bucket_region` to access the store). 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- add proper validation of the `LocationConstraint` to not allow `aws-global` when the client region is `us-east-1` and add parity tests
