### PR TITLE
remove pins on pip and pip-compile

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -85,8 +85,7 @@ jobs:
           bin/release-helper.sh set-dep-ver awscli "==$AWSCLI_VERSION"
 
           # upgrade the requirements files only for the botocore package
-          # TODO: Avoid pip 25.3 for now due to https://github.com/jazzband/pip-tools/issues/2252
-          python3 -m pip install --upgrade "pip!=25.3" pip-tools
+          python3 -m pip install --upgrade pip pip-tools
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra runtime -o requirements-runtime.txt pyproject.toml
           pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra test -o requirements-test.txt pyproject.toml

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ freeze:                   ## Run pip freeze -l in the virtual environment
 	@$(VENV_RUN); pip freeze -l
 
 upgrade-pinned-dependencies: venv
-	# TODO: Avoid pip 25.3 for now due to https://github.com/jazzband/pip-tools/issues/2252
-	$(VENV_RUN); $(PIP_CMD) install --upgrade "pip!=25.3" pip-tools pre-commit
+	$(VENV_RUN); $(PIP_CMD) install --upgrade pip pip-tools pre-commit
 	$(VENV_RUN); pip-compile --strip-extras --upgrade -o requirements-basic.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra runtime -o requirements-runtime.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra test -o requirements-test.txt pyproject.toml


### PR DESCRIPTION
## Motivation
We have been facing some issues with the dependency pinning using `pip-tools` due to https://github.com/jazzband/pip-tools/issues/2252. We addressed these issues by pinning the `pip` version with https://github.com/localstack/localstack/pull/13305 and https://github.com/localstack/localstack/pull/13311. Since these issues should be resolved with `pip-tools==7.5.2` ([which was released a few hours ago](https://github.com/jazzband/pip-tools/releases/tag/v7.5.2)), this PR reverts these changes / removes the pins again.

## Changes
- Reverts changes from https://github.com/localstack/localstack/pull/13305 and https://github.com/localstack/localstack/pull/13311.

## TODO
- [x] Verify that the initial issues do not reappear with this PR.
  - Tested `make upgrade-pinned-dependencies` locally. It uses the latest versions of `pip` and `pip-tools` and works just fine.