### PR TITLE
DNS: Move tests to integration tests, reenable skipped test

### DIFF
--- a/tests/integration/dns/test_dns_server.py
+++ b/tests/integration/dns/test_dns_server.py
@@ -20,6 +20,14 @@ from localstack.utils.sync import retry
 
 
 class TestDNSServer:
+    """
+    End to end tests of our DNS server implementation.
+    These tests use the `example.org` and `example.com` domains for testing, and also tests the fallback to the public DNS
+    Changes in the upstream name resolution of those domains might lead to test failures.
+
+    TODO we should investigate creating our own test domain with a fixed behavior to avoid potential test failures
+    """
+
     @pytest.fixture
     def dns_server(self):
         dns_port = get_free_udp_port()
@@ -176,12 +184,11 @@ class TestDNSServer:
         assert "something.org." in answer.to_text()
         assert "noc.something.org." in answer.to_text()
 
-    @pytest.mark.skip(reason="failing as of 2025-12-11")
     def test_dns_server_subdomain_of_route(self, dns_server, query_dns):
         """Test querying a subdomain of a record entry without a wildcard"""
         # add ipv4 host
-        dns_server.add_host("example.org", TargetRecord("127.0.0.1", RecordType.A))
-        answer = query_dns("nonexistent.example.org", "A")
+        dns_server.add_host("example.com", TargetRecord("127.0.0.1", RecordType.A))
+        answer = query_dns("nonexistent.example.com", "A")
         assert not answer.answer
         # should still have authority section
         # TODO uncomment once it is clear why in CI the authority section is missing


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Currently our DNS tests are marked as unit tests. However, they are not actually unit tests, as they test the end to end behavior of the DNS server, including calls to upstream DNS servers.

This PR will correctly move them to the integration tests. (cc @peter-smith-phd)

Also, recently it seems that `example.org` was moved to cloudflare DNS, which leads to a different response code for one of our queries - NOERROR (with an empty response) instead of NXDOMAIN.

By moving to `example.com` for this test we for now circumvent this issue - as a simple change in the assertion is not sufficient, since this change is still not propagated everywhere (and might even change in the future again).

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Move DNS test suite to integration tests
* Use `example.com` domain for skipped tests to reenable.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related
Fixes UNC-164
<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
