### PR TITLE
APIGW: fix regional domain name to take into account region

### DIFF
--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -984,20 +984,20 @@ def is_variable_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("}")
 
 
-def get_domain_name_hash(domain_name: str) -> str:
+def get_domain_name_hash(domain_name: str, region_name: str) -> str:
     """
     Return a hash of the given domain name, which help construct regional domain names for APIs.
     TODO: use this in the future to dispatch API Gateway API invocations made to the regional domain name
     """
-    return hashlib.shake_128(to_bytes(domain_name)).hexdigest(4)
+    return hashlib.shake_128(to_bytes(domain_name + region_name)).hexdigest(4)
 
 
-def get_regional_domain_name(domain_name: str) -> str:
+def get_regional_domain_name(domain_name: str, region_name: str) -> str:
     """
     Return the regional domain name for the given domain name.
     In real AWS, this would look something like: "d-oplm2qchq0.execute-api.us-east-1.amazonaws.com"
     In LocalStack, we're returning this format: "d-<domain_hash>.execute-api.localhost.localstack.cloud"
     """
-    domain_name_hash = get_domain_name_hash(domain_name)
+    domain_name_hash = get_domain_name_hash(domain_name, region_name)
     host = localstack_host().host
     return f"d-{domain_name_hash}.execute-api.{host}"

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -562,7 +562,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             domainName=domain_name,
             certificateName=certificate_name,
             certificateArn=certificate_arn,
-            regionalDomainName=get_regional_domain_name(domain_name),
+            regionalDomainName=get_regional_domain_name(domain_name, context.region),
             domainNameStatus=DomainNameStatus.AVAILABLE,
             regionalHostedZoneId=zone_id,
             regionalCertificateName=regional_certificate_name,


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
When working with Regional Domain Names from APIGW, we had a little flaw: we only used the hash of the custom domain name, but not the region is lived it. This meant that for two Custom Domain Names living in 2 different regions, their regional domain names would be the same, which defeat the purpose. 

This PR adapts the utility to take into account the region now. 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- add the region as a parameter to calculate the regional domain name value (it could also very well be randomly generated to be honest)

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
