### PR TITLE
SFN:TestState: Add validations for mock fields compatibility

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/provider.py
+++ b/localstack-core/localstack/services/stepfunctions/provider.py
@@ -1508,9 +1508,7 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
             raise ValidationException("State not found in definition")
 
         mock_input = request.get("mock")
-        TestStateStaticAnalyser.validate_mock(
-            mock_input=mock_input, definition=definition, state_name=state_name
-        )
+        TestStateStaticAnalyser.validate_mock(test_state_input=request)
 
         if state_configuration := request.get("stateConfiguration"):
             # TODO: Add validations for this i.e assert len(input) <= failureCount

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py
@@ -85,3 +85,21 @@ class TestStateMockValidation:
                 mock=mock,
             )
         sfn_snapshot.match("validation_exception", e.value.response)
+
+    @markers.aws.validated
+    def test_reveal_secrets_is_true_and_mock_result_is_set(
+        self,
+        aws_client_no_sync_prefix,
+        sfn_snapshot,
+    ):
+        template = TST.load_sfn_template(TST.BASE_LAMBDA_SERVICE_TASK_STATE)
+        definition = json.dumps(template)
+        mock = {"result": json.dumps({"mock": "response"})}
+        with pytest.raises(Exception) as e:
+            aws_client_no_sync_prefix.stepfunctions.test_state(
+                definition=definition,
+                inspectionLevel=InspectionLevel.TRACE,
+                mock=mock,
+                revealSecrets=True,
+            )
+        sfn_snapshot.match("validation_exception", e.value.response)

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-PassState]": {
-    "recorded-date": "04-12-2025, 17:02:01",
+    "recorded-date": "04-12-2025, 20:55:08",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -16,7 +16,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-FailState]": {
-    "recorded-date": "04-12-2025, 17:02:01",
+    "recorded-date": "04-12-2025, 20:55:09",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -32,7 +32,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-SucceedState]": {
-    "recorded-date": "04-12-2025, 17:02:01",
+    "recorded-date": "04-12-2025, 20:55:09",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -48,7 +48,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-PassState]": {
-    "recorded-date": "04-12-2025, 17:02:02",
+    "recorded-date": "04-12-2025, 20:55:09",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -64,7 +64,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-FailState]": {
-    "recorded-date": "04-12-2025, 17:02:02",
+    "recorded-date": "04-12-2025, 20:55:09",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -80,7 +80,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-SucceedState]": {
-    "recorded-date": "04-12-2025, 17:02:02",
+    "recorded-date": "04-12-2025, 20:55:09",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -96,7 +96,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapState]": {
-    "recorded-date": "04-12-2025, 17:02:02",
+    "recorded-date": "04-12-2025, 20:55:10",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -112,7 +112,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapTaskState]": {
-    "recorded-date": "04-12-2025, 17:02:02",
+    "recorded-date": "04-12-2025, 20:55:10",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -128,7 +128,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_both_mock_result_and_mock_error_output_are_set": {
-    "recorded-date": "04-12-2025, 17:02:03",
+    "recorded-date": "04-12-2025, 20:55:10",
     "recorded-content": {
       "validation_exception": {
         "Error": {
@@ -136,6 +136,22 @@
           "Message": "A test mock should have only one of the following fields: [result, errorOutput]."
         },
         "message": "A test mock should have only one of the following fields: [result, errorOutput].",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_reveal_secrets_is_true_and_mock_result_is_set": {
+    "recorded-date": "04-12-2025, 20:55:10",
+    "recorded-content": {
+      "validation_exception": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "TestState does not support RevealSecrets when a mock is specified."
+        },
+        "message": "TestState does not support RevealSecrets when a mock is specified.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.validation.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_both_mock_result_and_mock_error_output_are_set": {
-    "last_validated_date": "2025-12-04T17:02:03+00:00",
+    "last_validated_date": "2025-12-04T20:55:10+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.19,
@@ -8,26 +8,26 @@
       "total": 0.19
     }
   },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-FailState]": {
-    "last_validated_date": "2025-12-04T17:02:02+00:00",
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_reveal_secrets_is_true_and_mock_result_is_set": {
+    "last_validated_date": "2025-12-04T20:55:10+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.22,
+      "call": 0.18,
       "teardown": 0.0,
-      "total": 0.22
+      "total": 0.18
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-FailState]": {
+    "last_validated_date": "2025-12-04T20:55:09+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.19,
+      "teardown": 0.0,
+      "total": 0.19
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-PassState]": {
-    "last_validated_date": "2025-12-04T17:02:02+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.24,
-      "teardown": 0.0,
-      "total": 0.24
-    }
-  },
-  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-SucceedState]": {
-    "last_validated_date": "2025-12-04T17:02:02+00:00",
+    "last_validated_date": "2025-12-04T20:55:09+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.2,
@@ -35,8 +35,17 @@
       "total": 0.2
     }
   },
+  "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_error_output-SucceedState]": {
+    "last_validated_date": "2025-12-04T20:55:09+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 0.19,
+      "teardown": 0.0,
+      "total": 0.19
+    }
+  },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-FailState]": {
-    "last_validated_date": "2025-12-04T17:02:01+00:00",
+    "last_validated_date": "2025-12-04T20:55:09+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
       "call": 0.2,
@@ -45,39 +54,39 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-PassState]": {
-    "last_validated_date": "2025-12-04T17:02:01+00:00",
+    "last_validated_date": "2025-12-04T20:55:08+00:00",
     "durations_in_seconds": {
-      "setup": 0.55,
-      "call": 0.66,
+      "setup": 0.54,
+      "call": 0.64,
       "teardown": 0.0,
-      "total": 1.21
+      "total": 1.18
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_does_not_accept_mock[mock_result-SucceedState]": {
-    "last_validated_date": "2025-12-04T17:02:01+00:00",
+    "last_validated_date": "2025-12-04T20:55:09+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.18,
+      "call": 0.21,
       "teardown": 0.0,
-      "total": 0.18
+      "total": 0.21
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapState]": {
-    "last_validated_date": "2025-12-04T17:02:02+00:00",
+    "last_validated_date": "2025-12-04T20:55:10+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.21,
+      "call": 0.19,
       "teardown": 0.0,
-      "total": 0.21
+      "total": 0.19
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_mock_validation.py::TestStateMockValidation::test_state_type_requires_mock[MapTaskState]": {
-    "last_validated_date": "2025-12-04T17:02:02+00:00",
+    "last_validated_date": "2025-12-04T20:55:10+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.21,
+      "call": 0.2,
       "teardown": 0.0,
-      "total": 0.21
+      "total": 0.2
     }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Improve test state mock validation parity.

Closes DRG-311.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

- Updates the validation message to match the AWS one when both mock result and error are present. Also, moves the validation to the static analyzer to group it with the rest of mock validations.
- Adds validation for revealSecrets cannot be true when a mock is specified

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
