### PR TITLE
increase size of image consolidation notice on DockerHub

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,7 +1,7 @@
-> ℹ️ **Important**
+> # ℹ️ **Important**
 >
-> We’re moving toward a unified LocalStack for AWS image, updating how access works.
-> For details on timing and impact please refer [to this blog post](https://localstack.cloud/2026-updates).
+> ## We’re moving toward a unified LocalStack for AWS image, updating how access works.
+> ## For details on timing and impact please refer [to this blog post](https://localstack.cloud/2026-updates).
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/localstack/localstack/main/docs/localstack-readme-banner.svg" alt="LocalStack - A fully functional local cloud stack">


### PR DESCRIPTION
## Motivation
Following up on https://github.com/localstack/localstack/pull/13638, we got the feedback that the callout on DockerHub is a bit too small. This PR updates the size of the callout as follows:
- Before:
  <img width="1215" height="728" alt="image" src="https://github.com/user-attachments/assets/8e0c0eee-62cb-43c7-ae4a-780b242b9e8f" />

- After:
  <img width="1081" height="740" alt="image" src="https://github.com/user-attachments/assets/67090a69-f1d8-498e-80de-6014194da06b" />

## Changes
- Update formatting of the top callout on the DockerHub README

## Questions?
If you have questions about the upcoming changes, check the detailed FAQ in our blog post or share questions or concerns via our community Slack channel.