### PR TITLE
APIGW: fix errors when importing invalid json/yaml

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -23,7 +23,7 @@ from localstack.aws.api.apigateway import (
     IntegrationType,
     Model,
     NotFoundException,
-    PutRestApiRequest,
+    PutMode,
     RequestValidator,
 )
 from localstack.constants import (
@@ -39,8 +39,7 @@ from localstack.services.apigateway.models import (
     apigateway_stores,
 )
 from localstack.utils import common
-from localstack.utils.json import parse_json_or_yaml
-from localstack.utils.strings import short_uid, to_bytes, to_str
+from localstack.utils.strings import short_uid, to_bytes
 from localstack.utils.urls import localstack_host
 
 LOG = logging.getLogger(__name__)
@@ -472,11 +471,9 @@ def add_documentation_parts(rest_api_container, documentation):
 
 
 def import_api_from_openapi_spec(
-    rest_api: MotoRestAPI, context: RequestContext, request: PutRestApiRequest
+    rest_api: MotoRestAPI, context: RequestContext, open_api_spec: dict, mode: PutMode
 ) -> tuple[MotoRestAPI, list[str]]:
     """Import an API from an OpenAPI spec document"""
-    body = parse_json_or_yaml(to_str(request["body"].read()))
-
     warnings = []
 
     # TODO There is an issue with the botocore specs so the parameters doesn't get populated as it should
@@ -484,15 +481,14 @@ def import_api_from_openapi_spec(
     # query_params = request.get("parameters") or {}
     query_params: dict = context.request.values.to_dict()
 
-    resolved_schema = resolve_references(copy.deepcopy(body), rest_api_id=rest_api.id)
+    resolved_schema = resolve_references(copy.deepcopy(open_api_spec), rest_api_id=rest_api.id)
     account_id = context.account_id
     region_name = context.region
 
     # TODO:
-    # 1. validate the "mode" property of the spec document, "merge" or "overwrite", and properly apply it
+    # 1. properly apply the mode (overwrite or merge)
     #    for now, it only considers it for the binaryMediaTypes
     # 2. validate the document type, "swagger" or "openapi"
-    mode = request.get("mode", "merge")
 
     rest_api.version = (
         str(version) if (version := resolved_schema.get("info", {}).get("version")) else None

--- a/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.snapshot.json
@@ -5022,5 +5022,32 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts_bad_file": {
+    "recorded-date": "18-11-2025, 17:21:35",
+    "recorded-content": {
+      "import-documentation-parts-bad-yaml-file": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Unable to build importer with provided input."
+        },
+        "message": "Unable to build importer with provided input.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "import-documentation-parts-bad-json-file": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Unable to build importer with provided input."
+        },
+        "message": "Unable to build importer with provided input.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_api.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_api.validation.json
@@ -11,6 +11,15 @@
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts": {
     "last_validated_date": "2024-04-15T20:56:45+00:00"
   },
+  "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_import_documentation_parts_bad_file": {
+    "last_validated_date": "2025-11-18T17:21:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.83,
+      "call": 1.14,
+      "teardown": 0.34,
+      "total": 2.31
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_api.py::TestApiGatewayApiDocumentationPart::test_invalid_create_documentation_part_operations": {
     "last_validated_date": "2024-04-15T20:53:48+00:00"
   },

--- a/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.snapshot.json
@@ -5474,5 +5474,54 @@
         }
       }
     }
+  },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_api_bad_file": {
+    "recorded-date": "18-11-2025, 17:29:30",
+    "recorded-content": {
+      "import-api-bad-yaml-file": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid OpenAPI input."
+        },
+        "message": "Invalid OpenAPI input.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "import-api-bad-json-file": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid OpenAPI input."
+        },
+        "message": "Invalid OpenAPI input.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-rest-api-bad-yaml-file": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid OpenAPI input."
+        },
+        "message": "Invalid OpenAPI input.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-rest-api-bad-json-file": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid OpenAPI input."
+        },
+        "message": "Invalid OpenAPI input.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/apigateway/test_apigateway_import.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_import.validation.json
@@ -17,6 +17,15 @@
       "total": 22.98
     }
   },
+  "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_api_bad_file": {
+    "last_validated_date": "2025-11-18T17:29:30+00:00",
+    "durations_in_seconds": {
+      "setup": 0.51,
+      "call": 0.97,
+      "teardown": 0.01,
+      "total": 1.49
+    }
+  },
   "tests/aws/services/apigateway/test_apigateway_import.py::TestApiGatewayImportRestApi::test_import_rest_api": {
     "last_validated_date": "2025-07-02T16:22:33+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

<!--
Elaborate the background and intent for raising this PR.
-->

Looking at errors we receive, I've spotted the following:
```python
File "/opt/code/localstack/.venv/lib/python3.13/site-packages/yaml/parser.py", line 438, in parse_block_mapping_key
    raise ParserError("while parsing a block mapping", self.marks[-1],
            "expected <block end>, but found %r" % [token.id](http://token.id/), token.start_mark)
localstack.aws.api.core.CommonServiceException: exception while calling apigateway.PutRestApi: while parsing a block mapping
expected <block end>, but found ':'
  in "<unicode string>", line 21, column 13:
              - : []
```

This issue is raided due to an invalid YAML file being passed to `PutRestApi`. 

I went ahead and fixed where we use `parse_json_or_yaml` to have proper exception handling: `ImportRestApi`, `PutRestApi` and `ImportDocumentationParts`. 

There are small refactoring along the way, but ultimately we need to rework how we import file, and how we deal with `ImportRestApi` recreating context and calling `PutRestApi` internally, meaning we parse the OpenAPI spec multiple times. 

## Changes
- write new tests with invalid JSON and YAML input when importing OpenAPI documents
- wrap JSON/YAML parsing with exception handling