### PR TITLE
upgrade lambda-runtime-init

### DIFF
--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -12,7 +12,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.36-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.37-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Upgrade version of [lambda-runtime-init](https://github.com/localstack/lambda-runtime-init).

Related PR https://github.com/localstack/lambda-runtime-init/pull/43
<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
There was a vulnerability issue in the go version it was using. Go is now upgraded to 1.25.

<!--
Summarise the changes proposed in the PR.
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->

closes DRG-193