### PR TITLE
Fix DNS port mapping in localstack.dev.kubernetes

### DIFF
--- a/localstack-core/localstack/dev/kubernetes/__main__.py
+++ b/localstack-core/localstack/dev/kubernetes/__main__.py
@@ -189,15 +189,7 @@ def generate_k8s_cluster_config(
                 "nodeFilters": [
                     "server:0",
                 ],
-                "port": f"{dns_port}:{EDGE_SERVICE_DNS_PORT}/udp",
-            }
-        )
-        ports.append(
-            {
-                "nodeFilters": [
-                    "server:0",
-                ],
-                "port": f"{dns_port}:{EDGE_SERVICE_DNS_PORT}/tcp",
+                "port": f"{dns_port}:{EDGE_SERVICE_DNS_PORT}",
             }
         )
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Fixes a bug with `localstack.dev.kubernetes` not exposing the DNS port properly.
K3d was failing to map both ports, resulting in failures with DNS resolution.

## Changes

Replaces two protocol-specific DNS port entries with a single one. 

## Tests

Following the instructions of this script
`python -m localstack.dev.kubernetes --pro --write --expose-dns`

And then running pro tests that require DNS should be successful 


## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
