### PR TITLE
Remove incorrect deprecation message about USE_SSL

### DIFF
--- a/localstack-core/localstack/deprecations.py
+++ b/localstack-core/localstack/deprecations.py
@@ -35,12 +35,6 @@ class EnvVarDeprecation:
 # Please make sure this is in-sync with https://docs.localstack.cloud/references/configuration/
 #
 DEPRECATIONS = [
-    # Since 0.11.3 - HTTP / HTTPS multiplexing
-    EnvVarDeprecation(
-        "USE_SSL",
-        "0.11.3",
-        "Each endpoint now supports multiplexing HTTP/HTTPS traffic over the same port. Please remove this environment variable.",  # noqa
-    ),
     # Since 0.12.8 - PORT_UI was removed
     EnvVarDeprecation(
         "PORT_WEB_UI",


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

This PR removes wrong message about the environment variable `USE_SSL` being deprecated. The env variable is still being used and it is being used as:
> Whether to return URLs using HTTP (0) or HTTPS (1). Changed with 3.0.0. In earlier versions this was toggling SSL support on or off.

The env variable purpose is described in LocalStack docs [here](https://docs.localstack.cloud/aws/capabilities/config/configuration/)

## Changes

Remove deprecation message.

Closes FLC-194