### PR TITLE
[SFN][TestState] Add test for invalid state machine definition in test state call

### DIFF
--- a/tests/aws/services/stepfunctions/templates/test_state/statemachines/base_invalid_state_definition.json5
+++ b/tests/aws/services/stepfunctions/templates/test_state/statemachines/base_invalid_state_definition.json5
@@ -1,0 +1,10 @@
+{
+  "Comment": "Base state machine with a state that is not a valid state definition.",
+  "StartAt": "ExistingButInvalidState",
+  "States": {
+    "ExistingButInvalidState": {
+      "Type": "TypeThatDoesNotExist",
+      "End": true
+    }
+  }
+}

--- a/tests/aws/services/stepfunctions/templates/test_state/test_state_templates.py
+++ b/tests/aws/services/stepfunctions/templates/test_state/test_state_templates.py
@@ -124,3 +124,7 @@ class TestStateMachineTemplate(TemplateLoader):
     LOCALSTACK_BLOGPOST_SCENARIO_STATE_MACHINE: Final[str] = os.path.join(
         _THIS_FOLDER, "statemachines/localstack_blogpost_scenario_state_machine.json5"
     )
+
+    BASE_INVALID_STATE_DEFINITION: Final[str] = os.path.join(
+        _THIS_FOLDER, "statemachines/base_invalid_state_definition.json5"
+    )

--- a/tests/aws/services/stepfunctions/v2/test_state/test_test_state_machine_scenarios.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_test_state_machine_scenarios.snapshot.json
@@ -345,5 +345,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_test_state_machine_scenarios.py::TestStateMachineScenarios::test_state_name_invalid_state_definition": {
+    "recorded-date": "04-12-2025, 12:16:39",
+    "recorded-content": {
+      "validation_exception": {
+        "Error": {
+          "Code": "InvalidDefinition",
+          "Message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The field 'Type' should have one of these values: [Task, Wait, Pass, Succeed, Fail, Choice, Parallel, Map] at /States/ExistingButInvalidState/Type'"
+        },
+        "message": "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: The field 'Type' should have one of these values: [Task, Wait, Pass, Succeed, Fail, Choice, Parallel, Map] at /States/ExistingButInvalidState/Type'",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/stepfunctions/v2/test_state/test_test_state_machine_scenarios.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_test_state_machine_scenarios.validation.json
@@ -160,5 +160,14 @@
       "teardown": 0.0,
       "total": 0.59
     }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_test_state_machine_scenarios.py::TestStateMachineScenarios::test_state_name_invalid_state_definition": {
+    "last_validated_date": "2025-12-04T12:16:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.55,
+      "call": 0.67,
+      "teardown": 0.0,
+      "total": 1.22
+    }
   }
 }


### PR DESCRIPTION
Ignoring the exact validation message for now

<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Add tests for failure modes.

Closes DRG-133.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Adds a test for invalid state machine definition in test state call.

ANTLR parser message has different wording but the same meaning as AWS response. Not investing time now to convert to the exact same wording - relying on error code for test.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
