### PR TITLE
IAM: Update `create_user_with_policy` fixture

### DIFF
--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -33,7 +33,7 @@ from localstack.services.stores import (
     LocalAttribute,
 )
 from localstack.testing.aws.cloudformation_utils import load_template_file, render_template
-from localstack.testing.aws.util import get_lambda_logs, is_aws_cloud
+from localstack.testing.aws.util import get_lambda_logs, is_aws_cloud, wait_for_user
 from localstack.testing.config import (
     SECONDARY_TEST_AWS_ACCOUNT_ID,
     SECONDARY_TEST_AWS_REGION_NAME,
@@ -2396,13 +2396,15 @@ def create_role_with_policy(create_role, create_policy_generated_document, aws_c
 
 
 @pytest.fixture
-def create_user_with_policy(create_policy_generated_document, create_user, aws_client):
-    def _create_user_with_policy(effect, actions, resource=None):
+def create_user_with_policy(create_policy_generated_document, create_user, aws_client, region_name):
+    def _create_user_with_policy(effect, actions, resource=None, user_name=None):
         policy_arn = create_policy_generated_document(effect, actions, resource=resource)
-        username = f"user-{short_uid()}"
+        username = user_name or f"user-{short_uid()}"
         create_user(UserName=username)
         aws_client.iam.attach_user_policy(UserName=username, PolicyArn=policy_arn)
         keys = aws_client.iam.create_access_key(UserName=username)["AccessKey"]
+
+        wait_for_user(keys=keys, region_name=region_name)
         return username, keys
 
     return _create_user_with_policy


### PR DESCRIPTION
## Description
- Updates the `create_user_with_policy` to take a username - this helps with snapshot testing as sometimes the error will contain the username which you will want to know ahead of time.
- Now waits for the user to be created before returning.
- This change came up as a result of this POC PR: https://github.com/localstack/localstack-pro/pull/5719

Pro AWS Build Test and Push: https://github.com/localstack/localstack-pro/actions/runs/20571377274