### PR TITLE
Fix OpenSearch AutoTune State Transitions

### DIFF
--- a/localstack-core/localstack/services/opensearch/provider.py
+++ b/localstack-core/localstack/services/opensearch/provider.py
@@ -116,6 +116,11 @@ DEFAULT_OPENSEARCH_DOMAIN_ENDPOINT_OPTIONS = DomainEndpointOptions(
     CustomEndpointEnabled=False,
 )
 
+DEFAULT_AUTOTUNE_OPTIONS = AutoTuneOptionsOutput(
+    State=AutoTuneState.ENABLED,
+    UseOffPeakWindow=False,
+)
+
 
 def cluster_manager() -> ClusterManager:
     global __CLUSTER_MANAGER
@@ -203,6 +208,13 @@ def _status_to_config(status: DomainStatus) -> DomainConfig:
     cluster_cfg = status.get("ClusterConfig") or {}
     default_cfg = DEFAULT_OPENSEARCH_CLUSTER_CONFIG
     config_status = get_domain_config_status()
+    autotune_options = status.get("AutoTuneOptions") or DEFAULT_AUTOTUNE_OPTIONS
+    autotune_state = autotune_options.get("State") or AutoTuneState.ENABLED
+    desired_state = (
+        AutoTuneDesiredState.ENABLED
+        if autotune_state == AutoTuneState.ENABLED
+        else AutoTuneDesiredState.DISABLED
+    )
     return DomainConfig(
         AccessPolicies=AccessPoliciesStatus(
             Options=status.get("AccessPolicies", ""),
@@ -275,15 +287,16 @@ def _status_to_config(status: DomainStatus) -> DomainConfig:
         ),
         AutoTuneOptions=AutoTuneOptionsStatus(
             Options=AutoTuneOptions(
-                DesiredState=AutoTuneDesiredState.ENABLED,
+                DesiredState=desired_state,
                 RollbackOnDisable=RollbackOnDisable.NO_ROLLBACK,
                 MaintenanceSchedules=[],
+                UseOffPeakWindow=autotune_options.get("UseOffPeakWindow", False),
             ),
             Status=AutoTuneStatus(
                 CreationDate=config_status.get("CreationDate"),
                 UpdateDate=config_status.get("UpdateDate"),
                 UpdateVersion=config_status.get("UpdateVersion"),
-                State=AutoTuneState.ENABLED,
+                State=autotune_state,
                 PendingDeletion=config_status.get("PendingDeletion"),
             ),
         ),
@@ -314,6 +327,22 @@ def get_domain_status(
         stored_status = deepcopy(stored_status)
         stored_status.update(request)
         default_cfg.update(request.get("ClusterConfig", {}))
+
+    autotune_options = stored_status.get("AutoTuneOptions") or deepcopy(DEFAULT_AUTOTUNE_OPTIONS)
+    if request and (request_options := request.get("AutoTuneOptions")):
+        desired_state = request_options.get("DesiredState") or AutoTuneDesiredState.ENABLED
+        state = (
+            AutoTuneState.ENABLED
+            if desired_state == AutoTuneDesiredState.ENABLED
+            else AutoTuneState.DISABLED
+        )
+        autotune_options = AutoTuneOptionsOutput(
+            State=state,
+            UseOffPeakWindow=request_options.get(
+                "UseOffPeakWindow", autotune_options.get("UseOffPeakWindow", False)
+            ),
+        )
+    stored_status["AutoTuneOptions"] = autotune_options
 
     domain_processing_status = stored_status.get("DomainProcessingStatus", None)
     processing = stored_status.get("Processing", True)
@@ -377,7 +406,10 @@ def get_domain_status(
         AdvancedSecurityOptions=AdvancedSecurityOptions(
             Enabled=False, InternalUserDatabaseEnabled=False
         ),
-        AutoTuneOptions=AutoTuneOptionsOutput(State=AutoTuneState.ENABLE_IN_PROGRESS),
+        AutoTuneOptions=AutoTuneOptionsOutput(
+            State=stored_status.get("AutoTuneOptions", {}).get("State"),
+            UseOffPeakWindow=autotune_options.get("UseOffPeakWindow", False),
+        ),
     )
     return new_status
 
@@ -581,6 +613,24 @@ class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
             domain_status = store.opensearch_domains.get(domain_key.domain_name, None)
             if domain_status is None:
                 raise ResourceNotFoundException(f"Domain not found: {domain_key.domain_name}")
+
+            if payload.get("AutoTuneOptions"):
+                auto_request = payload.pop("AutoTuneOptions")
+                desired_state = auto_request.get("DesiredState") or AutoTuneDesiredState.ENABLED
+
+                state = (
+                    AutoTuneState.ENABLED
+                    if desired_state == AutoTuneDesiredState.ENABLED
+                    else AutoTuneState.DISABLED
+                )
+
+                current_autotune = domain_status.get("AutoTuneOptions", {})
+                domain_status["AutoTuneOptions"] = AutoTuneOptionsOutput(
+                    State=state,
+                    UseOffPeakWindow=auto_request.get(
+                        "UseOffPeakWindow", current_autotune.get("UseOffPeakWindow", False)
+                    ),
+                )
 
             status_update: dict = _update_domain_config_request_to_status(payload)
             domain_status.update(status_update)

--- a/tests/aws/services/opensearch/test_opensearch.snapshot.json
+++ b/tests/aws/services/opensearch/test_opensearch.snapshot.json
@@ -1248,5 +1248,33 @@
         "UpgradeProcessing": false
       }
     }
+  },
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_autotune_state_transitions": {
+    "recorded-date": "19-11-2025, 13:12:26",
+    "recorded-content": {
+      "autotune_enabled_status": {
+        "State": "ENABLED",
+        "UseOffPeakWindow": false
+      },
+      "autotune_disabled_status": {
+        "State": "DISABLED",
+        "UseOffPeakWindow": false
+      },
+      "autotune_domain_config": {
+        "Options": {
+          "DesiredState": "DISABLED",
+          "MaintenanceSchedules": [],
+          "RollbackOnDisable": "NO_ROLLBACK",
+          "UseOffPeakWindow": false
+        },
+        "Status": {
+          "CreationDate": "<datetime>",
+          "PendingDeletion": false,
+          "State": "DISABLED",
+          "UpdateDate": "<datetime>",
+          "UpdateVersion": 15
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/opensearch/test_opensearch.validation.json
+++ b/tests/aws/services/opensearch/test_opensearch.validation.json
@@ -1,4 +1,13 @@
 {
+  "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_autotune_state_transitions": {
+    "last_validated_date": "2025-11-19T13:12:26+00:00",
+    "durations_in_seconds": {
+      "setup": 0.62,
+      "call": 1105.63,
+      "teardown": 0.34,
+      "total": 1106.59
+    }
+  },
   "tests/aws/services/opensearch/test_opensearch.py::TestOpensearchProvider::test_domain_lifecycle": {
     "last_validated_date": "2025-09-12T08:04:43+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

We currently hard code the output of the AutoTune state in OpenSearch. This leads to problems in external tooling.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

- Add simple state transition logic that binds the current state to the requested desired state

<!--
Summarise the changes proposed in the PR.
-->

## Tests

- Added a new snapshot test to verify this behavior

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
