### PR TITLE
Allow redirecting test traffic to arbitrary endpoint

### DIFF
--- a/localstack-core/localstack/testing/aws/util.py
+++ b/localstack-core/localstack/testing/aws/util.py
@@ -29,6 +29,7 @@ from localstack.testing.config import (
     SECONDARY_TEST_AWS_SECRET_ACCESS_KEY,
     SECONDARY_TEST_AWS_SESSION_TOKEN,
     TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_ENDPOINT_URL,
     TEST_AWS_REGION_NAME,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
@@ -240,7 +241,7 @@ def base_aws_client_factory(session: boto3.Session) -> ClientFactory:
 
         # Prevent this fixture from using the region configured in system config
         config = config.merge(botocore.config.Config(region_name=TEST_AWS_REGION_NAME))
-        return ExternalClientFactory(session=session, config=config)
+        return ExternalClientFactory(session=session, config=config, endpoint=TEST_AWS_ENDPOINT_URL)
 
 
 def base_testing_aws_client(client_factory: ClientFactory) -> ServiceLevelClientFactory:

--- a/localstack-core/localstack/testing/config.py
+++ b/localstack-core/localstack/testing/config.py
@@ -9,6 +9,7 @@ TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
 TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
 TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"
 TEST_AWS_REGION_NAME = os.getenv("TEST_AWS_REGION_NAME") or "us-east-1"
+TEST_AWS_ENDPOINT_URL = os.getenv("TEST_AWS_ENDPOINT_URL")
 
 # Secondary test AWS profile - only used for testing against AWS
 SECONDARY_TEST_AWS_PROFILE = os.getenv("SECONDARY_TEST_AWS_PROFILE")


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Currently, we only have two options:

1. Run the tests against `http://localhost:4566`
2. Run the tests against AWS.

We recently have the requirement to test against an LS instance not running on localhost - we can however not reuse the AWS test mode, as it would influence behavior of the tests, especially for snapshots (ignoring the skip_verify paths, for example)

Please note that this change is not exhaustive - some tests might manually use an internal client or override the endpoint url themselves - in these cases, this change will not lead to correct test behavior.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Introduce `TEST_AWS_ENDPOINT_URL` to redirect test clients to arbitrary urls
* Some simplifications / error corrections regarding endpoint urls.

<!--
Summarise the changes proposed in the PR.
-->

## Tests
Set `TEST_AWS_ENDPOINT_URL` to some url pointing towards an LS instance and run the tests.

<!--
Optional: How are the proposed changes tested?
-->

## Related
Related to UNC-120

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
