### PR TITLE
fix/external client CA bundle

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -687,7 +687,12 @@ class ExternalBypassDnsClientFactory(ExternalAwsClientFactory):
         if ca_cert := os.getenv("REQUESTS_CA_BUNDLE"):
             LOG.debug("Creating External AWS Client with REQUESTS_CA_BUNDLE=%s", ca_cert)
 
-        super().__init__(use_ssl=True, verify=ca_cert or True, session=session, config=config)
+        super().__init__(
+            use_ssl=localstack_config.is_env_not_false("USE_SSL"),
+            verify=ca_cert or True,
+            session=session,
+            config=config,
+        )
 
     def _get_client_post_hook(self, client: BaseClient) -> BaseClient:
         client = super()._get_client_post_hook(client)


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

This PR enforces custom CA Certificates to the `ExternalBypassDnsClientFactory`. This change will enable our users using proxy with ssl termination to register their own CA bundles.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

The CA bundle provided with `REQUESTS_CA_BUNDLE` will now be used to configure the connections of the `ExternalBypassDnsClientFactory`

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

fixes UNC-137
upstream test full-run: 19842076873

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
