### PR TITLE
update kinesis-mock from 0.4.14 to 0.5.1

### DIFF
--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -7,7 +7,7 @@ from localstack.packages import InstallTarget, Package
 from localstack.packages.core import GitHubReleaseInstaller, NodePackageInstaller
 from localstack.packages.java import JavaInstallerMixin, java_package
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.4.14"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.5.1"
 
 
 class KinesisMockEngine(StrEnum):


### PR DESCRIPTION
## Motivation
@etspaceman released a new minor and a patch version of `kinesis-mock` yesterday:  [`0.5.0`](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.5.0) and  [`0.5.1`](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.5.1) 🥳 
The changelog for the `0.5.0` and `0.5.1` release state that the release primary upgrades Skala and the Docker runtime image (which we do not use).
This PR upgrades `kinesis-mock` to the latest version, see https://github.com/localstack/localstack/pull/13360 for the last upgrade.

## Changes
- Changes the default version of the `kinesis-mock` package from `0.4.14` to `0.5.1`.