### PR TITLE
add poc for internal lambda endpoint to list invocations

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation_log.py
+++ b/localstack-core/localstack/services/lambda_/invocation_log.py
@@ -1,0 +1,96 @@
+import dataclasses
+import datetime
+import json
+import logging
+import tempfile
+import threading
+from typing import IO
+
+from localstack import config
+from localstack.services.lambda_.invocation.lambda_models import InvocationResult
+from localstack.utils.json import CustomEncoder
+
+LOG = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class InvocationLogRecord:
+    timestamp: datetime.datetime
+    request_id: str
+    function_arn: str
+    payload: str
+    result: InvocationResult
+
+    def to_dict(self) -> dict:
+        doc = dataclasses.asdict(self)
+        doc["timestamp"] = self.timestamp.isoformat()
+        doc["result"] = dataclasses.asdict(self.result)
+        if isinstance(doc["result"].get("payload"), bytes):
+            doc["result"]["payload"] = doc["result"]["payload"].decode("utf-8")
+
+        return doc
+
+
+class InvocationLog:
+    _file: IO[bytes]
+    _lock: threading.Lock
+
+    def __init__(self):
+        # 1MB in-memory buffer before rolling over to disk
+        self._file = tempfile.SpooledTemporaryFile(
+            max_size=1024 * 1024, mode="w+b", dir=config.dirs.data
+        )
+        self._lock = threading.Lock()
+
+    def append(self, record: InvocationLogRecord):
+        doc = record.to_dict()
+        line = json.dumps(doc, cls=CustomEncoder) + "\n"
+        # SpooledTemporaryFile might not be thread-safe for seeks and writes.
+        # Since this is a global log, multiple threads might call it concurrently.
+        # Adding a lock for safety.
+        with self._lock:
+            self._file.seek(0, 2)
+            self._file.write(line.encode("utf-8"))
+
+    def get_all(self) -> list[InvocationLogRecord]:
+        with self._lock:
+            self._file.seek(0)
+            # We read everything into memory here anyway, as requested by return type.
+            # For a true NDJSON file, we iterate over lines.
+            lines = self._file.readlines()
+
+        records = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                doc = json.loads(line.decode("utf-8"))
+                # Restore types
+                doc["timestamp"] = datetime.datetime.fromisoformat(doc["timestamp"])
+                res = doc["result"]
+                if res.get("payload") is not None:
+                    res["payload"] = res["payload"].encode("utf-8")
+
+                doc["result"] = InvocationResult(**res)
+                records.append(InvocationLogRecord(**doc))
+            except Exception:
+                LOG.exception("Failed to de-serialize invocation log record")
+        return records
+
+
+INVOCATIONS = InvocationLog()
+
+
+def log_invocation(
+    timestamp: datetime.datetime,
+    request_id: str,
+    function_arn: str,
+    payload: str,
+    result: InvocationResult,
+) -> None:
+    record = InvocationLogRecord(timestamp, request_id, function_arn, payload, result)
+    INVOCATIONS.append(record)
+
+
+def get_invocations() -> list[InvocationLogRecord]:
+    return INVOCATIONS.get_all()


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

This is a PoC for an internal `/_aws/lambda/invocations` endpoint that lists all lambda invocations and their logs. Invocations record are collected through the `ExecutorEndpoint` into a global log. The log uses a spooled temp file to keep things in memory for most use cases, but rolls to disk to avoid memory leaks.

It's not production ready or anything, but can provide a basis for discussing how to implement this as a first-class feature. Perhaps we find that we want to have this (particularly the lambda logs) in app inspector traces instead?

Here's how to use it and an example output:

```console
 % curl -s "localhost:4566/_aws/lambda/invocations?formatted=true&arn=arn:aws:lambda:us-east-1:000000000000:function:sample" | jq .
```

```json
{
  "invocations": [
    {
      "timestamp": "2026-02-01T15:23:40.581386+00:00",
      "request_id": "6a192bc5-14fd-41c0-bb19-f9eb87992fb8",
      "function_arn": "arn:aws:lambda:us-east-1:000000000000:function:sample",
      "payload": {},
      "result": {
        "request_id": "6a192bc5-14fd-41c0-bb19-f9eb87992fb8",
        "payload": "eyJzdGF0dXNDb2RlIjogMjAwLCAiYm9keSI6ICJvayJ9",
        "is_error": false,
        "logs": [
          "START RequestId: 6a192bc5-14fd-41c0-bb19-f9eb87992fb8 Version: $LATEST",
          "hello! {}",
          "END RequestId: 6a192bc5-14fd-41c0-bb19-f9eb87992fb8",
          "REPORT RequestId: 6a192bc5-14fd-41c0-bb19-f9eb87992fb8\tDuration: 0.39 ms\tBilled Duration: 1 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB\t"
        ],
        "executed_version": null
      }
    },
    {
      "timestamp": "2026-02-01T15:23:46.969256+00:00",
      "request_id": "a37a17e2-f5ba-4f37-bee9-0cd20f18d402",
      "function_arn": "arn:aws:lambda:us-east-1:000000000000:function:sample",
      "payload": {
        "msg": "hello"
      },
      "result": {
        "request_id": "a37a17e2-f5ba-4f37-bee9-0cd20f18d402",
        "payload": "eyJzdGF0dXNDb2RlIjogMjAwLCAiYm9keSI6ICJvayJ9",
        "is_error": false,
        "logs": [
          "START RequestId: a37a17e2-f5ba-4f37-bee9-0cd20f18d402 Version: $LATEST",
          "hello! {'msg': 'hello'}",
          "END RequestId: a37a17e2-f5ba-4f37-bee9-0cd20f18d402",
          "REPORT RequestId: a37a17e2-f5ba-4f37-bee9-0cd20f18d402\tDuration: 0.54 ms\tBilled Duration: 1 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB\t"
        ],
        "executed_version": null
      }
    }
  ]
}
```

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
