### PR TITLE
remove release announcement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 <p align="center">
-:zap: We are thrilled to announce the release of <a href="https://blog.localstack.cloud/localstack-for-aws-release-v-4-11-0/">LocalStack 4.11</a> :zap:
-</p>
-
-<p align="center">
   <img src="docs/localstack-readme-banner.svg" alt="LocalStack - The Leading Platform for Local Cloud Development">
 </p>
 


### PR DESCRIPTION
## Motivation
This PR removes the first sentence of the README announcing the new release.
I think it would be best to remove this sentence because it is often out-dated (like it is right now), and we do announce new releases on a lot of different channels anyways (including here on GitHub as releases of the repo).

## Changes
- Remove the top section of the README.md announcing the new release.