### PR TITLE
use OUTBOUND_HTTP_PROXY for for external bypass client

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -704,14 +704,12 @@ class ExternalBypassDnsClientFactory(ExternalAwsClientFactory):
                 "https": localstack_config.OUTBOUND_HTTPS_PROXY,
             }
         )
-        if config:
-            proxy_config = config.merge(proxy_config)
 
         super().__init__(
             use_ssl=localstack_config.is_env_not_false("USE_SSL"),
             verify=ca_cert or True,
             session=session,
-            config=proxy_config,
+            config=config.merge(proxy_config) if config else proxy_config,
         )
 
     def _get_client_post_hook(self, client: BaseClient) -> BaseClient:


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

When creating an `ExternalBypassDnsClient`, we should remain mindful of users proxy configurations and ensure that those external calls are respecting the Outbound Proxy configuration.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Ensure both the client and the http session are created with the user's http proxy configuration.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

- setup a local proxy.
- start LocalStack with `OUTBOUND_HTTP_PROXY` and `OUTBOUND_HTTPS_PROXY` set to your proxies, configuration. It might be required also to set `REQUESTS_CA_BUNDLE`.
- try to use the replicator to trigger the use of dns bypass client

<!--
Optional: How are the proposed changes tested?
-->

## Related

relates to UNC-146

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
