### PR TITLE
[SFN][TestState] Add validations for mock presence depending on state type

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -1515,11 +1515,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             raise ValidationException("State not found in definition")
 
         mock_input = request.get("mock")
+        TestStateStaticAnalyser.validate_mock(
+            mock_input=mock_input, definition=definition, state_name=state_name
+        )
         if mock_input is not None:
             self._validate_test_state_mock_input(mock_input)
-            TestStateStaticAnalyser.validate_mock(
-                mock_input=mock_input, definition=definition, state_name=state_name
-            )
 
         if state_configuration := request.get("stateConfiguration"):
             # TODO: Add validations for this i.e assert len(input) <= failureCount

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-PassState]": {
-    "recorded-date": "02-12-2025, 14:11:36",
+    "recorded-date": "03-12-2025, 16:48:23",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -16,7 +16,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-FailState]": {
-    "recorded-date": "02-12-2025, 14:11:51",
+    "recorded-date": "03-12-2025, 16:48:23",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -32,7 +32,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-SucceedState]": {
-    "recorded-date": "02-12-2025, 14:12:05",
+    "recorded-date": "03-12-2025, 16:48:23",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -48,7 +48,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-PassState]": {
-    "recorded-date": "02-12-2025, 14:12:19",
+    "recorded-date": "03-12-2025, 16:48:23",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -64,7 +64,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-FailState]": {
-    "recorded-date": "02-12-2025, 14:12:33",
+    "recorded-date": "03-12-2025, 16:48:23",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -80,7 +80,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-SucceedState]": {
-    "recorded-date": "02-12-2025, 14:12:47",
+    "recorded-date": "03-12-2025, 16:48:24",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -88,6 +88,38 @@
           "Message": "State type 'Succeed' is not supported when a mock is specified"
         },
         "message": "State type 'Succeed' is not supported when a mock is specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapState]": {
+    "recorded-date": "03-12-2025, 16:48:24",
+    "recorded-content": {
+      "validation_exception": {
+        "Error": {
+          "Code": "InvalidDefinition",
+          "Message": "TestState API does not support Map or Parallel states. Supported state types include: [Task, Wait, Pass, Succeed, Fail, Choice]"
+        },
+        "message": "TestState API does not support Map or Parallel states. Supported state types include: [Task, Wait, Pass, Succeed, Fail, Choice]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapTaskState]": {
+    "recorded-date": "03-12-2025, 16:48:24",
+    "recorded-content": {
+      "validation_exception": {
+        "Error": {
+          "Code": "InvalidDefinition",
+          "Message": "TestState API does not support Map or Parallel states. Supported state types include: [Task, Wait, Pass, Succeed, Fail, Choice]"
+        },
+        "message": "TestState API does not support Map or Parallel states. Supported state types include: [Task, Wait, Pass, Succeed, Fail, Choice]",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.validation.json
@@ -1,56 +1,74 @@
 {
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-FailState]": {
-    "last_validated_date": "2025-12-02T14:12:34+00:00",
+    "last_validated_date": "2025-12-03T16:48:23+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 13.1,
-      "teardown": 1.12,
-      "total": 14.22
+      "call": 0.22,
+      "teardown": 0.0,
+      "total": 0.22
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-PassState]": {
-    "last_validated_date": "2025-12-02T14:12:20+00:00",
+    "last_validated_date": "2025-12-03T16:48:23+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 12.97,
-      "teardown": 1.14,
-      "total": 14.11
+      "call": 0.2,
+      "teardown": 0.0,
+      "total": 0.2
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-SucceedState]": {
-    "last_validated_date": "2025-12-02T14:12:48+00:00",
+    "last_validated_date": "2025-12-03T16:48:24+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 12.89,
-      "teardown": 1.06,
-      "total": 13.95
+      "call": 0.21,
+      "teardown": 0.0,
+      "total": 0.21
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-FailState]": {
-    "last_validated_date": "2025-12-02T14:11:52+00:00",
+    "last_validated_date": "2025-12-03T16:48:23+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 12.93,
-      "teardown": 1.1,
-      "total": 14.03
+      "call": 0.23,
+      "teardown": 0.0,
+      "total": 0.23
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-PassState]": {
-    "last_validated_date": "2025-12-02T14:11:38+00:00",
+    "last_validated_date": "2025-12-03T16:48:23+00:00",
     "durations_in_seconds": {
-      "setup": 0.5,
-      "call": 14.06,
-      "teardown": 1.15,
-      "total": 15.71
+      "setup": 0.54,
+      "call": 0.67,
+      "teardown": 0.0,
+      "total": 1.21
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-SucceedState]": {
-    "last_validated_date": "2025-12-02T14:12:06+00:00",
+    "last_validated_date": "2025-12-03T16:48:23+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 13.01,
-      "teardown": 1.08,
-      "total": 14.09
+      "call": 0.22,
+      "teardown": 0.0,
+      "total": 0.22
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapState]": {
+    "last_validated_date": "2025-12-03T16:48:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.19,
+      "teardown": 0.0,
+      "total": 0.19
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapTaskState]": {
+    "last_validated_date": "2025-12-03T16:48:24+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.57,
+      "teardown": 0.0,
+      "total": 0.57
     }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Add validations for mock presence depending on state type.

Closes DRG-310

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Add validations:

- mock is specified and the tested state is a Pass state
- mock is specified and the tested state is a Success state
- mock is specified and the tested state is a Fail state
- mock is not specified and the tested state is a Map or a Parallel state


<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
