### PR TITLE
Fix Lambda CI log pollution issues

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -1547,8 +1547,10 @@ def create_event_source_mapping(aws_client):
     for uuid in uuids:
         try:
             aws_client.lambda_.delete_event_source_mapping(UUID=uuid)
-        except Exception:
-            LOG.debug("Unable to delete event source mapping %s in cleanup", uuid)
+        except aws_client.lambda_.exceptions.ResourceNotFoundException:
+            pass
+        except Exception as ex:
+            LOG.debug("Unable to delete event source mapping %s in cleanup: %s", uuid, ex)
 
 
 @pytest.fixture

--- a/tests/aws/services/lambda_/test_lambda_api.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda_api.snapshot.json
@@ -17872,7 +17872,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_filter_criteria_validation": {
-    "recorded-date": "25-11-2025, 02:48:23",
+    "recorded-date": "18-12-2025, 15:04:51",
     "recorded-content": {
       "response-with-empty-filters": {
         "BatchSize": 100,

--- a/tests/aws/services/lambda_/test_lambda_api.validation.json
+++ b/tests/aws/services/lambda_/test_lambda_api.validation.json
@@ -108,12 +108,12 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_filter_criteria_validation": {
-    "last_validated_date": "2025-11-25T02:48:23+00:00",
+    "last_validated_date": "2025-12-18T15:07:44+00:00",
     "durations_in_seconds": {
-      "setup": 0.01,
-      "call": 10.92,
-      "teardown": 2.08,
-      "total": 13.01
+      "setup": 12.13,
+      "call": 22.59,
+      "teardown": 2.65,
+      "total": 37.37
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_self_managed": {
@@ -1935,75 +1935,75 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[dotnetcore3.1]": {
-    "last_validated_date": "2025-11-25T02:26:09+00:00",
+    "last_validated_date": "2025-12-18T15:11:17+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.16,
-      "teardown": 0.01,
-      "total": 0.17
+      "call": 0.27,
+      "teardown": 0.0,
+      "total": 0.27
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[go1.x]": {
-    "last_validated_date": "2025-11-25T02:26:08+00:00",
+    "last_validated_date": "2025-12-18T15:11:16+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.14,
-      "teardown": 0.01,
-      "total": 0.15
+      "setup": 0.01,
+      "call": 0.26,
+      "teardown": 0.0,
+      "total": 0.27
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[java8]": {
-    "last_validated_date": "2025-11-25T02:26:08+00:00",
+    "last_validated_date": "2025-12-18T15:11:15+00:00",
     "durations_in_seconds": {
-      "setup": 11.1,
-      "call": 0.37,
-      "teardown": 0.01,
-      "total": 11.48
+      "setup": 12.15,
+      "call": 0.71,
+      "teardown": 0.0,
+      "total": 12.86
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs12.x]": {
-    "last_validated_date": "2025-11-25T02:26:09+00:00",
+    "last_validated_date": "2025-12-18T15:11:18+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.16,
-      "teardown": 0.01,
-      "total": 0.17
+      "setup": 0.01,
+      "call": 0.29,
+      "teardown": 0.76,
+      "total": 1.06
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[nodejs14.x]": {
-    "last_validated_date": "2025-11-25T02:26:08+00:00",
+    "last_validated_date": "2025-12-18T15:11:17+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.18,
-      "teardown": 0.01,
-      "total": 0.19
+      "call": 0.28,
+      "teardown": 0.0,
+      "total": 0.28
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[provided]": {
-    "last_validated_date": "2025-11-25T02:26:08+00:00",
+    "last_validated_date": "2025-12-18T15:11:16+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.14,
-      "teardown": 0.01,
-      "total": 0.15
+      "call": 0.27,
+      "teardown": 0.0,
+      "total": 0.27
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[python3.7]": {
-    "last_validated_date": "2025-11-25T02:26:09+00:00",
+    "last_validated_date": "2025-12-18T15:11:17+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 0.17,
-      "teardown": 0.01,
-      "total": 0.18
+      "setup": 0.01,
+      "call": 0.27,
+      "teardown": 0.0,
+      "total": 0.28
     }
   },
   "tests/aws/services/lambda_/test_lambda_api.py::TestRuntimeValidation::test_create_deprecated_function_runtime_with_validation_enabled[ruby2.7]": {
-    "last_validated_date": "2025-11-25T02:26:08+00:00",
+    "last_validated_date": "2025-12-18T15:11:16+00:00",
     "durations_in_seconds": {
       "setup": 0.0,
-      "call": 0.16,
-      "teardown": 0.01,
-      "total": 0.17
+      "call": 0.27,
+      "teardown": 0.0,
+      "total": 0.27
     }
   }
 }


### PR DESCRIPTION
## Motivation

Our CI logs are very noisy, including many avoidable WARNING and ERROR messages, making it difficult to debug real issues. In particular:
* 57 errors and stack traces leaking into other tests from an ESM poller that is not shut down properly:
> localstack.services.lambda_.event_source_mapping.esm_worker : Error while polling messages for event source arn:aws:dynamodb:us-east-1:000000000000:table/table-612184b5/stream/2025-12-15T05:07:00.383: An error occurred (ResourceNotFoundException) when calling the DescribeStream operation: Requested resource not found: Stream: arn:aws:dynamodb:us-east-1:000000000000:table/table-612184b5/stream/2025-12-15T05:07:00.383 not found
* DEBUG: `DeleteEventSourceMapping operation: The resource you requested does not exist.` gets logged 27 times

## Changes

* Use ESM fixture and fix cleanups (due to lifecycle timings) for `test_create_event_filter_criteria_validation`
* Fix unnecessary DeleteEventSourceMapping debug log by catching the ResourceNotFoundException in the fixture. There is no need to delete something that doesn't exist :)
* Remove some unnecessary parameters (LoggingConfig, MemorySize, Timeout) from Lambda runtime validation tests

## Related

Discovered during AI Winter hackathon :)
