### PR TITLE
S3Control: implement Tagging support for S3 Bucket

### DIFF
--- a/localstack-core/localstack/services/s3control/provider.py
+++ b/localstack-core/localstack/services/s3control/provider.py
@@ -1,5 +1,104 @@
-from localstack.aws.api.s3control import S3ControlApi
+from localstack.aws.api import CommonServiceException, RequestContext
+from localstack.aws.api.s3control import (
+    AccountId,
+    ListTagsForResourceResult,
+    S3ControlApi,
+    S3ResourceArn,
+    TagKeyList,
+    TagList,
+    TagResourceResult,
+    UntagResourceResult,
+)
+from localstack.aws.forwarder import NotImplementedAvoidFallbackError
+from localstack.services.s3.models import s3_stores
+from localstack.services.s3control.validation import validate_tags
+from localstack.utils.tagging import TaggingService
+
+
+class NoSuchResource(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("NoSuchResource", status_code=404, message=message)
 
 
 class S3ControlProvider(S3ControlApi):
-    pass
+    """
+    S3Control is a management interface for S3, and can access some of its internals with no public API
+    This requires us to access the s3 stores directly
+    """
+
+    @staticmethod
+    def _get_tagging_service_for_bucket(
+        resource_arn: S3ResourceArn,
+        partition: str,
+        region: str,
+        account_id: str,
+    ) -> TaggingService:
+        s3_prefix = f"arn:{partition}:s3:::"
+        if not resource_arn.startswith(s3_prefix):
+            # Moto does not support Tagging operations for S3 Control, so we should not forward those operations back
+            # to it
+            raise NotImplementedAvoidFallbackError(
+                "LocalStack only support Bucket tagging operations for S3Control"
+            )
+
+        store = s3_stores[account_id][region]
+        bucket_name = resource_arn.removeprefix(s3_prefix)
+        if bucket_name not in store.global_bucket_map:
+            raise NoSuchResource("The specified resource doesn't exist.")
+
+        return store.TAGS
+
+    def tag_resource(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        resource_arn: S3ResourceArn,
+        tags: TagList,
+        **kwargs,
+    ) -> TagResourceResult:
+        # currently S3Control only supports tagging buckets
+        tagging_service = self._get_tagging_service_for_bucket(
+            resource_arn=resource_arn,
+            partition=context.partition,
+            region=context.region,
+            account_id=account_id,
+        )
+
+        validate_tags(tags=tags)
+        tagging_service.tag_resource(resource_arn, tags)
+
+        return TagResourceResult()
+
+    def untag_resource(
+        self,
+        context: RequestContext,
+        account_id: AccountId,
+        resource_arn: S3ResourceArn,
+        tag_keys: TagKeyList,
+        **kwargs,
+    ) -> UntagResourceResult:
+        # currently S3Control only supports tagging buckets
+        tagging_service = self._get_tagging_service_for_bucket(
+            resource_arn=resource_arn,
+            partition=context.partition,
+            region=context.region,
+            account_id=account_id,
+        )
+
+        tagging_service.untag_resource(resource_arn, tag_keys)
+
+        return TagResourceResult()
+
+    def list_tags_for_resource(
+        self, context: RequestContext, account_id: AccountId, resource_arn: S3ResourceArn, **kwargs
+    ) -> ListTagsForResourceResult:
+        # currently S3Control only supports tagging buckets
+        tagging_service = self._get_tagging_service_for_bucket(
+            resource_arn=resource_arn,
+            partition=context.partition,
+            region=context.region,
+            account_id=account_id,
+        )
+
+        tags = tagging_service.list_tags_for_resource(resource_arn)
+        return ListTagsForResourceResult(Tags=tags["Tags"])

--- a/localstack-core/localstack/services/s3control/validation.py
+++ b/localstack-core/localstack/services/s3control/validation.py
@@ -1,0 +1,50 @@
+from localstack.aws.api.s3 import InvalidTag
+from localstack.aws.api.s3control import Tag, TagList
+from localstack.services.s3.exceptions import MalformedXML
+from localstack.services.s3.utils import TAG_REGEX
+
+
+def validate_tags(tags: TagList):
+    """
+    Validate the tags provided. This is the same function as S3, but with different error messages
+    :param tags: a TagList object
+    :raises MalformedXML if the object does not conform to the schema
+    :raises InvalidTag if the tag key or value are outside the set of validations defined by S3 and S3Control
+    :return: None
+    """
+    keys = set()
+    for tag in tags:
+        tag: Tag
+        if set(tag) != {"Key", "Value"}:
+            raise MalformedXML()
+
+        key = tag["Key"]
+        value = tag["Value"]
+
+        if key is None or value is None:
+            raise MalformedXML()
+
+        if key in keys:
+            raise InvalidTag(
+                "There are duplicate tag keys in your request. Remove the duplicate tag keys and try again.",
+                TagKey=key,
+            )
+
+        if key.startswith("aws:"):
+            raise InvalidTag(
+                'User-defined tag keys can\'t start with "aws:". This prefix is reserved for system tags. Remove "aws:" from your tag keys and try again.',
+            )
+
+        if not TAG_REGEX.match(key):
+            raise InvalidTag(
+                "This request contains a tag key or value that isn't valid. Valid characters include the following: [a-zA-Z+-=._:/]. Tag keys can contain up to 128 characters. Tag values can contain up to 256 characters.",
+                TagKey=key,
+            )
+        elif not TAG_REGEX.match(value):
+            raise InvalidTag(
+                "This request contains a tag key or value that isn't valid. Valid characters include the following: [a-zA-Z+-=._:/]. Tag keys can contain up to 128 characters. Tag values can contain up to 256 characters.",
+                TagKey=key,
+                TagValue=value,
+            )
+
+        keys.add(key)

--- a/tests/aws/services/s3control/test_s3control.snapshot.json
+++ b/tests/aws/services/s3control/test_s3control.snapshot.json
@@ -589,5 +589,202 @@
         }
       }
     }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlTagging::test_tag_lifecycle": {
