### PR TITLE
SQS - updating queues before saving a snapshot

### DIFF
--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -701,6 +701,10 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         self._stop_cloudwatch_metrics_reporting()
 
+    def on_before_state_save(self) -> None:
+        # As we do not want to snapshot expired messages, we update all the queues before saving the state.
+        self._queue_update_worker.do_update_all_queues()
+
     @staticmethod
     def _require_queue(
         account_id: str, region_name: str, name: str, is_query: bool = False


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Whenever we save an SQS state, we should avoid snapshotting expired messages.
We have seen reports from users claiming that the saved states contain messages that should have been cleared.

Closes PNX-548

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- Before saving the state, we update the queues via `do_update_all_queues`. This should trigger the deletion of expired messages. Since I am not very familiar with the service internals, I am not 100% sure we can use any other internal API to do the same.