### PR TITLE
CI: Skip failing DNS unit test

### DIFF
--- a/tests/integration/dns/test_dns_server.py
+++ b/tests/integration/dns/test_dns_server.py
@@ -184,6 +184,7 @@ class TestDNSServer:
         assert "something.org." in answer.to_text()
         assert "noc.something.org." in answer.to_text()
 
+    @pytest.mark.skip(reason="failing as of 2025-12-17")
     def test_dns_server_subdomain_of_route(self, dns_server, query_dns):
         """Test querying a subdomain of a record entry without a wildcard"""
         # add ipv4 host


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

A failing unit test is blocking the main pipeline and MA/MR pipeline

## Changes

- Skip failing DNS unit test unit.test_dns_server.TestDNSServer.test_dns_server_subdomain_of_route


## Related

FLC-248
