### PR TITLE
fix: replace hardcoded region in SNS test

### DIFF
--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -609,7 +609,7 @@ class TestSNSTopicCrudV2:
 
     @markers.aws.validated
     @pytest.mark.skipif(condition=is_sns_v1_provider(), reason="Not implemented in moto")
-    def test_data_protection_policy_crud(self, snapshot, aws_client):
+    def test_data_protection_policy_crud(self, snapshot, aws_client, region_name):
         topic_name = f"topic-{short_uid()}"
         topic_arn = aws_client.sns.create_topic(Name=topic_name)["TopicArn"]
 
@@ -623,7 +623,7 @@ class TestSNSTopicCrudV2:
                     "DataDirection": "Inbound",
                     "Principal": ["*"],
                     "DataIdentifier": [
-                        "arn:aws:dataprotection:us-east-1::data-identifier/EmailAddress"
+                        f"arn:aws:dataprotection:{region_name}::data-identifier/EmailAddress"
                     ],
                     "Operation": {"Deny": {}},
                 }

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -7030,7 +7030,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_data_protection_policy_crud": {
-    "recorded-date": "17-12-2025, 13:06:58",
+    "recorded-date": "18-12-2025, 07:54:08",
     "recorded-content": {
       "get-topic-attributes-before-policy": {
         "Attributes": {

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -1353,12 +1353,12 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_data_protection_policy_crud": {
-    "last_validated_date": "2025-12-17T13:06:58+00:00",
+    "last_validated_date": "2025-12-18T07:54:08+00:00",
     "durations_in_seconds": {
-      "setup": 1.14,
-      "call": 2.36,
-      "teardown": 0.02,
-      "total": 3.52
+      "setup": 0.84,
+      "call": 1.82,
+      "teardown": 0.04,
+      "total": 2.7
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_delete_non_existent_topic": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
A hard-coded region parameter slipped through into main and this is breaking  the MA/MR pipeline. This PR addresses this.
<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

<!--
Summarise the changes proposed in the PR.
-->

## Tests
Here is a [manual run](https://github.com/localstack/localstack/actions/runs/20332002040/job/58410558942) of the MA/MR pipeline which passed
<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
