### PR TITLE
Move steps for updating ASF modules to Makefile

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -44,15 +44,7 @@ jobs:
 
       - name: Update ASF APIs
         run: |
-          source .venv/bin/activate
-          python3 -m localstack.aws.scaffold upgrade
-
-      - name: Format code
-        run: |
-          source .venv/bin/activate
-          # explicitly perform an unsafe fix to remove unused imports in the generated ASF APIs
-          ruff check --select F401 --unsafe-fixes --fix localstack-core/localstack/aws/api/ --config "lint.preview = true"
-          make format-modified
+          make asf-regenerate
 
       - name: Check for changes
         id: check-for-changes

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,12 @@ format-modified:          ## Run ruff to format only modified code
 	  python -m ruff check --output-format=full --fix `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`; \
 	  python -m ruff format `git diff --diff-filter=d --name-only HEAD | grep '\.py$$' | xargs`)
 
+asf-regenerate:                   ## Regenerate ASF APIs
+	$(VENV_RUN); python -m localstack.aws.scaffold upgrade
+	@echo 'Removing unused imports from generated modules'
+	$(VENV_RUN); python -m ruff check --select F401 --unsafe-fixes --fix localstack-core/localstack/aws/api/ --config "lint.preview = true"
+	$(VENV_RUN); python -m ruff format localstack-core/localstack/aws/api/
+
 init-precommit:    		  ## install te pre-commit hook into your local git repository
 	($(VENV_RUN); pre-commit install)
 
@@ -158,4 +164,4 @@ clean-dist:				  ## Clean up python distribution directories
 	rm -rf dist/ build/
 	rm -rf localstack-core/*.egg-info
 
-.PHONY: usage freeze install-basic install-runtime install-test install-dev install entrypoints dist publish coveralls start docker-run-tests docker-cp-coverage test test-coverage lint lint-modified format format-modified init-precommit clean clean-dist upgrade-pinned-dependencies
+.PHONY: usage freeze install-basic install-runtime install-test install-dev install entrypoints dist publish coveralls start docker-run-tests docker-cp-coverage test test-coverage lint lint-modified format format-modified asf-regenerate init-precommit clean clean-dist upgrade-pinned-dependencies


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Hidden in the GitHub workflow, it was hard to find the command to run to fix the unused imports in the generated file, and the `pre-commit` doesn't pick this up if you run the scaffold generation manually and forget this step.

## Changes

Here we move the necessary commands to a single Makefile rule, for convenient manual and automated use.

(A further small commit also fixes a small issue in an existing Makefile rule, wherein a failing command wouldn't short-circuit the following command.)

## Tests

`make asf-regenerate` works nicely locally: the corresponding workflow would need to be run to fully test it, but it looks pretty safe to me.

