### PR TITLE
kms: Fix ECDH derive-shared-secret behavior

### DIFF
--- a/tests/aws/services/kms/test_kms.snapshot.json
+++ b/tests/aws/services/kms/test_kms.snapshot.json
@@ -3642,5 +3642,20 @@
         }
       }
     }
+  },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret_matches_openssl": {
+    "recorded-date": "14-11-2025, 06:17:43",
+    "recorded-content": {
+      "derived-shared-key-resp": {
+        "KeyAgreementAlgorithm": "ECDH",
+        "KeyId": "<key-id:1>",
+        "KeyOrigin": "AWS_KMS",
+        "SharedSecret": "shared-secret",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/kms/test_kms.validation.json
+++ b/tests/aws/services/kms/test_kms.validation.json
@@ -59,6 +59,15 @@
   "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret": {
     "last_validated_date": "2024-12-25T14:45:00+00:00"
   },
+  "tests/aws/services/kms/test_kms.py::TestKMS::test_derive_shared_secret_matches_openssl": {
+    "last_validated_date": "2025-11-14T06:17:43+00:00",
+    "durations_in_seconds": {
+      "setup": 1.43,
+      "call": 1.75,
+      "teardown": 0.38,
+      "total": 3.56
+    }
+  },
   "tests/aws/services/kms/test_kms.py::TestKMS::test_describe_and_list_sign_key": {
     "last_validated_date": "2024-04-11T15:53:27+00:00"
   },


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
This PR fixes a bug in KMS ECDH handling where `DeriveSharedSecret` applied an HKDF to the raw ECDH output instead of returning the raw shared secret. That behavior caused derived secrets returned by LocalStack to differ from the raw ECDH output produced by OpenSSL, breaking compatibility with the steps described in [AWS ECDH support blog](https://aws.amazon.com/blogs/security/announcing-aws-kms-elliptic-curve-diffie-hellman-ecdh-support/).

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
This PR fixes the ECDH `DeriveSharedSecret` behavior and adds a snapshot validated test to validate the behavior. 


## Related
Closes https://github.com/localstack/localstack/issues/12129 
Fixes [FLC-170](https://linear.app/localstack/issue/FLC-170/kms-derivesharedsecret-should-return-the-raw-ecdh-secret)

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
