### PR TITLE
Explicitly fix import order when regenerating ASF modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ asf-regenerate:                   ## Regenerate ASF APIs
 	$(VENV_RUN); python -m localstack.aws.scaffold upgrade
 	@echo 'Removing unused imports from generated modules'
 	$(VENV_RUN); python -m ruff check --select F401 --unsafe-fixes --fix localstack-core/localstack/aws/api/ --config "lint.preview = true"
+	$(VENV_RUN); python -m ruff check --output-format=full --fix localstack-core/localstack/aws/api/
 	$(VENV_RUN); python -m ruff format localstack-core/localstack/aws/api/
 
 init-precommit:    		  ## install te pre-commit hook into your local git repository


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Small adjustment needed to #13354, since when applying this to the pro version, I realised a further `ruff check --fix` pass is required if the `make asf-regenerate` command is to be fully self-contained. Without this, the results of the `asf-update` GitHub workflow would not pass the linter.

## Changes

Also run `ruff check --fix`, as done in `make format`.

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

#13354