### PR TITLE
 update kinesis-mock from 0.5.1 to 0.5.2

### DIFF
--- a/localstack-core/localstack/services/kinesis/packages.py
+++ b/localstack-core/localstack/services/kinesis/packages.py
@@ -7,7 +7,7 @@ from localstack.packages import InstallTarget, Package
 from localstack.packages.core import GitHubReleaseInstaller, NodePackageInstaller
 from localstack.packages.java import JavaInstallerMixin, java_package
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.5.1"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.5.2"
 
 
 class KinesisMockEngine(StrEnum):


### PR DESCRIPTION
## Motivation
@etspaceman released new patch version of `kinesis-mock`:  [`0.5.2`](https://github.com/etspaceman/kinesis-mock/releases/tag/v0.5.2) 🥳 
The changelog for the `0.5.2` show that the release contains a small fix and lots of dependency updates.
This PR upgrades `kinesis-mock` to the latest version, see https://github.com/localstack/localstack/pull/13371 for the last upgrade.

## Changes
- Changes the default version of the `kinesis-mock` package from `0.5.1` to `0.5.2`.