### PR TITLE
feat: add tag support for step function activites

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/backend/activity.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/activity.py
@@ -7,8 +7,10 @@ from localstack.aws.api.stepfunctions import (
     Arn,
     DescribeActivityOutput,
     Name,
+    TagList,
     Timestamp,
 )
+from localstack.services.stepfunctions.backend.tag_manager import TagManager
 
 
 class ActivityTask:
@@ -21,16 +23,35 @@ class ActivityTask:
 
 
 class Activity:
+    """
+    Represents a Step Functions activity with tag support.
+
+    Activities are used for manual task execution in Step Functions workflows.
+    This class now includes a TagManager to support full tagging operations.
+    """
     arn: Final[Arn]
     name: Final[Name]
     creation_date: Final[Timestamp]
     _tasks: Final[deque[ActivityTask]]
+    tag_manager: Final[TagManager]  # Tag manager for activity tagging operations
 
-    def __init__(self, arn: Arn, name: Name, creation_date: Timestamp | None = None):
+    def __init__(self, arn: Arn, name: Name, tags: TagList | None = None, creation_date: Timestamp | None = None):
+        """
+        Initialize a new Activity.
+
+        :param arn: The ARN of the activity
+        :param name: The name of the activity
+        :param tags: Optional list of tags to apply to the activity
+        :param creation_date: Optional creation date (defaults to current time)
+        """
         self.arn = arn
         self.name = name
         self.creation_date = creation_date or datetime.datetime.now(tz=datetime.UTC)
         self._tasks = deque()
+        # Initialize tag manager and apply any initial tags
+        self.tag_manager = TagManager()
+        if tags:
+            self.tag_manager.add_all(tags)
 
     def add_task(self, task: ActivityTask):
         self._tasks.append(task)

--- a/localstack-core/localstack/services/stepfunctions/backend/state_machine.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/state_machine.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import datetime
 import json