+    "recorded-date": "28-11-2025, 11:45:27",
+    "recorded-content": {
+      "list-tags-before": {
+        "Tags": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag-resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-tags-1": {
+        "Tags": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          },
+          {
+            "Key": "key2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag-resource-after-update": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-tags-after-update": {
+        "Tags": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          },
+          {
+            "Key": "key2",
+            "Value": "value2"
+          },
+          {
+            "Key": "key3",
+            "Value": "value3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag-resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "list-tags-after-untag": {
+        "Tags": [
+          {
+            "Key": "key1",
+            "Value": "value1"
+          },
+          {
+            "Key": "key2",
+            "Value": "value2"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "untag-resource-idempotent": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlTagging::test_tag_resource_validation": {
+    "recorded-date": "28-11-2025, 12:06:32",
+    "recorded-content": {
+      "tags-key-none": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "tags-value-none": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "tags-key-aws-prefix": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "User-defined tag keys can't start with \"aws:\". This prefix is reserved for system tags. Remove \"aws:\" from your tag keys and try again."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "tags-key-aws-duplicated-key": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "There are duplicate tag keys in your request. Remove the duplicate tag keys and try again."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "tags-key-aws-bad-value": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "This request contains a tag key or value that isn't valid. Valid characters include the following: [a-zA-Z+-=._:/]. Tag keys can contain up to 128 characters. Tag values can contain up to 256 characters."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "tags-key-aws-bad-key": {
+        "Error": {
+          "Code": "InvalidTag",
+          "Message": "This request contains a tag key or value that isn't valid. Valid characters include the following: [a-zA-Z+-=._:/]. Tag keys can contain up to 128 characters. Tag values can contain up to 256 characters."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlTagging::test_tag_operation_no_bucket": {
+    "recorded-date": "28-11-2025, 11:45:32",
+    "recorded-content": {
+      "tag-resource-no-exist": {
+        "Error": {
+          "Code": "NoSuchResource",
+          "Message": "The specified resource doesn't exist."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "untag-resource-no-exist": {
+        "Error": {
+          "Code": "NoSuchResource",
+          "Message": "The specified resource doesn't exist."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "list-resource-tags-no-exist": {
+        "Error": {
+          "Code": "NoSuchResource",
+          "Message": "The specified resource doesn't exist."
+        },
+        "HostId": "host-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/s3control/test_s3control.validation.json
+++ b/tests/aws/services/s3control/test_s3control.validation.json
@@ -25,5 +25,32 @@
   },
   "tests/aws/services/s3control/test_s3control.py::TestS3ControlPublicAccessBlock::test_empty_public_access_block": {
     "last_validated_date": "2024-05-30T17:32:59+00:00"
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlTagging::test_tag_lifecycle": {
+    "last_validated_date": "2025-11-28T11:45:28+00:00",
+    "durations_in_seconds": {
+      "setup": 1.07,
+      "call": 1.41,
+      "teardown": 0.64,
+      "total": 3.12
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlTagging::test_tag_operation_no_bucket": {
+    "last_validated_date": "2025-11-28T11:45:33+00:00",
+    "durations_in_seconds": {
+      "setup": 0.54,
+      "call": 0.56,
+      "teardown": 0.6,
+      "total": 1.7
+    }
+  },
+  "tests/aws/services/s3control/test_s3control.py::TestS3ControlTagging::test_tag_resource_validation": {
+    "last_validated_date": "2025-11-28T12:06:32+00:00",
+    "durations_in_seconds": {
+      "setup": 1.18,
+      "call": 2.18,
+      "teardown": 0.61,
+      "total": 3.97
+    }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Following the #13426 report and fixing the first reported issue, when trying the sample, I got a report from Terraform than the tagging operations for S3 were not implemented, but after having a better look I finally realized it was S3 Control:

```
│ Error: listing tags for S3 (Simple Storage) Bucket (my-test-bucket): operation error S3 Control: ListTagsForResource, https response error StatusCode: 501, RequestID: 8f07ba3c-e0ef-4497-9c57-d4f4d6af4238, HostID: , api error InternalFailure: No moto route for service s3control on path /v20180820/tags/arn%3Aaws%3As3%3A%3A%3Amy-test-bucket found.
│ 
│   with aws_s3_bucket.test,
│   on main.tf line 37, in resource "aws_s3_bucket" "test":
│   37: resource "aws_s3_bucket" "test" {
│ 
```

I first got this issue:
```
│ Error: listing tags for S3 (Simple Storage) Bucket (my-test-bucket): operation error S3 Control: ListTagsForResource, failed to resolve service endpoint, endpoint rule error, AccountId must only contain a-z, A-Z, 0-9 and `-`.
│ 
│   with aws_s3_bucket.test,
│   on main.tf line 37, in resource "aws_s3_bucket" "test":
│   37: resource "aws_s3_bucket" "test" {
│ 
```

Because the `skip_requesting_account_id  = true` was set, but worked after removing it, so something to keep note of. 

This PR implements implements the 3 tagging operations `ListTagsForResource`, `TagResource` and `UntagResource` for S3 Buckets via S3 Control. 
This unblocks the `6.23` AWS Terraform provider and it now works if you check out this PR.

A follow up from this pr will be to implement `PutBucketAbac` and `GetBucketAbac`. 

Another thing to note is that S3 Control is heavily tied and coupled to S3, and seems to be able to mutate S3 internal state in AWS without going through public APIs, which justify the uses of the `s3_stores` directly here. 


<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- implement the 3 tagging operations in the S3 Control provider
- add the tests related to the feature

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->
To fully validate that the issue is fixed for the Terraform provider, you can try the sample given in the linked issue, just remove the `skip_requesting_account_id  = true` line. 
