### PR TITLE
IaC: Enable parity metrics to be captured during release

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -972,7 +972,7 @@ jobs:
 
   capture-not-implemented:
     name: "Capture Not Implemented"
-    if: ${{ !inputs.onlyAcceptanceTests && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
+    if: ${{ (!inputs.onlyAcceptanceTests && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     needs: build
     env:


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

In IaC project we need to construct full license catalog file from artifacts generated during the release process. One of artifacts needed to construct full license catalog is `capture-not-implemented`. This PR enables execution of the `capture-not-implemented` job during release in the AWS/Integration Tests workflow.

## Changes

The PR changes the logic for when the `capture-not-implemented` job in theAWS/Integration Tests workflow is triggered. It now runs capture-not-implemented on every release run (github ref starts with `refs/tags/v`)

Related to [FLC-76](https://linear.app/localstack/issue/FLC-76)