### PR TITLE
Docker: Support cpu shares and memory limit

### DIFF
--- a/localstack-core/localstack/utils/container_utils/container_client.py
+++ b/localstack-core/localstack/utils/container_utils/container_client.py
@@ -544,6 +544,8 @@ class ContainerConfiguration:
     labels: dict[str, str] | None = None
     init: bool | None = None
     log_config: LogConfig | None = None
+    cpu_shares: int | None = None
+    mem_limit: int | str | None = None
 
 
 class ContainerConfigurator(Protocol):
@@ -979,6 +981,8 @@ class ContainerClient(metaclass=ABCMeta):
             ulimits=container_config.ulimits,
             init=container_config.init,
             log_config=container_config.log_config,
+            cpu_shares=container_config.cpu_shares,
+            mem_limit=container_config.mem_limit,
         )
 
     @abstractmethod
@@ -1011,6 +1015,8 @@ class ContainerClient(metaclass=ABCMeta):
         ulimits: list[Ulimit] | None = None,
         init: bool | None = None,
         log_config: LogConfig | None = None,
+        cpu_shares: int | None = None,
+        mem_limit: int | str | None = None,
     ) -> str:
         """Creates a container with the given image
 
@@ -1048,6 +1054,8 @@ class ContainerClient(metaclass=ABCMeta):
         ulimits: list[Ulimit] | None = None,
         init: bool | None = None,
         log_config: LogConfig | None = None,
+        cpu_shares: int | None = None,
+        mem_limit: int | str | None = None,
     ) -> tuple[bytes, bytes]:
         """Creates and runs a given docker container
 
@@ -1086,6 +1094,8 @@ class ContainerClient(metaclass=ABCMeta):
             ulimits=container_config.ulimits,
             init=container_config.init,
             log_config=container_config.log_config,
+            cpu_shares=container_config.cpu_shares,
+            mem_limit=container_config.mem_limit,
         )
 
     @abstractmethod

--- a/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_cmd_client.py
@@ -827,6 +827,8 @@ class CmdDockerClient(ContainerClient):
         ulimits: list[Ulimit] | None = None,
         init: bool | None = None,
         log_config: LogConfig | None = None,
+        cpu_shares: int | None = None,
+        mem_limit: int | str | None = None,
     ) -> tuple[list[str], str]:
         env_file = None
         cmd = self._docker_cmd() + [action]
@@ -890,6 +892,10 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--log-driver", log_config.type]
             for key, value in log_config.config.items():
                 cmd += ["--log-opt", f"{key}={value}"]
+        if cpu_shares:
+            cmd += ["--cpu-shares", str(cpu_shares)]
+        if mem_limit:
+            cmd += ["--memory", str(mem_limit)]
 
         if additional_flags:
             cmd += shlex.split(additional_flags)

--- a/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack-core/localstack/utils/container_utils/docker_sdk_client.py
@@ -729,6 +729,8 @@ class SdkDockerClient(ContainerClient):
         ulimits: list[Ulimit] | None = None,
         init: bool | None = None,
         log_config: LogConfig | None = None,
+        cpu_shares: int | None = None,
+        mem_limit: int | str | None = None,
     ) -> str:
         LOG.debug("Creating container with attributes: %s", locals())
         extra_hosts = None
@@ -793,6 +795,10 @@ class SdkDockerClient(ContainerClient):
                     )
                     for ulimit in ulimits
                 ]
+            if cpu_shares:
+                kwargs["cpu_shares"] = cpu_shares
+            if mem_limit:
+                kwargs["mem_limit"] = mem_limit
             mounts = None
             if volumes:
                 mounts = Util.convert_mount_list_to_dict(volumes)
@@ -860,6 +866,8 @@ class SdkDockerClient(ContainerClient):
         ulimits: list[Ulimit] | None = None,
         init: bool | None = None,
         log_config: LogConfig | None = None,
+        cpu_shares: int | None = None,
+        mem_limit: int | str | None = None,
     ) -> tuple[bytes, bytes]:
         LOG.debug("Running container with image: %s", image_name)
         container = None
@@ -891,6 +899,8 @@ class SdkDockerClient(ContainerClient):
                 labels=labels,
                 ulimits=ulimits,
                 log_config=log_config,
+                cpu_shares=cpu_shares,
+                mem_limit=mem_limit,
             )
             result = self.start_container(
                 container_name_or_id=container,


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
We currently do not support specifying the cpu shares or the memory limit (https://docs.docker.com/engine/containers/resource_constraints/) for the container.
However, we need a possibility to specify those values for parity for some compute services.

The tests for these work on both cgroup v1 and v2, however for some values a conversion is necessary in the assertions.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Allow specification of the cpu-shares and mem-limit container configuration values.

<!--
Summarise the changes proposed in the PR.
-->

## Tests
* Tests for the docker client are added, more testing of that functionaity will be done as part of the feature depending on these configuration options.

<!--
Optional: How are the proposed changes tested?
-->

## Related
Fixes UNC-147

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
