### PR TITLE
Adding client context to lambda

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/execution_environment.py
@@ -384,6 +384,7 @@ class ExecutionEnvironment:
             "invoked-function-arn": invocation.invoked_arn,
             "payload": to_str(invocation.payload),
             "trace-id": aws_trace_header.to_header_str(),
+            "client-context": invocation.client_context,
         }
         return self.runtime_executor.invoke(payload=invoke_payload)
 

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -1808,7 +1808,7 @@ class TestLambdaFeatures:
         snapshot.match("invocation-response", result)
 
     # TODO: implement in new provider (was tested in old provider)
-    @pytest.mark.skip(reason="Not yet implemented")
+
     @markers.aws.validated
     def test_lambda_with_context(
         self, create_lambda_function, check_lambda_logs, snapshot, aws_client

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -841,7 +841,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaFeatures::test_lambda_with_context": {
-    "recorded-date": "09-09-2022, 20:19:33",
+    "recorded-date": "27-01-2026, 11:01:42",
     "recorded-content": {
       "creation": {
         "CreateEventSourceMappingResponse": null,
@@ -862,11 +862,22 @@
           "FunctionName": "<function-name:1>",
           "Handler": "lambda_integration.handler",
           "LastModified": "date",
+          "LoggingConfig": {
+            "LogFormat": "Text",
+            "LogGroup": "/aws/lambda/<function-name:1>"
+          },
           "MemorySize": 128,
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
           "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "nodejs16.x",
+          "Runtime": "nodejs20.x",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -456,7 +456,13 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaFeatures::test_lambda_with_context": {
-    "last_validated_date": "2022-09-09T18:19:33+00:00"
+    "last_validated_date": "2026-01-27T11:01:42+00:00",
+    "durations_in_seconds": {
+      "setup": 12.04,
+      "call": 11.93,
+      "teardown": 1.39,
+      "total": 25.36
+    }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaFeatures::test_upload_lambda_from_s3": {
     "last_validated_date": "2025-11-24T23:12:31+00:00",


### PR DESCRIPTION
## Motivation
- This PR tackles the following issue https://github.com/localstack/localstack/issues/11053

## Changes:
- Adds client context to payload.

## Notes:
- This PR: https://github.com/localstack/lambda-runtime-init/pull/75 needs to be approved before merging this one.

