### PR TITLE
Fix CloudWatch model annotation

### DIFF
--- a/localstack-core/localstack/services/cloudwatch/models.py
+++ b/localstack-core/localstack/services/cloudwatch/models.py
@@ -107,7 +107,7 @@ class CloudWatchStore(BaseStore):
 
     # Contains all the Alarm Histories. Per documentation, an alarm history is retained even if the alarm is deleted,
     # making it necessary to save this at store level
-    histories: list[dict[str, AlarmHistoryItem]] = LocalAttribute(default=list)
+    histories: list[AlarmHistoryItem] = LocalAttribute(default=list)
 
     dashboards: dict[str, LocalStackDashboard] = LocalAttribute(default=dict)
 


### PR DESCRIPTION
## Motivation
This is a follow-up of https://github.com/localstack/localstack/pull/13511.
I made a mistake while adding the proper annotation to `histories`.

## Changes
- Fix the type hint
