### PR TITLE
ESM: add '$LATEST.PUBLISHED' support for Lambda Managed Instances

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -2258,6 +2258,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     raise Exception("unknown version")  # TODO: cover via test
             elif qualifier == "$LATEST":
                 pass
+            elif qualifier == "$LATEST.PUBLISHED":
+                if fn.versions.get(qualifier):
+                    pass
             else:
                 raise Exception("invalid functionname")  # TODO: cover via test
             fn_arn = api_utils.qualified_lambda_arn(function_name, qualifier, account, region)


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Add `$LATEST.PUBLISHED` qualifier support for Event Source Mapping using Lambda Managed Instances.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
<!--
Summarise the changes proposed in the PR.
-->
Allow ESM validation to pass (previously raised an exception) when using '$LATEST.PUBLISHED' qualifier for Lambda Managed Instances.

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
