### PR TITLE
Update README with notice on image consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> **We’re moving toward a unified LocalStack for AWS image, updating how access works.**
+> **For details on timing and impact please refer [to this blog post](https://localstack.cloud/2026-updates).**
+
 <p align="center">
   <img src="docs/localstack-readme-banner.svg" alt="LocalStack - The Leading Platform for Local Cloud Development">
 </p>


### PR DESCRIPTION
## Motivation
As announced in this [blog post](https://blog.localstack.cloud/the-road-ahead-for-localstack/), we are unifying the LocalStack images in March.
This PR adds an info callout to the top of the README informing users about the upcoming change:
<img width="1201" height="727" alt="image" src="https://github.com/user-attachments/assets/3b391e39-db7e-46ca-8811-5084fb384a02" />

Closes ENG-196.

## Changes
- Adds a callout on the top of the readme referring users [to this blog post](https://localstack.cloud/2026-updates).

## Questions?
If you have questions about the upcoming changes, check the detailed FAQ in our blog post or share questions or concerns via our community Slack channel.