### PR TITLE
Sns/v2 publish continued

### DIFF
--- a/localstack-core/localstack/services/sns/publisher.py
+++ b/localstack-core/localstack/services/sns/publisher.py
@@ -561,7 +561,10 @@ class HttpTopicPublisher(TopicPublisher):
             ):
                 return sub_content_type
 
-        if json_topic_delivery_policy := topic_attributes.get("delivery_policy"):
+        # TODO: remove lower case access once legacy v1 provider is removed
+        if json_topic_delivery_policy := topic_attributes.get(
+            "delivery_policy", topic_attributes.get("DeliveryPolicy")
+        ):
             topic_delivery_policy = json.loads(json_topic_delivery_policy)
             if not (
                 topic_content_type := topic_delivery_policy.get(subscriber["Protocol"].lower())

--- a/localstack-core/localstack/services/sns/v2/provider.py
+++ b/localstack-core/localstack/services/sns/v2/provider.py
@@ -690,9 +690,12 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     raise InvalidParameterException(
                         "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified"
                     )
-                elif not platform_endpoint.platform_endpoint["Attributes"].get(
-                    "Enabled"
-                ):  # TODO: double check enabled attribute
+                elif (
+                    not platform_endpoint.platform_endpoint["Attributes"]
+                    .get("Enabled", "false")
+                    .lower()
+                    == "true"
+                ):
                     raise EndpointDisabledException("Endpoint is disabled")
             else:
                 topic = self._get_topic(topic_or_target_arn, context)

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -212,6 +212,15 @@
       "total": 0.3
     }
   },
+  "tests/aws/services/sns/test_sns.py::TestSNSPlatformEndpoint::test_publish_disabled_endpoint": {
+    "last_validated_date": "2025-11-27T08:34:37+00:00",
+    "durations_in_seconds": {
+      "setup": 1.83,
+      "call": 48.48,
+      "teardown": 1.6,
+      "total": 51.91
+    }
+  },
   "tests/aws/services/sns/test_sns.py::TestSNSPlatformEndpointCrud::test_create_platform_endpoint": {
     "last_validated_date": "2025-10-31T21:26:47+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
This PR enables all of the remaining publish tests that were skipped due to the v2 provider not having enough features.
It also fixes wrong behaviour where the v2 provider incorrectly assigns a default SignatureVersion for fifo topics.
closes PNX-379
closes PNX-75
<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- re-enable most tests
- remove signature version = 2 for fifo topics
<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
