### PR TITLE
add warning on image consolidation to CLI start

### DIFF
--- a/localstack-core/localstack/cli/localstack.py
+++ b/localstack-core/localstack/cli/localstack.py
@@ -523,6 +523,16 @@ def cmd_start(
         print_app()
         console.line()
 
+    # check if we are about to activate Pro, if not raise a warning about the upcoming changes
+    # LOCALSTACK_ACTIVATE_PRO is set by the Pro config if the auth token is cached or explicitly set in the env
+    if not config.is_env_true("LOCALSTACK_ACTIVATE_PRO"):
+        console.log(
+            "Warning: You are starting LocalStack without an auth token. "
+            "Starting in March 2026, LocalStack will require an auth token. "
+            "Go to this page for more infos: https://localstack.cloud/2026-updates",
+            style="bold red",
+        )
+
     from localstack.utils import bootstrap
 
     if not no_banner:


### PR DESCRIPTION
## Motivation
As announced in this [blog post](https://blog.localstack.cloud/the-road-ahead-for-localstack/), we are unifying the LocalStack images in March.
This means that from then on there will not be a dedicated LocalStack for AWS Community image anymore, and you will have to use an auth token when starting LocalStack from the CLI.
This PR adds an explicit warning when starting LocalStack using the CLI without any kind of authentication:
```
❯ localstack start

     __                     _______ __             __
    / /   ____  _________ _/ / ___// /_____ ______/ /__
   / /   / __ \/ ___/ __ `/ /\__ \/ __/ __ `/ ___/ //_/
  / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
 /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|

- LocalStack CLI: 4.12.1.dev78
- Profile: default
- App: https://app.localstack.cloud

[16:22:10] Warning: You are starting LocalStack without an auth token. Starting in localstack.py:527
           March 2026, LocalStack will require an auth token. Go to this page for                   
           more infos: https://localstack.cloud/2026-updates                                        
           starting LocalStack in Docker mode 🐳                                   localstack.py:540
────────────────────────── LocalStack Runtime Log (press CTRL-C to quit) ───────────────────────────

```
Relates to https://github.com/localstack/localstack/pull/13638 and https://github.com/localstack/localstack/pull/13637.
Closes ENG-323.

## Changes
- Posts a warning if the CLI is about to start the Community version of LocalStack (i.e. no auth token is set and no auth token was set using `localstack auth set-token`.

## Questions?
If you have questions about the upcoming changes, check the detailed FAQ in our blog post or share questions or concerns via our community Slack channel.