### PR TITLE
OpenSearch: Move Tagging into Provider Methods

### DIFF
--- a/localstack-core/localstack/services/opensearch/provider.py
+++ b/localstack-core/localstack/services/opensearch/provider.py
@@ -577,7 +577,7 @@ class OpensearchProvider(OpensearchApi, ServiceLifecycleHook):
 
             # set the tags
             if tags := request.get("TagList", []):
-                self.add_tags(context, domain_key.arn, tags)
+                self._add_tags(context, domain_key.arn, tags)
 
             # get the (updated) status
             status = get_domain_status(domain_key)


### PR DESCRIPTION
## Changes
- Moves the existing tagging functionality into provider methods so that it can be overwritten in Pro.
- This doesn't change any existing functionality.