### PR TITLE
Expand on the typing for volume types to support Kubernetes

### DIFF
--- a/localstack-core/localstack/utils/bootstrap.py
+++ b/localstack-core/localstack/utils/bootstrap.py
@@ -34,8 +34,8 @@ from localstack.utils.container_utils.container_client import (
     NoSuchImage,
     NoSuchNetwork,
     PortMappings,
-    VolumeDirMount,
     VolumeMappings,
+    VolumeMappingSpecification,
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
@@ -666,7 +666,7 @@ class ContainerConfigurators:
         return _cfg
 
     @staticmethod
-    def volume(volume: BindMount | VolumeDirMount):
+    def volume(volume: VolumeMappingSpecification):
         def _cfg(cfg: ContainerConfiguration):
             cfg.volumes.add(volume)
 

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -12,7 +12,6 @@ from localstack import config
 from localstack.utils.collections import ensure_list
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
-    BindMount,
     CancellableStream,
     ContainerClient,
     ContainerException,
@@ -21,16 +20,16 @@ from localstack.utils.container_utils.container_client import (
     DockerNotAvailable,
     DockerPlatform,
     LogConfig,
+    Mount,
     NoSuchContainer,
     NoSuchImage,
     NoSuchNetwork,
     NoSuchObject,
     PortMappings,
     RegistryConnectionError,
-    SimpleVolumeBind,
     Ulimit,
     Util,
-    VolumeDirMount,
+    VolumeMappingSpecification,
 )
 from localstack.utils.run import run
 from localstack.utils.strings import first_char_to_upper, to_str
@@ -810,7 +809,7 @@ class CmdDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: list[str] | str | None = None,
-        volumes: list[SimpleVolumeBind] | None = None,
+        volumes: list[VolumeMappingSpecification] | None = None,
         ports: PortMappings | None = None,
         exposed_ports: list[str] | None = None,
         env_vars: dict[str, str] | None = None,
@@ -900,7 +899,7 @@ class CmdDockerClient(ContainerClient):
         return cmd, env_file
 
     @staticmethod
-    def _map_to_volume_param(volume: SimpleVolumeBind | BindMount | VolumeDirMount) -> str:
+    def _map_to_volume_param(volume: VolumeMappingSpecification) -> str:
         """
         Maps the mount volume, to a parameter for the -v docker cli argument.
 
@@ -911,7 +910,8 @@ class CmdDockerClient(ContainerClient):
         :param volume: Either a SimpleVolumeBind, in essence a tuple (host_dir, container_dir), or a VolumeBind object
         :return: String which is passable as parameter to the docker cli -v option
         """
-        if isinstance(volume, (BindMount, VolumeDirMount)):
+        # TODO: move this logic to the VolumeMappingSpecification type
+        if isinstance(volume, Mount):
             return volume.to_str()
         else:
             return f"{volume[0]}:{volume[1]}"


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

While building out support in Kubernetes, we need a way to specify volumes for mounting into pods. Ideally this should be strongly typed.
<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

* Build type hierarchy for volume mounts that is expandable in the future
* Create a type alias for supported argument types in `VolumeMappings`
* Update usages of previous compound volume types to use the new alias


<!--
Summarise the changes proposed in the PR.
-->

## Tests

`VolumeMappings` is a container that wraps a list. The actual types within it are only important to consumers (e.g. container abstractions) and as such this class is not really tested. Otherwise the new types are used in a PR in the private repository.

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->

Resolves UNC-91
