### PR TITLE
update usage of deprecated utcnow() in service request aggregator

### DIFF
--- a/localstack-core/localstack/utils/analytics/service_request_aggregator.py
+++ b/localstack-core/localstack/utils/analytics/service_request_aggregator.py
@@ -34,7 +34,7 @@ class ServiceRequestAggregator:
         self._flush_interval = flush_interval
         self._flush_scheduler = Scheduler()
         self._mutex = threading.RLock()
-        self._period_start_time = datetime.datetime.utcnow()
+        self._period_start_time = datetime.datetime.now(datetime.UTC)
         self._is_started = False
         self._is_shutdown = False
 
@@ -101,12 +101,14 @@ class ServiceRequestAggregator:
                 self._emit_payload(analytics_payload)
                 self.counter.clear()
             finally:
-                self._period_start_time = datetime.datetime.utcnow()
+                self._period_start_time = datetime.datetime.now(datetime.UTC)
 
     def _create_analytics_payload(self):
         return {
-            "period_start_time": self._period_start_time.isoformat() + "Z",
-            "period_end_time": datetime.datetime.utcnow().isoformat() + "Z",
+            "period_start_time": self._period_start_time.isoformat().replace("+00:00", "Z"),
+            "period_end_time": datetime.datetime.now(datetime.UTC)
+            .isoformat()
+            .replace("+00:00", "Z"),
             "api_calls": self._aggregate_api_calls(self.counter),
         }
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

I was a bit annoyed to see this every single time I ran a test:

```
/home/work/src/localstack/localstack/localstack-core/localstack/utils/analytics/service_request_aggregator.py:104:
  DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-
  aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self._period_start_time = datetime.datetime.utcnow()
```
    
## Changes

Basically [utcnow](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) is deprecated. The code was creating a naive datetime just to calculate an interval, and then attaching it to the payload adding a Zulu marker.

I just create now the forced UTC equivalent from the beginning `datetime.datetime.now(datetime.UTC)`. I am not sure if the backend would work with the standard isoformat(), so I kept the Zulu based format.

This is a critical piece of analytics, so let me know if I miss something important in the picture.

## Tests

Just made sure that `tests/unit/utils/analytics/test_service_call_aggregator.py` passes. It does not test the payload, but at least parses it and checks the times are relative to each other.

## Related

There are other pieces of the code that use the deprecated method, which is a nice code janitor job. Expect more.
