### PR TITLE
update kinesis-mock from 0.4.13 to 0.4.14

### DIFF
--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -7,7 +7,7 @@ from localstack.packages import InstallTarget, Package
 from localstack.packages.core import GitHubReleaseInstaller, NodePackageInstaller
 from localstack.packages.java import JavaInstallerMixin, java_package
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.13"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.14"
 
 
 class KinesisMockEngine(StrEnum):


### PR DESCRIPTION
## Motivation
@etspaceman released a new patch version of `kinesis-mock` a few days ago: [`0.4.14`](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.4.14) 🥳 
The changelog for this release only contains dependency updates.
This PR upgrades `kinesis-mock` to this latest version, see https://github.com/localstack/localstack/pull/12878 for the last upgrade.

## Changes
- Changes the default version of the `kinesis-mock` package from `0.4.13` to `0.4.14`.