### PR TITLE
fix lambda state reset method to shutdown esm workers correctly

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -292,6 +292,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         visitor.visit(lambda_stores)
 
     def on_before_state_reset(self):
+        for esm_worker in self.esm_workers.values():
+            esm_worker.stop_for_shutdown()
+        self.esm_workers = {}
         self.lambda_service.stop()
 
     def on_after_state_reset(self):


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

While working on a project, I noticed that after calling `localstack state reset`, the logs indicated that ESM workers were not shut down correctly. I have a simple SQS <- ESM -> Lambda setup, and after resetting the state, I continued to get error messages that look like they're coming from the worker:

```
2026-01-31T14:34:46.821  INFO --- [et.reactor-1] localstack.request.http    : POST /_localstack/state/reset => 200
2026-01-31T14:34:47.230 ERROR --- [functhread12] l.s.l.e.esm_worker         : Error while polling messages for event source arn:aws:sqs:us-east-1:000000000000:messages-queue: An error occurred (AWS.SimpleQueueService.NonExistentQueue) when calling the ReceiveMessage operation: The specified queue does not exist.
2026-01-31T14:34:48.377 ERROR --- [functhread12] l.s.l.e.esm_worker         : Error while polling messages for event source arn:aws:sqs:us-east-1:000000000000:messages-queue: An error occurred (AWS.SimpleQueueService.NonExistentQueue) when calling the ReceiveMessage operation: The specified queue does not exist.
```

This PR simply replicates what `on_before_stop` does, which is iterating over the ESM workers and stopping them. Additionally, we're now also clearing the state that holds references to the workers.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

* ESM workers are now shut down and removed correctly when resetting lambda state

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->
Tested manually with a simple project:
* Create a simple SQS/Lambda ESM setup, observe the esm worker logs that they are polling from the queue
* call `localstack state reset`, and observe that the logs are no longer producing the error output
* re-deploy the same resources again and make sure it still works (ensuring no breaking state side-effects)

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
