### PR TITLE
add warning to Community image startup

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -3,17 +3,27 @@
 set -eo pipefail
 shopt -s nullglob
 
+if [ -z $LOCALSTACK_AUTH_TOKEN ]; then
+    echo "WARNING"
+    echo "================================================================================"
+    echo "  You are starting the LocalStack Community Docker image."
+    echo "  We move towards a unified LocalStack for AWS image in March 2026."
+    echo "  Go to this page for more infos: https://localstack.cloud/2026-updates"
+    echo "================================================================================"
+    echo ""
+fi
+
 # When trying to activate pro features in the community version, raise a warning
 if [[ -n $LOCALSTACK_API_KEY || -n $LOCALSTACK_AUTH_TOKEN ]]; then
     echo "WARNING"
-    echo "============================================================================"
-    echo "  It seems you are trying to use the LocalStack Pro version without using "
-    echo "  the dedicated Pro image."
+    echo "================================================================================"
+    echo "  It seems you are trying to use the LocalStack Pro version without using the"
+    echo "  dedicated Pro image."
     echo "  LocalStack will only start with community services enabled."
     echo "  To fix this warning, use localstack/localstack-pro instead."
     echo ""
     echo "  See: https://github.com/localstack/localstack/issues/7882"
-    echo "============================================================================"
+    echo "================================================================================"
     echo ""
 fi
 


### PR DESCRIPTION
## Motivation
As announced in this [blog post](https://blog.localstack.cloud/the-road-ahead-for-localstack/), we are unifying the LocalStack images in March.
This means that from then on there will not be a dedicated LocalStack for AWS Community image anymore, and you will have to use an auth token when starting LocalStack from the CLI.
This PR adds an explicit warning when starting the LocalStack for AWS Community Docker image:
```
❯ docker run localstack/localstack
WARNING
================================================================================
  You are starting the LocalStack Community Docker image.
  We move towards a unified LocalStack for AWS image in March 2026.
  Go to this page for more infos: https://localstack.cloud/2026-updates
================================================================================


LocalStack version: 4.12.1.dev78
LocalStack build date: 2026-01-26
LocalStack build git hash: 73c77398e

Ready.
```
Relates to https://github.com/localstack/localstack/pull/13638, https://github.com/localstack/localstack/pull/13637, and https://github.com/localstack/localstack/pull/13645.
Closes ENG-198.

## Changes
- Posts a prominent warning when starting the Community Docker image of LocalStack for AWS.
- Formats the other warning message to max out on 80 characters (usually the default max characters per line in a terminal).

## Questions?
If you have questions about the upcoming changes, check the detailed FAQ in our blog post or share questions or concerns via our community Slack channel.