### PR TITLE
Admin: Add typehints to utils/strings and utils/threads

### DIFF
--- a/localstack-core/localstack/utils/run.py
+++ b/localstack-core/localstack/utils/run.py
@@ -170,7 +170,7 @@ def is_command_available(cmd: str) -> bool:
         return False
 
 
-def kill_process_tree(parent_pid):
+def kill_process_tree(parent_pid: int) -> None:
     # Note: Do NOT import "psutil" at the root scope
     import psutil
 

--- a/localstack-core/mypy.ini
+++ b/localstack-core/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 explicit_package_bases = true
 mypy_path=localstack-core
-files=localstack/aws/api/core.py,localstack/packages,localstack/services/transcribe,localstack/services/kinesis/packages.py
+files=localstack/aws/api/core.py,localstack/utils/threads.py,localstack/utils/strings.py,localstack/packages,localstack/services/transcribe,localstack/services/kinesis/packages.py
 ignore_missing_imports = False
 follow_imports = silent
 ignore_errors = False

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -2,7 +2,6 @@ import base64
 import io
 import itertools
 import os
-import threading
 import time
 import zipfile
 from datetime import UTC, date, datetime, timedelta
@@ -362,24 +361,6 @@ class TestCommon:
         assert fn(12.521, decimals=4) == "12.521"
         assert fn(-12.521, decimals=4) == "-12.521"
         assert fn(-1.2234354123e3, decimals=4) == "-1223.4354"
-
-    def test_cleanup_threads_and_processes_calls_shutdown_hooks(self):
-        # TODO: move all run/concurrency related tests into separate class
-
-        started = threading.Event()
-        done = threading.Event()
-
-        def run_method(*args, **kwargs):
-            started.set()
-            func_thread = kwargs["_thread"]
-            # thread waits until it is stopped
-            func_thread._stop_event.wait()
-            done.set()
-
-        common.start_thread(run_method)
-        assert started.wait(timeout=2)
-        common.cleanup_threads_and_processes()
-        assert done.wait(timeout=2)
 
     def test_proxy_map(self):
         old_http_proxy = config.OUTBOUND_HTTP_PROXY

--- a/tests/unit/utils/test_threads.py
+++ b/tests/unit/utils/test_threads.py
@@ -1,0 +1,62 @@
+import threading
+
+from localstack.utils.threads import (
+    TMP_THREADS,
+    FuncThread,
+    cleanup_threads_and_processes,
+    start_thread,
+    start_worker_thread,
+)
+
+
+class TestThreads:
+    class TestStartThread:
+        def test_start_thread_returns_a_func_thread(self):
+            def examplefunc(*args):
+                pass
+
+            thread = start_thread(examplefunc)
+
+            assert isinstance(thread, FuncThread)
+            assert thread.name.startswith("examplefunc-")
+            assert thread in TMP_THREADS
+
+        def test_start_thread_with_custom_name(self):
+            thread = start_thread(lambda: None, name="somefunc")
+
+            assert thread.name.startswith("somefunc-")
+
+    class TestStartWorkerThread:
+        def test_start_worker_thread_returns_a_func_thread(self):
+            thread = start_worker_thread(lambda: None)
+
+            assert isinstance(thread, FuncThread)
+            assert thread.name.startswith("start_worker_thread-")
+            assert thread not in TMP_THREADS
+
+        def test_start_worker_thread_with_custom_name(self):
+            thread = start_worker_thread(lambda: None, name="somefunc")
+            assert thread.name.startswith("somefunc-")
+
+    def test_cleanup_threads_and_processes_calls_shutdown_hooks(self):
+        started = threading.Event()
+        done = threading.Event()
+
+        # Note: we're extending FuncThread here to make sure we have access to `_stop_event`
+        # Regular users would use `start_thread` instead
+        class ThreadTest(FuncThread):
+            def __init__(self) -> None:
+                super().__init__(self.run_method)
+
+            def run_method(self, *args):
+                started.set()
+                # thread waits until it is stopped
+                self._stop_event.wait()
+                done.set()
+
+        test_thread = ThreadTest()
+        TMP_THREADS.append(test_thread)
+        test_thread.start()
+        assert started.wait(timeout=2)
+        cleanup_threads_and_processes()
+        assert done.wait(timeout=2)


### PR DESCRIPTION
## Motivation

This PR adds typehints to some utilities (`utils/strings.py` and `utils/threads.py`) and explicitly verifies the correctness using `mypy`. 

The original intention was to only add types to the most common methods, like `to_str` and `start_thread` - but adding types to the entire file wasn't that much more effort, that's why I went all out.

Some logic has been moved around - I'll add some inline comments to explain what happened, and why this is (IMHO) acceptable.

The (single) test that we had for `FuncThreads` has also been reworked and moved to a dedicated testfile, with some additional tests for good measure.

Not sure who actually owns these utilities! @alexrashed I've tagged you as the resident Python guru, but feel free to re-assign if you think someone else is more suitable :slightly_smiling_face: 
