### PR TITLE
fix minimum click version for used CLI features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "asn1crypto>=1.5.1",
-    "click>=7.1",
+    "click>=8.2.0",
     "cachetools>=5.0",
     "cryptography",
     "dill==0.3.6",


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13398, we explicitly marked the host mode as deprecated using click's native deprecation mechanism introduced in https://github.com/pallets/click/pull/2271.
Unfortunately, I forgot to bump the minimum version of click, and while we now need at least 8.2, in some environments with an older click version already present this can cause the following error:
```
Traceback (most recent call last):
  File "/home/runner/.local/bin/localstack", line 23, in <module>
    main()
  File "/home/runner/.local/bin/localstack", line 19, in main
    main.main()
  File "/home/runner/.local/lib/python3.12/site-packages/localstack/cli/main.py", line 15, in main
    from .localstack import create_with_plugins
  File "/home/runner/.local/lib/python3.12/site-packages/localstack/cli/localstack.py", line 436, in <module>
    @click.option("--host", is_flag=True, help="Start LocalStack directly on the host", deprecated=True)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 373, in decorator
    _param_memo(f, cls(param_decls, **attrs))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 2536, in __init__
    super().__init__(param_decls, type=type, multiple=multiple, **attrs)
TypeError: Parameter.__init__() got an unexpected keyword argument 'deprecated'
Error: Process completed with exit code 1.
```

## Changes
- Declare that we need `click>=8.2.0`.
- No need to update the dependency locks, since they are already on the latest version.

## Testing
Unfortunately, we can't really have a pipeline testing LocalStack's CLI with all the different possible dependency versions.
In the future we will revamp the CLI and at least extract it from the repo to make releases easier and disconnected to the runtime.
For now, I verified this fix manually:
```
cd /tmp
python3 -m venv .venv
source .venv/bin/activate
pip install localstack==4.11.0 click==8.1.2
localstack --help || true
# shows the error
pip install click==8.2.0
localstack --help
# shows the deprecation warning but works just fine
```