### PR TITLE
Update DockerHub with notice on image consolidation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,3 +1,8 @@
+> ℹ️ **Important**
+>
+> We’re moving toward a unified LocalStack for AWS image, updating how access works.
+> For details on timing and impact please refer [to this blog post](https://localstack.cloud/2026-updates).
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/localstack/localstack/main/docs/localstack-readme-banner.svg" alt="LocalStack - A fully functional local cloud stack">
 </p>


### PR DESCRIPTION
## Motivation
As announced in this [blog post](https://blog.localstack.cloud/the-road-ahead-for-localstack/), we are unifying the LocalStack images in March.
Analogous to #13637 this PR adds an information to the top of the DockerHub README informing users about the upcoming change:
<img width="1215" height="728" alt="image" src="https://github.com/user-attachments/assets/fc57b12b-999e-4185-b86c-996dc397df2d" />
The syntax looks a bit different, because DockerHub does not support GitHub Markdown Alerts.
Once this PR is merged, the README will automatically be updated with [this GitHub workflow](https://github.com/localstack/localstack/actions/workflows/dockerhub-description.yml).
Closes ENG-197.

## Changes
- Adds a callout on the top of the DockerHub README referring users [to this blog post](https://localstack.cloud/2026-updates).

## Questions?
If you have questions about the upcoming changes, check the detailed FAQ in our blog post or share questions or concerns via our community Slack channel.