### PR TITLE
S3: fix change in behavior in CreateBucketConfiguration

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -492,16 +492,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not is_bucket_name_valid(bucket_name):
             raise InvalidBucketName("The specified bucket is not valid.", BucketName=bucket_name)
 
-        # the XML parser returns an empty dict if the body contains the following:
-        # <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />
-        # but it also returns an empty dict if the body is fully empty. We need to differentiate the 2 cases by checking
-        # if the body is empty or not
-        if context.request.data and (
-            (create_bucket_configuration := request.get("CreateBucketConfiguration")) is not None
-        ):
-            if not (bucket_region := create_bucket_configuration.get("LocationConstraint")):
-                raise MalformedXML()
-
+        # TODO: support `Tags` in `CreateBucketConfiguration`
+        create_bucket_configuration = request.get("CreateBucketConfiguration") or {}
+        bucket_region = create_bucket_configuration.get("LocationConstraint")
+        if bucket_region:
             if context.region == AWS_REGION_US_EAST_1:
                 if bucket_region in ("us-east-1", "aws-global"):
                     raise InvalidLocationConstraint(

--- a/tests/aws/services/s3/test_s3.snapshot.json
+++ b/tests/aws/services/s3/test_s3.snapshot.json
@@ -1137,7 +1137,7 @@
     }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "21-01-2025, 18:30:47",
+    "recorded-date": "27-11-2025, 10:52:05",
     "recorded-content": {
       "get-bucket-location-bucket-us-east-1": {
         "LocationConstraint": null,
@@ -1158,13 +1158,10 @@
         }
       },
       "create-bucket-constraint-us-east-1-with-None": {
-        "Error": {
-          "Code": "MalformedXML",
-          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
-        },
+        "Location": "<location>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 400
+          "HTTPStatusCode": 200
         }
       },
       "get-bucket-location-bucket-us-east-2": {
@@ -1175,6 +1172,16 @@
         }
       },
       "create-bucket-us-east-2-no-constraint-exc": {
+        "Error": {
+          "Code": "IllegalLocationConstraintException",
+          "Message": "The unspecified location constraint is incompatible for the region specific endpoint this request was sent to."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-bucket-constraint-us-east-2-with-None": {
         "Error": {
           "Code": "IllegalLocationConstraintException",
           "Message": "The unspecified location constraint is incompatible for the region specific endpoint this request was sent to."

--- a/tests/aws/services/s3/test_s3.validation.json
+++ b/tests/aws/services/s3/test_s3.validation.json
@@ -96,7 +96,13 @@
     "last_validated_date": "2025-01-21T18:31:37+00:00"
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "last_validated_date": "2025-01-21T18:30:47+00:00"
+    "last_validated_date": "2025-11-27T10:52:08+00:00",
+    "durations_in_seconds": {
+      "setup": 0.47,
+      "call": 5.59,
+      "teardown": 3.04,
+      "total": 9.1
+    }
   },
   "tests/aws/services/s3/test_s3.py::TestS3::test_download_fileobj_multiple_range_requests": {
     "last_validated_date": "2025-01-21T18:31:23+00:00"


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

We got a report that the newer 6.23 Terraform AWS provider version is failing with LocalStack: #13426

This is due to a change in what exceptions are being raised by AWS: previously, if the body contained a `CreateBucketConfiguration` XML tag, it also needed to have the `LocationConstraint` tag inside of it. This seems to have change in AWS, probably related to the new addition of the `Tags` XML tag inside of it: see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#AmazonS3-CreateBucket-request-Tags

When trying to revalidate the test against AWS, the exception was not raised anymore, so the logic of the provider has been updated. 

There is still more to be done to make the `6.23` AWS provider work with LocalStack, because it requires the new tagging endpoints that are not yet part of our stubs. Some follow-up work will still need to be done. 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- do not validate that `CreateBucketConfiguration` must contain `LocationConstraint` anymore
- update the tests against AWS

<!--
Summarise the changes proposed in the PR.
-->

## Next up

<!--
Optional: How are the proposed changes tested?
-->

Support the `Tags` input value in `CreateBucketConfiguration`

