### PR TITLE
Lambda: adjust qualifier validation for integrations

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -2502,7 +2502,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
     @staticmethod
     def _validate_qualifier(qualifier: str) -> None:
-        if qualifier == "$LATEST" or (qualifier and api_utils.qualifier_is_version(qualifier)):
+        if qualifier in ["$LATEST", "$LATEST.PUBLISHED"] or (
+            qualifier and api_utils.qualifier_is_version(qualifier)
+        ):
             raise ValidationException(
                 f"1 validation error detected: Value '{qualifier}' at 'qualifier' failed to satisfy constraint: Member must satisfy regular expression pattern: ((?!^\\d+$)^[0-9a-zA-Z-_]+$)"
             )


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
API operation `CreateFunctionUrlConfig` needs some adjustment for the validation to pass in the context of Lambda Managed Instances.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
Adjust qualifier validation for integrations using "$LATEST.PUBLISHED" qualifier.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
