### PR TITLE
update: bump Lambda RIE version to v0.1.38-pre

### DIFF
--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -12,7 +12,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.37-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.38-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Updates the Lambda RIE version following the upstream changes being integrated.

The changes are largely cosmetic, and involve a refactor of the RIE structure into a more go-idiomatic format. In addition, these changes introduce a distinction between managed instance and standard lambda function executions.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- Bumps the Lambda RIE version to `v0.1.38`.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related
- Upstream PR https://github.com/localstack/lambda-runtime-init/pull/62


Closes DRG-241
