### PR TITLE
fix(pyproject): Make inclusion of additional cfn schemas more permissive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ exclude = ["tests*"]
 "localstack" = [
     "aws/**/*.json",
     "services/**/*.html",
-    "services/**/resource_providers/*.schema.json",
+    "services/**/resource_providers/**/*.schema.json",
     "utils/kinesis/java/cloud/localstack/*.*",
     "openapi.yaml",
     "http/resources/swagger/templates/index.html"


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

With the addition of the `resource_providers/generated` subdirectory, we need to ensure the package data we include is more permissive schema data residing in subdirectories.

Related to https://github.com/localstack/localstack/pull/13534

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- Change `pyproject.toml` to include JSON schema data within recursive subdirectories of `resource_providers`

<!--
Summarise the changes proposed in the PR.
-->

## Tests

- Manually tested this on my local by specifically targeting the commit SHA of this branch as a localstack dependency and validating that the `generated/**/aws_sqs_queuepolicy.schema.json` file is present i.e


   ```sh
   pip install git+https://github.com/localstack/localstack.git@3043c83fd5ccbc8e1a9216e46ae2e31b48c287e9

   test -f ".venv/lib/python3.13/site-packages/localstack/services/sqs/resource_providers/generated/aws_sqs_queuepolicy.schema.json" && echo "aws_sqs_queuepolicy.schema.json exists" || echo "aws_sqs_queuepolicy.schema.json does not exist"
   ```

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
