### PR TITLE
fix(docs): repair broken links in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,9 +5,9 @@ We welcome contributions to LocalStack! Please refer to the following sections t
 ## Sections
 
 - [Contribution Guidelines](#contribution-guidelines)
-- [Development Environment Setup](development-environment-setup/README.md)
-- [LocalStack Concepts](localstack-concepts/README.md)
-- [Testing](testing/README.md)
+- [Development Environment Setup](/docs/development-environment-setup/README.md)
+- [LocalStack Concepts](/docs/localstack-concepts/README.md)
+- [Testing](/docs/testing/README.md)
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
## Motivation
While setting up my development environment to contribute to LocalStack, I accessed the **Contributing** guidelines via the repository's main page overlay. I noticed that clicking on key setup links (specifically "Development Environment Setup", "LocalStack Concepts", and"Testing") resulted in **404 Page Not Found** errors. Spent a solid 5 mins wondering where the files are supposed to be.
This happens because the overlay renders the Markdown from the repository root, breaking the relative links that assume the user is browsing inside the `docs/` directory.
<img width="3072" height="839" alt="Screenshot from 2026-01-26 21-00-20" src="https://github.com/user-attachments/assets/bf563117-8b4e-4134-921f-0a69ae3ab0ba" />

## Changes
Updated the links in `docs/CONTRIBUTING.md` to use root-relative paths (e.g., `/docs/development-environment-setup/README.md`). This ensures the links resolve correctly in **both** the file browser view and the main "Contributing" overlay tab.

## Tests
Manually verified that the new paths correctly point to the existing files in the repository structure.

## Related
N/A