### PR TITLE
fix deprecation warning for xml.ElementTree

### DIFF
--- a/localstack-core/localstack/aws/protocol/serializer.py
+++ b/localstack-core/localstack/aws/protocol/serializer.py
@@ -2192,7 +2192,7 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
 
     def _prepare_additional_traits_in_xml(self, root: ETree.Element | None, request_id: str):
         # some tools (Serverless) require a newline after the "<?xml ...>\n" preamble line, e.g., for LocationConstraint
-        if root and not root.tail:
+        if root is not None and not root.tail:
             root.tail = "\n"
 
         root.attrib["xmlns"] = self.XML_NAMESPACE


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Looking at some test run I saw the following warning in the logs:

```python
DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.

    if root and not root.tail:
```

I think we might have not been directly touched by that, except by the fact that `if root` might have returned `False` sometimes when we did not expect it to. 

## Changes

- update a truthiness check of `xml.ElementTree` to a `None` check before accessing an attribute

