### PR TITLE
CFn: raise validation error if the template is not valid

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_preparer.py
@@ -6,6 +6,7 @@ from localstack.services.cloudformation.engine.transformers import (
     apply_global_transformations,
     apply_intrinsic_transformations,
 )
+from localstack.services.cloudformation.engine.validations import ValidationError
 from localstack.utils.json import clone_safe
 
 LOG = logging.getLogger(__name__)
@@ -17,9 +18,12 @@ def parse_template(template: str) -> dict:
     except Exception:
         try:
             return clone_safe(yaml_parser.parse_yaml(template))
-        except Exception as e:
-            LOG.debug("Unable to parse CloudFormation template (%s): %s", e, template)
+        except ValidationError:
+            # The error is handled in the yaml parsing helper
             raise
+        except Exception:
+            # TODO: present the user with a better error message including error location
+            raise ValidationError("Template format error: YAML not well-formed.")
 
 
 def template_to_json(template: str) -> str:

--- a/tests/aws/services/cloudformation/api/test_templates.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_templates.snapshot.json
@@ -259,5 +259,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_invalid_yaml_template_should_fail": {
+    "recorded-date": "13-11-2025, 11:36:51",
+    "recorded-content": {
+      "create-invalid-yaml": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Template format error: YAML not well-formed.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_templates.validation.json
+++ b/tests/aws/services/cloudformation/api/test_templates.validation.json
@@ -11,6 +11,15 @@
   "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_from_s3_template_url[s3_url]": {
     "last_validated_date": "2023-10-10T22:03:44+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_create_stack_invalid_yaml_template_should_fail": {
+    "last_validated_date": "2025-11-13T11:36:51+00:00",
+    "durations_in_seconds": {
+      "setup": 1.06,
+      "call": 0.3,
+      "teardown": 0.0,
+      "total": 1.36
+    }
+  },
   "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_missing_resources": {
     "last_validated_date": "2025-09-12T16:08:17+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

When submitting invalid templates, the CloudFormation template parser raises a 500 internal server error rather than a 400 validation error.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Raise validation error instead
<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
