### PR TITLE
SFN:TestState: Fix hardcoded region in test state's context object test

### DIFF
--- a/tests/aws/services/stepfunctions/templates/test_state/statemachines/io_sqs_service_task_wait.json5
+++ b/tests/aws/services/stepfunctions/templates/test_state/statemachines/io_sqs_service_task_wait.json5
@@ -3,7 +3,7 @@
     "Type": "Task",
     "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
     "Parameters": {
-        "QueueUrl": "https://sqs.us-east-2.amazonaws.com/123456789012/myQueue",
+        "QueueUrl": "__QUEUE_URL__",
         "MessageBody": {
             "Message": "Hello from Step Functions!",
             "TaskToken.$": "$$.Task.Token"

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py
@@ -99,11 +99,16 @@ class TestStateContextObject:
     def test_state_wait_task_context_object(
         self,
         aws_client_no_sync_prefix,
+        account_id,
+        region_name,
         sfn_snapshot,
     ):
         state_template = TST.load_sfn_template(
             TST.IO_SQS_SERVICE_TASK_WAIT,
         )
+
+        sqs_queue_url = f"https://sqs.{region_name}.amazonaws.com/{account_id}/test-queue"
+        state_template["Parameters"]["QueueUrl"] = sqs_queue_url
 
         definition = json.dumps(state_template)
         mocked_result = json.dumps({"pokemon": ["charizard", "pikachu", "bulbasaur"]})

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.snapshot.json
@@ -333,13 +333,13 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_wait_task_context_object": {
-    "recorded-date": "03-12-2025, 18:51:49",
+    "recorded-date": "09-12-2025, 11:42:20",
     "recorded-content": {
       "test_case_response": {
         "inspectionData": {
           "afterInputPath": {},
           "afterParameters": {
-            "QueueUrl": "https://sqs.us-east-2.amazonaws.com/123456789012/myQueue",
+            "QueueUrl": "https://sqs.<region>.amazonaws.com/111111111111/test-queue",
             "MessageBody": {
               "Message": "Hello from Step Functions!",
               "TaskToken": "abcd123"

--- a/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.validation.json
@@ -126,12 +126,12 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_state/test_state_context_object.py::TestStateContextObject::test_state_wait_task_context_object": {
-    "last_validated_date": "2025-12-03T18:51:49+00:00",
+    "last_validated_date": "2025-12-09T11:42:20+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.19,
+      "setup": 0.48,
+      "call": 0.62,
       "teardown": 0.0,
-      "total": 0.19
+      "total": 1.1
     }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Fix flaky test (MA/MR).

Closes DRG-317.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

The queue url in `io_sqs_service_task_wait.json5` was hardcoded to `us-east-2`. When this region is randomly selected by MA/MR pipeline it gets transformed to `<region>` but the recorded value is `us-east-2` since the snapshot was recorded against different region.

Formats `queueUrl` value to always match the region that tests are executed against.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
