### PR TITLE
mypy: add moto-ext as additional-dependencies in pre-commit hook

### DIFF
--- a/localstack-core/localstack/services/transcribe/provider.py
+++ b/localstack-core/localstack/services/transcribe/provider.py
@@ -104,7 +104,6 @@ _DL_LOCK = threading.Lock()
 class TranscribeProvider(TranscribeApi):
     def accept_state_visitor(self, visitor: StateVisitor) -> None:
         from moto.transcribe.models import transcribe_backends
-        # pp
 
         visitor.visit(transcribe_backends)
         visitor.visit(transcribe_stores)


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Locally, when running mypy on the transcribe service, we might get the following failure since #13433:

```
mypy.......................................................................Failed
- hook id: mypy
- exit code: 1

localstack/services/transcribe/provider.py:106: error: Cannot find implementation or library stub for module named "moto.transcribe.models"  [import-not-found]
localstack/services/transcribe/provider.py:106: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 14 source files)
```

I had encountered the issue in the PR introducing this import locally, but when adding the type ignore so that it would work, it started failing in CI saying that the type ignore was useless so I removed it. See https://github.com/localstack/localstack/pull/13433/commits/3e1ff49508de75b901ad03189649f26b7d266a54

This is because locally, we did not declare `moto-ext` as an `additional-dependencies` for the pre-commit hook

\cc @silv-io 
\cc @bblommers ~you might have an idea about why we'd get such error, with your experience of mypy? I have trouble making sense of the error message~

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- add `moto-ext` to the list of additional dependencies in the pre-commit hook

<!--
Summarise the changes proposed in the PR.
-->

## Tests
- check out the branch, run the pre-commit and see that it works
<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
