### PR TITLE
fix/openapi spec

### DIFF
--- a/localstack-core/localstack/openapi.yaml
+++ b/localstack-core/localstack/openapi.yaml
@@ -1056,7 +1056,9 @@ paths:
           description: Information about init scripts in a specific stage
         '404':
           content:
-            text/xml: {}
+            text/plain:
+              schema:
+                type: string
           description: Stage not found
   /_localstack/plugins:
     get:

--- a/localstack-core/localstack/services/internal.py
+++ b/localstack-core/localstack/services/internal.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from datetime import datetime
 
 from plux import PluginManager
-from werkzeug.exceptions import NotFound
 
 from localstack import config, constants
 from localstack.deprecations import deprecated_endpoint
@@ -260,8 +259,8 @@ class InitScriptsStageResource:
 
         try:
             stage = Stage[stage.upper()]
-        except KeyError as e:
-            raise NotFound(f"no such stage {stage}") from e
+        except KeyError:
+            return Response(f"no such stage {stage}", 404)
 
         return {
             "completed": manager.stage_completed.get(stage),


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

#13551 introduced an error in the openapi spec. The `/init/stage-invalid` endpoint is meant to return plain text, not xml.

Looking at the response, I also noticed that the text was not sent, essentially returning an empty message. so I took the opportunity to improve the response returned in case of a stage not found.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

- updated the content type of the openapi specs
- fix error handling in the init script handler

<!--
Summarise the changes proposed in the PR.
-->

<!--
Optional: How are the proposed changes tested?
-->

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
