### PR TITLE
clean-up references to CircleCI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 exclude .github/**
-exclude .circleci/**
 exclude docs/**
 exclude tests/**
 exclude .test_durations

--- a/localstack-core/localstack/testing/testselection/matching.py
+++ b/localstack-core/localstack/testing/testselection/matching.py
@@ -181,7 +181,6 @@ MATCHING_RULES: list[MatchingRule] = [
     ).passthrough(),  # changes in a test file should always at least test that file
     # CI
     Matchers.glob(".github/**").full_suite(),
-    Matchers.glob(".circleci/**").full_suite(),
     # dependencies / project setup
     Matchers.glob("requirements*.txt").full_suite(),
     Matchers.glob("setup.cfg").full_suite(),


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

<!--
Elaborate the background and intent for raising this PR.
-->

When running `make entrypoints`, a warning is logged:
`warning: no previously-included files found matching '.circleci/**'`

Looking at our code searching through the codebase, I found this to be because of `MANIFEST.in` ([file to control what is in the distribution](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html)). I've also found a leftover reference to CircleCI in our test selection

This PR cleans it up

## Changes
- remove references to CircleCI

## Testing

Run `make entrypoints` and see that after the following line `reading manifest template 'MANIFEST.in'` we do not see the warning anymore
