### PR TITLE
[SFN][TestState] Fix state context tests MA/MR run failure

### DIFF
--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py
@@ -19,14 +19,14 @@ TEST_STATE_NAME: Final[str] = "TestState"
 
 _CONTEXT_OBJECT_FULL: Final[dict] = {
     "Execution": {
-        "Id": "arn:aws:states:__region_placeholder__:__account_id_placeholder__:execution:MyStateMachine:execution-name-12345",
+        "Id": "arn:aws:states:::execution:MyStateMachine:execution-name-12345",
         "Input": {
             "input-value": 0,
             "message": "test data",
             "values": ["charizard", "pikachu", "bulbasaur"],
         },
         "Name": "execution-name-12345",
-        "RoleArn": "arn:aws:iam::__account_id_placeholder__:role/StepFunctionsRole",
+        "RoleArn": "arn:aws:iam:::role/StepFunctionsRole",
         "StartTime": "2025-01-15T10:30:00.000Z",
     },
     "State": {
@@ -35,7 +35,7 @@ _CONTEXT_OBJECT_FULL: Final[dict] = {
         "RetryCount": 0,
     },
     "StateMachine": {
-        "Id": "arn:aws:states:__region_placeholder__:__account_id_placeholder__:stateMachine:MyStateMachine",
+        "Id": "arn:aws:states:::stateMachine:MyStateMachine",
         "Name": "MyStateMachine",
     },
     # Context object contains 'Task' when state is not a Task state with a '.sync' or '.waitForTaskToken' service integration pattern
@@ -67,8 +67,6 @@ class TestStateContextObject:
     def test_state_task_context_object(
         self,
         aws_client_no_sync_prefix,
-        region_name,
-        account_id,
         sfn_snapshot,
         context_object_literal,
     ):
@@ -88,15 +86,11 @@ class TestStateContextObject:
         )
         mocked_result = json.dumps({"pokemon": ["charizard", "pikachu", "bulbasaur"]})
 
-        context_object_full = CONTEXT_OBJECT_FULL.replace(
-            "__region_placeholder__", region_name
-        ).replace("__account_id_placeholder__", account_id)
-
         test_case_response = aws_client_no_sync_prefix.stepfunctions.test_state(
             definition=definition,
             input=exec_input,
             inspectionLevel=InspectionLevel.TRACE,
-            context=context_object_full,
+            context=CONTEXT_OBJECT_FULL,
             mock={"result": mocked_result},
         )
         sfn_snapshot.match("test_case_response", test_case_response)
@@ -105,8 +99,6 @@ class TestStateContextObject:
     def test_state_wait_task_context_object(
         self,
         aws_client_no_sync_prefix,
-        region_name,
-        account_id,
         sfn_snapshot,
     ):
         state_template = TST.load_sfn_template(
@@ -116,14 +108,10 @@ class TestStateContextObject:
         definition = json.dumps(state_template)
         mocked_result = json.dumps({"pokemon": ["charizard", "pikachu", "bulbasaur"]})
 
-        task_context_object_full = TASK_CONTEXT_OBJECT_FULL.replace(
-            "__region_placeholder__", region_name
-        ).replace("__account_id_placeholder__", account_id)
-
         test_case_response = aws_client_no_sync_prefix.stepfunctions.test_state(
             definition=definition,
             inspectionLevel=InspectionLevel.TRACE,
-            context=task_context_object_full,
+            context=TASK_CONTEXT_OBJECT_FULL,
             mock={"result": mocked_result},
         )
         sfn_snapshot.match("test_case_response", test_case_response)
@@ -138,8 +126,6 @@ class TestStateContextObject:
     def test_state_map_context_object(
         self,
         aws_client_no_sync_prefix,
-        region_name,
-        account_id,
         sfn_snapshot,
         context_object_literal,
     ):
@@ -157,15 +143,11 @@ class TestStateContextObject:
         exec_input = json.dumps(["fire", "electricity", "grass"])
         mocked_result = json.dumps(["CHARIZARD", "PIKACHU", "BULBASAUR"])
 
-        context_object_full = CONTEXT_OBJECT_FULL.replace(
-            "__region_placeholder__", region_name
-        ).replace("__account_id_placeholder__", account_id)
-
         test_case_response = aws_client_no_sync_prefix.stepfunctions.test_state(
             definition=definition,
             input=exec_input,
             inspectionLevel=InspectionLevel.TRACE,
-            context=context_object_full,
+            context=CONTEXT_OBJECT_FULL,
             mock={"result": mocked_result},
         )
         sfn_snapshot.match("test_case_response", test_case_response)

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[ALL]": {
-    "recorded-date": "03-12-2025, 12:32:47",
+    "recorded-date": "03-12-2025, 18:51:48",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
@@ -24,7 +24,7 @@
           "afterResultPath": {
             "ContextObjectValue": {
               "Execution": {
-                "Id": "arn:<partition>:states:<region>:111111111111:execution:MyStateMachine:execution-name-12345",
+                "Id": "arn:<partition>:states:::execution:MyStateMachine:execution-name-12345",
                 "Input": {
                   "input-value": 0,
                   "message": "test data",
@@ -35,7 +35,7 @@
                   ]
                 },
                 "Name": "execution-name-12345",
-                "RoleArn": "arn:<partition>:iam::111111111111:role/StepFunctionsRole",
+                "RoleArn": "arn:<partition>:iam:::role/StepFunctionsRole",
                 "StartTime": "date"
               },
               "State": {
@@ -44,7 +44,7 @@
                 "RetryCount": 0
               },
               "StateMachine": {
-                "Id": "arn:<partition>:states:<region>:111111111111:stateMachine:MyStateMachine",
+                "Id": "arn:<partition>:states:::stateMachine:MyStateMachine",
                 "Name": "MyStateMachine"
               }
             },
@@ -59,7 +59,7 @@
           "afterResultSelector": {
             "ContextObjectValue": {
               "Execution": {
-                "Id": "arn:<partition>:states:<region>:111111111111:execution:MyStateMachine:execution-name-12345",
+                "Id": "arn:<partition>:states:::execution:MyStateMachine:execution-name-12345",
                 "Input": {
                   "input-value": 0,
                   "message": "test data",
@@ -70,7 +70,7 @@
                   ]
                 },
                 "Name": "execution-name-12345",
-                "RoleArn": "arn:<partition>:iam::111111111111:role/StepFunctionsRole",
+                "RoleArn": "arn:<partition>:iam:::role/StepFunctionsRole",
                 "StartTime": "date"
               },
               "State": {
@@ -79,7 +79,7 @@
                 "RetryCount": 0
               },
               "StateMachine": {
-                "Id": "arn:<partition>:states:<region>:111111111111:stateMachine:MyStateMachine",
+                "Id": "arn:<partition>:states:::stateMachine:MyStateMachine",
                 "Name": "MyStateMachine"
               }
             },
@@ -108,7 +108,7 @@
         "output": {
           "ContextObjectValue": {
             "Execution": {
-              "Id": "arn:<partition>:states:<region>:111111111111:execution:MyStateMachine:execution-name-12345",
+              "Id": "arn:<partition>:states:::execution:MyStateMachine:execution-name-12345",
               "Input": {
                 "input-value": 0,
                 "message": "test data",
@@ -119,7 +119,7 @@
                 ]
               },
               "Name": "execution-name-12345",
-              "RoleArn": "arn:<partition>:iam::111111111111:role/StepFunctionsRole",
+              "RoleArn": "arn:<partition>:iam:::role/StepFunctionsRole",
               "StartTime": "date"
             },
             "State": {
@@ -128,7 +128,7 @@
               "RetryCount": 0
             },
             "StateMachine": {
-              "Id": "arn:<partition>:states:<region>:111111111111:stateMachine:MyStateMachine",
+              "Id": "arn:<partition>:states:::stateMachine:MyStateMachine",
               "Name": "MyStateMachine"
             }
           },
@@ -149,7 +149,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[EXECUTION_INPUT]": {
-    "recorded-date": "03-12-2025, 12:32:47",
+    "recorded-date": "03-12-2025, 18:51:48",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
@@ -247,7 +247,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[EXECUTION_INPUT_VALUES]": {
-    "recorded-date": "03-12-2025, 12:32:47",
+    "recorded-date": "03-12-2025, 18:51:49",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
@@ -333,7 +333,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_wait_task_context_object": {
-    "recorded-date": "03-12-2025, 12:32:47",
+    "recorded-date": "03-12-2025, 18:51:49",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
@@ -389,7 +389,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[ALL]": {
-    "recorded-date": "03-12-2025, 12:32:47",
+    "recorded-date": "03-12-2025, 18:51:49",
     "recorded-content": {
       "test_case_response": {
         "cause": "Reference path \"$\" must point to array.",
@@ -407,7 +407,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[EXECUTION_INPUT]": {
-    "recorded-date": "03-12-2025, 12:32:48",
+    "recorded-date": "03-12-2025, 18:51:49",
     "recorded-content": {
       "test_case_response": {
         "cause": "Reference path \"$.Execution.Input\" must point to array.",
@@ -425,7 +425,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[EXECUTION_INPUT_VALUES]": {
-    "recorded-date": "03-12-2025, 12:32:48",
+    "recorded-date": "03-12-2025, 18:51:49",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
@@ -446,7 +446,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_invalid_states[TOKEN_TASK_NOT_SYNC]": {
-    "recorded-date": "03-12-2025, 12:32:48",
+    "recorded-date": "03-12-2025, 18:51:50",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -455,7 +455,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_invalid_states[INVALID_STATE_PASS]": {
-    "recorded-date": "03-12-2025, 12:32:48",
+    "recorded-date": "03-12-2025, 18:51:50",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -464,7 +464,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_EXECUTION_ID_TYPE]": {
-    "recorded-date": "03-12-2025, 12:32:48",
+    "recorded-date": "03-12-2025, 18:51:50",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -473,7 +473,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_MAP]": {
-    "recorded-date": "03-12-2025, 12:32:49",
+    "recorded-date": "03-12-2025, 18:51:50",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -482,7 +482,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_EXECUTION_FIELD]": {
-    "recorded-date": "03-12-2025, 12:32:49",
+    "recorded-date": "03-12-2025, 18:51:51",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -491,7 +491,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_FIELD]": {
-    "recorded-date": "03-12-2025, 12:32:49",
+    "recorded-date": "03-12-2025, 18:51:51",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -500,7 +500,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_edge_cases[EMPTY_OBJECTS]": {
-    "recorded-date": "03-12-2025, 12:32:49",
+    "recorded-date": "03-12-2025, 18:51:51",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
@@ -570,7 +570,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_edge_cases[EMPTY]": {
-    "recorded-date": "03-12-2025, 12:32:50",
+    "recorded-date": "03-12-2025, 18:51:51",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.validation.json
@@ -1,33 +1,33 @@
 {
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_edge_cases[EMPTY]": {
-    "last_validated_date": "2025-12-03T12:32:50+00:00",
+    "last_validated_date": "2025-12-03T18:51:51+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.19,
+      "call": 0.22,
       "teardown": 0.0,
-      "total": 0.19
+      "total": 0.22
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_edge_cases[EMPTY_OBJECTS]": {
-    "last_validated_date": "2025-12-03T12:32:49+00:00",
+    "last_validated_date": "2025-12-03T18:51:51+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.2,
+      "call": 0.22,
       "teardown": 0.0,
-      "total": 0.2
+      "total": 0.22
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_invalid_states[INVALID_STATE_PASS]": {
-    "last_validated_date": "2025-12-03T12:32:48+00:00",
+    "last_validated_date": "2025-12-03T18:51:50+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.19,
+      "call": 0.22,
       "teardown": 0.0,
-      "total": 0.19
+      "total": 0.22
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_invalid_states[TOKEN_TASK_NOT_SYNC]": {
-    "last_validated_date": "2025-12-03T12:32:48+00:00",
+    "last_validated_date": "2025-12-03T18:51:50+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.2,
@@ -36,16 +36,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_EXECUTION_FIELD]": {
-    "last_validated_date": "2025-12-03T12:32:49+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.22,
-      "teardown": 0.0,
-      "total": 0.22
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_EXECUTION_ID_TYPE]": {
-    "last_validated_date": "2025-12-03T12:32:48+00:00",
+    "last_validated_date": "2025-12-03T18:51:51+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.21,
@@ -53,62 +44,8 @@
       "total": 0.21
     }
   },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_FIELD]": {
