### PR TITLE
CFn: remove assertion on CFN_NO_WAIT_ITERATIONS

### DIFF
--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -430,9 +430,6 @@ class ResourceProviderExecutor:
         self.stack_name = stack_name
         self.stack_id = stack_id
 
-        # This should have been set up in the provider
-        assert isinstance(config.CFN_NO_WAIT_ITERATIONS, int)
-
     def deploy_loop(
         self,
         resource_provider: ResourceProvider,


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

While adding `CFN_NO_WAIT_ITERATIONS` for CloudFormation in #13455, I added an assertion to the `ResourceProviderExecutor` construction that made sure a configuration value was correctly parsed into an integer. 

Unfortunately this change broke the CloudControl provider since it also uses the ResourceProviderExecutor class.

This change was not picked up in our test suite for some reason, but this change removes the assertion. The config value is not required in CloudControl anyway as it configures the CloudFormation specific polling configuration. The assertion is also redundant as the CloudFormation provider correctly parses the configuration value on creation.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Remove unneeded assertion


