### PR TITLE
CFn: raise validation error in get-template if no arguments

### DIFF
--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -135,15 +135,15 @@ SSM_PARAMETER_TYPE_RE = re.compile(
 
 
 def is_stack_arn(stack_name_or_id: str) -> bool:
-    return ARN_STACK_REGEX.match(stack_name_or_id) is not None
+    return stack_name_or_id and ARN_STACK_REGEX.match(stack_name_or_id) is not None
 
 
 def is_changeset_arn(change_set_name_or_id: str) -> bool:
-    return ARN_CHANGESET_REGEX.match(change_set_name_or_id) is not None
+    return change_set_name_or_id and ARN_CHANGESET_REGEX.match(change_set_name_or_id) is not None
 
 
 def is_stack_set_arn(stack_set_name_or_id: str) -> bool:
-    return ARN_STACK_SET_REGEX.match(stack_set_name_or_id) is not None
+    return stack_set_name_or_id and ARN_STACK_SET_REGEX.match(stack_set_name_or_id) is not None
 
 
 class StackNotFoundError(ValidationError):
@@ -1388,7 +1388,7 @@ class CloudformationProviderV2(CloudformationProvider, ServiceLifecycleHook):
                     stack_name, message_override=f"Stack with id {stack_name} does not exist"
                 )
         else:
-            raise StackNotFoundError(stack_name)
+            raise ValidationError("StackName is required if ChangeSetName is not specified.")
 
         if template_stage == TemplateStage.Processed and "Transform" in stack.template_body:
             template_body = json.dumps(stack.processed_template)

--- a/tests/aws/services/cloudformation/api/test_templates.py
+++ b/tests/aws/services/cloudformation/api/test_templates.py
@@ -191,6 +191,14 @@ def test_validate_invalid_json_template_should_fail(aws_client, snapshot):
     snapshot.match("validate-invalid-json", ctx.value.response)
 
 
+@skip_if_legacy_engine()
+@markers.aws.validated
+def test_get_template_no_arguments(aws_client, snapshot):
+    with pytest.raises(ClientError) as exc_info:
+        aws_client.cloudformation.get_template()
+    snapshot.match("stack-error", exc_info.value.response)
+
+
 @markers.aws.validated
 def test_get_template_missing_resources_stack(aws_client, snapshot):
     with pytest.raises(ClientError) as exc_info:

--- a/tests/aws/services/cloudformation/api/test_templates.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_templates.snapshot.json
@@ -243,5 +243,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_no_arguments": {
+    "recorded-date": "13-11-2025, 16:48:31",
+    "recorded-content": {
+      "stack-error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "StackName is required if ChangeSetName is not specified.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_templates.validation.json
+++ b/tests/aws/services/cloudformation/api/test_templates.validation.json
@@ -47,6 +47,15 @@
       "total": 1.19
     }
   },
+  "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_no_arguments": {
+    "last_validated_date": "2025-11-13T16:48:31+00:00",
+    "durations_in_seconds": {
+      "setup": 1.54,
+      "call": 0.19,
+      "teardown": 0.0,
+      "total": 1.73
+    }
+  },
   "tests/aws/services/cloudformation/api/test_templates.py::test_get_template_summary": {
     "last_validated_date": "2023-05-24T13:05:00+00:00"
   },


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

When invoking `get_template`, if no arguments are passed in then currently we crash with a 5XX class error because we try to parse `None` as an ARN and fail.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

* Properly catch and raise a `ValidationError`
* Make sure the `is_*_arn` functions check the argument is truthy (catching e.g. `None`, or `""`)

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
