### PR TITLE
Skip flaky Lambda streaming test

### DIFF
--- a/tests/aws/test_integration.py
+++ b/tests/aws/test_integration.py
@@ -208,6 +208,7 @@ class TestIntegration:
         # clean up
         aws_client.firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
 
+    @pytest.mark.skip(reason="flaky")
     @markers.aws.unknown
     def test_lambda_streams_batch_and_transactions(
         self,


### PR DESCRIPTION
## Motivation

The test `aws.test_integration.TestIntegration.test_lambda_streams_batch_and_transactions` is frequently flaky in CI following our core CI dashboard (3 out of 8 runs failed; internal [link](https://grafana.data.aws.localstack.cloud/d/f0909ab8-6740-487d-994b-b8208967a6e7/core-ci-health-single-test-drilldown?orgId=1&var-repository=localstack%2Flocalstack-pro&var-workflow=pro_tests_aws_k8s_community&var-job_id=test-community&var-test_nodeid=tests%2Faws%2Ftest_integration.py::TestIntegration::test_lambda_streams_batch_and_transactions&from=now-7d&to=now&timezone=browser))

## Changes

* Skip flaky test `aws.test_integration.TestIntegration.test_lambda_streams_batch_and_transactions`

## Related

Related to DRG-318