### PR TITLE
Remove redundant ruff ignores for generated ASF modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,6 @@ extend-safe-fixes = [
 # Since F401 (removing unused imports) is currently an unsafe fix, these imports cannot be automatically removed.
 # Therefore, we temporarily disable the rules below for __init__ files.
 [tool.ruff.lint.per-file-ignores]
-"localstack-core/localstack/**/__init__.py" = ["UP006", "UP007", "UP035", "UP045"]
 "tests/aws/services/lambda_/functions/**" = ["UP"]  # lambda tests parametrize the runtime
 
 [tool.ruff.lint.pyupgrade]


### PR DESCRIPTION

<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

As of #13347, the type annotations in those modules are modern and will not upset ruff.

## Changes

Remove per-file ignores for the ASF modules, since they are redundant.

## Tests

Running `make format`, `make lint` without those ignores present is successful.

## Related

Mentioned by @giograno in https://github.com/localstack/localstack/pull/13347#issuecomment-3503901531.