### PR TITLE
SecretsManager: add tag/untag resource handling for deleted secrets

### DIFF
--- a/localstack-core/localstack/services/secretsmanager/provider.py
+++ b/localstack-core/localstack/services/secretsmanager/provider.py
@@ -614,6 +614,32 @@ def backend_update_secret(
     return json.dumps(resp)
 
 
+@patch(SecretsManagerBackend.tag_resource)
+def backend_tag_resource(fn, self, secret_id, tags):
+    if secret_id not in self.secrets:
+        raise SecretNotFoundException()
+
+    if self.secrets[secret_id].is_deleted():
+        raise InvalidRequestException(
+            "You can't perform this operation on the secret because it was marked for deletion."
+        )
+
+    return fn(self, secret_id, tags)
+
+
+@patch(SecretsManagerBackend.untag_resource)
+def backend_untag_resource(fn, self, secret_id, tag_keys):
+    if secret_id not in self.secrets:
+        raise SecretNotFoundException()
+
+    if self.secrets[secret_id].is_deleted():
+        raise InvalidRequestException(
+            "You can't perform this operation on the secret because it was marked for deletion."
+        )
+
+    return fn(self, secret_id, tag_keys)
+
+
 @patch(SecretsManagerResponse.update_secret, pass_target=False)
 def response_update_secret(self):
     secret_id = self._get_param("SecretId")

--- a/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.snapshot.json
@@ -4761,5 +4761,50 @@
         }
       }
     }
+  },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_tag_untag_resource_on_deleted_secret": {
+    "recorded-date": "29-01-2026, 22:02:37",
+    "recorded-content": {
+      "create_secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<version_uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_secret": {
+        "ARN": "arn:<partition>:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "tag_deleted_secret_error": {
+        "Error": {
+          "Code": "InvalidRequestException",
+          "Message": "You can't perform this operation on the secret because it was marked for deletion."
+        },
+        "Message": "You can't perform this operation on the secret because it was marked for deletion.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "untag_deleted_secret_error": {
+        "Error": {
+          "Code": "InvalidRequestException",
+          "Message": "You can't perform this operation on the secret because it was marked for deletion."
+        },
+        "Message": "You can't perform this operation on the secret because it was marked for deletion.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
+++ b/tests/aws/services/secretsmanager/test_secretsmanager.validation.json
@@ -134,6 +134,15 @@
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_secret_version_not_found": {
     "last_validated_date": "2024-06-13T08:04:35+00:00"
   },
+  "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_tag_untag_resource_on_deleted_secret": {
+    "last_validated_date": "2026-01-29T22:02:38+00:00",
+    "durations_in_seconds": {
+      "setup": 0.79,
+      "call": 1.51,
+      "teardown": 0.23,
+      "total": 2.53
+    }
+  },
   "tests/aws/services/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_update_secret_description": {
     "last_validated_date": "2024-03-15T08:12:49+00:00"
   },


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

<!--
Elaborate the background and intent for raising this PR.
-->
Fixes #13648

LocalStack incorrectly allows tagging and untagging operations on secrets that have been marked for deletion. AWS Secrets Manager rejects these operations with an `InvalidRequestException`.


## Changes

<!--
Summarise the changes proposed in the PR.
-->
- Added `@patch` for `SecretsManagerBackend.tag_resource` to check if the secret is marked for deletion before allowing tagging
- Added `@patch` for `SecretsManagerBackend.untag_resource` to check if the secret is marked for deletion before allowing untagging
- Both patches raise `InvalidRequestException` with the same error message as AWS


## Tests

<!--
Optional: How are the proposed changes tested?
-->
- Added `test_tag_untag_resource_on_deleted_secret` - an AWS-validated snapshot test that verifies both `tag_resource` and `untag_resource` operations fail with `InvalidRequestException` when the secret is marked for deletion

## Related
- Issue: #13648
<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
