### PR TITLE
Lambda: Raise error when function added a capacity provider

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1362,6 +1362,19 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             if new_mode:
                 replace_kwargs["tracing_config_mode"] = new_mode
 
+        if "CapacityProviderConfig" in request:
+            if latest_version.config.CapacityProviderConfig and not request[
+                "CapacityProviderConfig"
+            ].get("LambdaManagedInstancesCapacityProviderConfig"):
+                raise ValidationException(
+                    "1 validation error detected: Value null at 'capacityProviderConfig.lambdaManagedInstancesCapacityProviderConfig' failed to satisfy constraint: Member must not be null"
+                )
+            if not latest_version.config.CapacityProviderConfig:
+                raise InvalidParameterValueException(
+                    "CapacityProviderConfig isn't supported for Lambda Default functions.",
+                    Type="User",
+                )
+
         new_latest_version = dataclasses.replace(
             latest_version,
             config=dataclasses.replace(


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Normal function updated doesn't support adding a capacity provider.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
Companion to https://github.com/localstack/localstack-pro/pull/5705