-from collections import OrderedDict
 from typing import Final
 
 from localstack.aws.api.stepfunctions import (
@@ -17,11 +16,8 @@ from localstack.aws.api.stepfunctions import (
     StateMachineStatus,
     StateMachineType,
     StateMachineVersionListItem,
-    Tag,
-    TagKeyList,
     TagList,
     TracingConfiguration,
-    ValidationException,
     VariableReferences,
 )
 from localstack.services.stepfunctions.asl.eval.event.logging import (
@@ -31,6 +27,7 @@ from localstack.services.stepfunctions.asl.static_analyser.variable_references_s
     VariableReferencesStaticAnalyser,
 )
 from localstack.services.stepfunctions.backend.alias import Alias
+from localstack.services.stepfunctions.backend.tag_manager import TagManager
 from localstack.utils.strings import long_uid
 
 
@@ -122,42 +119,6 @@ class TestStateMachine(StateMachineInstance):
 
     def itemise(self):
         raise NotImplementedError("TestStateMachine does not support itemise.")
-
-
-class TagManager:
-    _tags: Final[dict[str, str | None]]
-
-    def __init__(self):
-        self._tags = OrderedDict()
-
-    @staticmethod
-    def _validate_key_value(key: str) -> None:
-        if not key:
-            raise ValidationException()
-
-    @staticmethod
-    def _validate_tag_value(value: str) -> None:
-        if value is None:
-            raise ValidationException()
-
-    def add_all(self, tags: TagList) -> None:
-        for tag in tags:
-            tag_key = tag["key"]
-            tag_value = tag["value"]
-            self._validate_key_value(key=tag_key)
-            self._validate_tag_value(value=tag_value)
-            self._tags[tag_key] = tag_value
-
-    def remove_all(self, keys: TagKeyList):
-        for key in keys:
-            self._validate_key_value(key=key)
-            self._tags.pop(key, None)
-
-    def to_tag_list(self) -> TagList:
-        tag_list = []
-        for key, value in self._tags.items():
-            tag_list.append(Tag(key=key, value=value))
-        return tag_list
 
 
 class StateMachineRevision(StateMachineInstance):

--- a/localstack-core/localstack/services/stepfunctions/backend/tag_manager.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/tag_manager.py
@@ -1,0 +1,85 @@
+"""
+Shared tag management utilities for Step Functions resources (state machines and activities).
+
+This module provides a common TagManager class used to handle tag operations
+across different Step Functions resource types.
+"""
+from collections import OrderedDict
+from typing import Final
+
+from localstack.aws.api.stepfunctions import Tag, TagKeyList, TagList, ValidationException
+
+
+class TagManager:
+    """
+    Manages tags for Step Functions resources (state machines and activities).
+
+    Provides methods to add, remove, and list tags while enforcing AWS tag validation rules.
+    Tags are stored in an OrderedDict to maintain insertion order.
+    """
+    _tags: Final[dict[str, str | None]]
+
+    def __init__(self):
+        self._tags = OrderedDict()
+
+    @staticmethod
+    def _validate_key_value(key: str) -> None:
+        """
+        Validate that a tag key is not empty.
+
+        :param key: The tag key to validate
+        :raises ValidationException: If key is empty or None
+        """
+        if not key:
+            raise ValidationException()
+
+    @staticmethod
+    def _validate_tag_value(value: str) -> None:
+        """
+        Validate that a tag value is not None.
+
+        :param value: The tag value to validate
+        :raises ValidationException: If value is None
+        """
+        if value is None:
+            raise ValidationException()
+
+    def add_all(self, tags: TagList) -> None:
+        """
+        Add multiple tags to the resource.
+
+        If a tag key already exists, its value will be updated.
+
+        :param tags: List of Tag objects to add
+        :raises ValidationException: If any tag key or value is invalid
+        """
+        for tag in tags:
+            tag_key = tag["key"]
+            tag_value = tag["value"]
+            self._validate_key_value(key=tag_key)
+            self._validate_tag_value(value=tag_value)
+            self._tags[tag_key] = tag_value
+
+    def remove_all(self, keys: TagKeyList):
+        """
+        Remove multiple tags from the resource by their keys.
+
+        If a key doesn't exist, it is silently ignored.
+
+        :param keys: List of tag keys to remove
+        :raises ValidationException: If any key is invalid
+        """
+        for key in keys:
+            self._validate_key_value(key=key)
+            self._tags.pop(key, None)
+
+    def to_tag_list(self) -> TagList:
+        """
+        Convert internal tag storage to AWS TagList format.
+
+        :return: List of Tag objects suitable for API responses
+        """
+        tag_list = []
+        for key, value in self._tags.items():
+            tag_list.append(Tag(key=key, value=value))
+        return tag_list


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Problem: Terraform AWS provider automatically calls ListTagsForResource after creating resources. When deploying Step Functions with activities, Terraform fails because LocalStack returns ResourceNotFound for activity ARNs, even though the activities were successfully created.

Root Cause: The list_tags_for_resource() function only checked the state_machines store and ignored activities entirely.

Solution: Add tag support for activities following the same pattern used for state machines.

## Changes
- Extracted TagManager to a shared module for reuse between activities and state machines
- Added tag_manager field to Activity class with proper initialization
- Updated tag_resource(), untag_resource(), and list_tags_for_resource() to handle both activity and state machine ARNs
- Updated create_activity() to accept and store tags

This implements the TODO comments at lines 1392, 1404, and 1416 in provider.py.

## Tests
Added 3 new test methods in test_sfn_api_tagging.py:
✅ test_tag_activity() - Tests tagging activities with various tag lists (empty, single, multiple)
✅ test_untag_activity() - Tests removing tags from activities
✅ test_create_activity_with_tags() - Tests creating activities with initial tags

```
# Create activity with tags
aws stepfunctions create-activity --name test --tags '[{"key":"env","value":"dev"}]'

# List tags (previously returned ResourceNotFound, now works)
aws stepfunctions list-tags-for-resource --resource-arn <activity-arn>

# Terraform now completes successfully without errors
```
## Related

- Closes [#13430](https://github.com/localstack/localstack/issues/13430)
- Fixes DRG-420
