### PR TITLE
Fix version evaluation of boto3 in asf update action

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -68,9 +68,20 @@ jobs:
           source .venv/bin/activate
           # determine botocore version in venv
           BOTOCORE_VERSION=$(python -c "import botocore; print(botocore.__version__)");
-          echo "Pinning botocore, boto3, and boto3-stubs to version $BOTOCORE_VERSION"
+          echo "Pinning botocore to version $BOTOCORE_VERSION"
           bin/release-helper.sh set-dep-ver botocore "==$BOTOCORE_VERSION"
-          bin/release-helper.sh set-dep-ver boto3 "==$BOTOCORE_VERSION"
+
+          # determine boto3 version that works with $BOTOCORE_VERSION
+          uv venv /tmp/boto3-ver-venv
+          source /tmp/boto3-ver-venv/bin/activate
+          uv pip install "botocore==$BOTOCORE_VERSION" boto3
+          export BOTO3_VERSION=$(uv pip list --format=json | jq -r '.[] | select(.name=="boto3") | .version')
+          deactivate
+
+          # pin boto3 to that predetermined version
+          source .venv/bin/activate
+          echo "Pinning boto3 to version $BOTO3_VERSION"
+          bin/release-helper.sh set-dep-ver boto3 "==$BOTO3_VERSION"
 
           # determine awscli version that works with $BOTOCORE_VERSION
           uv venv /tmp/awscli-ver-venv
@@ -86,11 +97,11 @@ jobs:
 
           # upgrade the requirements files only for the botocore package
           python3 -m pip install --upgrade pip pip-tools
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra runtime -o requirements-runtime.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra test -o requirements-test.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra dev -o requirements-dev.txt pyproject.toml
-          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTOCORE_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra typehint -o requirements-typehint.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTO3_VERSION" --extra base-runtime -o requirements-base-runtime.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTO3_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra runtime -o requirements-runtime.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTO3_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra test -o requirements-test.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTO3_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra dev -o requirements-dev.txt pyproject.toml
+          pip-compile --strip-extras --upgrade-package "botocore==$BOTOCORE_VERSION" --upgrade-package "boto3==$BOTO3_VERSION" --upgrade-package "awscli==$AWSCLI_VERSION" --extra typehint -o requirements-typehint.txt pyproject.toml
 
       - name: Read PR markdown template
         if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Since `botocore==1.41.6`, `botocore` and `boto3` don't follow the same versioning scheme anymore. `botocore` updated to [1.41.6](https://pypi.org/project/botocore/1.41.6/) and `boto3` updated to [1.42.0](https://pypi.org/project/boto3/1.42.0/).

It is unclear if that was intentional or not. However, this shows we need to treat the boto3 version like the `awscli` version now and only determine it based on the upgraded `botocore` version. 

/cc @joe4dev 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

- Add the same version evaluation procedure that we're using for the awscli to determine the correct version for boto3 based on the botocore version

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

Running the ASF update action from this branch fixes the issue: https://github.com/localstack/localstack/actions/runs/19826844004/job/56802328770

It resulted in the successful ASF update PR #13443 (closed it to start a new one from main)

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->

FLC-210