-    "last_validated_date": "2025-12-03T12:32:49+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.23,
-      "teardown": 0.0,
-      "total": 0.23
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_MAP]": {
-    "last_validated_date": "2025-12-03T12:32:49+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.22,
-      "teardown": 0.0,
-      "total": 0.22
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[ALL]": {
-    "last_validated_date": "2025-12-03T12:32:47+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.22,
-      "teardown": 0.0,
-      "total": 0.22
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[EXECUTION_INPUT]": {
-    "last_validated_date": "2025-12-03T12:32:48+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.23,
-      "teardown": 0.0,
-      "total": 0.23
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[EXECUTION_INPUT_VALUES]": {
-    "last_validated_date": "2025-12-03T12:32:48+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.19,
-      "teardown": 0.0,
-      "total": 0.19
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[ALL]": {
-    "last_validated_date": "2025-12-03T12:32:47+00:00",
-    "durations_in_seconds": {
-      "setup": 0.53,
-      "call": 0.7,
-      "teardown": 0.0,
-      "total": 1.23
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[EXECUTION_INPUT]": {
-    "last_validated_date": "2025-12-03T12:32:47+00:00",
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_EXECUTION_ID_TYPE]": {
+    "last_validated_date": "2025-12-03T18:51:50+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.2,
@@ -116,8 +53,26 @@
       "total": 0.2
     }
   },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[EXECUTION_INPUT_VALUES]": {
