### PR TITLE
add precommit hook to prevent commits on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: no-commit-to-branch
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-json


### PR DESCRIPTION
## Motivation
I recently - in a different repo in the org - accidentally directly pushed a commit on `main` because I didn't switch to a branch before committing.
While we have a branch protection rule, we do have a single exclusion configured for commits created during the release process. Unfortunately, this also enables the feature that every other admin can mitigate the branch protection rules and a push is not properly blocked server-side by GitHub.
While this only affects very few people (org / repo admins), it generally is annoying when you forgot to branch from `main` after the commit but then have to reset `main` to the upstream state.
This is why this PR adds a single line to the pre-commit hook: [`no-commit-to-branch`](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#no-commit-to-branch)
By default this hook prevents commits on `main` or `master`, so there is no need for further config.

## Changes
- Adds a pre-commit hook which prevents commits on `main`.