-    "last_validated_date": "2025-12-03T12:32:47+00:00",
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_FIELD]": {
+    "last_validated_date": "2025-12-03T18:51:51+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.24,
+      "teardown": 0.0,
+      "total": 0.24
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_context_object_validation_failures[INVALID_MAP]": {
+    "last_validated_date": "2025-12-03T18:51:50+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.19,
+      "teardown": 0.0,
+      "total": 0.19
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[ALL]": {
+    "last_validated_date": "2025-12-03T18:51:49+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.23,
@@ -125,13 +80,58 @@
       "total": 0.23
     }
   },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_wait_task_context_object": {
-    "last_validated_date": "2025-12-03T12:32:47+00:00",
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[EXECUTION_INPUT]": {
+    "last_validated_date": "2025-12-03T18:51:49+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.22,
       "teardown": 0.0,
       "total": 0.22
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_map_context_object[EXECUTION_INPUT_VALUES]": {
+    "last_validated_date": "2025-12-03T18:51:49+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.21,
+      "teardown": 0.0,
+      "total": 0.21
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[ALL]": {
+    "last_validated_date": "2025-12-03T18:51:48+00:00",
+    "durations_in_seconds": {
+      "setup": 0.52,
+      "call": 0.67,
+      "teardown": 0.0,
+      "total": 1.19
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[EXECUTION_INPUT]": {
+    "last_validated_date": "2025-12-03T18:51:48+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.22,
+      "teardown": 0.0,
+      "total": 0.22
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_task_context_object[EXECUTION_INPUT_VALUES]": {
+    "last_validated_date": "2025-12-03T18:51:49+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.21,
+      "teardown": 0.0,
+      "total": 0.21
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_wait_task_context_object": {
+    "last_validated_date": "2025-12-03T18:51:49+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.19,
+      "teardown": 0.0,
+      "total": 0.19
     }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Fix a test added in #13418 

Closes DRG-299.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Context object constant had a hardcoded `us-east-1` region. Adjusts constant to be a template that is modified according to the region fixture value.

Also adding account id replacement according to fixture. Although the test was not failing on account id, such a replacement will cover all MA/MR bases.

Also removes unnecessary `roleArn` from context object test requests, as a follow-up to #13459, making tests much faster against AWS.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
