### PR TITLE
CloudFormation: Support intrinsic functions in DeletionPolicy and UpdateReplacePolicy

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -395,8 +395,8 @@ class NodeResource(ChangeSetNode):
     condition_reference: Final[Maybe[TerminalValue]]
     depends_on: Final[Maybe[NodeDependsOn]]
     requires_replacement: Final[bool]
-    deletion_policy: Final[Maybe[ChangeSetTerminal]]
-    update_replace_policy: Final[Maybe[ChangeSetTerminal]]
+    deletion_policy: Final[Maybe[ChangeSetEntity]]
+    update_replace_policy: Final[Maybe[ChangeSetEntity]]
     fn_transform: Final[Maybe[NodeIntrinsicFunctionFnTransform]]
 
     def __init__(
@@ -409,8 +409,8 @@ class NodeResource(ChangeSetNode):
         condition_reference: Maybe[TerminalValue],
         depends_on: Maybe[NodeDependsOn],
         requires_replacement: bool,
-        deletion_policy: Maybe[ChangeSetTerminal],
-        update_replace_policy: Maybe[ChangeSetTerminal],
+        deletion_policy: Maybe[ChangeSetEntity],
+        update_replace_policy: Maybe[ChangeSetEntity],
         fn_transform: Maybe[NodeIntrinsicFunctionFnTransform],
     ):
         super().__init__(scope=scope, change_type=change_type)
@@ -1043,26 +1043,20 @@ class ChangeSetModel:
 
     def _visit_deletion_policy(
         self, scope: Scope, before_deletion_policy: Any, after_deletion_policy: Any
-    ) -> TerminalValue:
+    ) -> ChangeSetEntity:
         value = self._visit_value(
             scope=scope, before_value=before_deletion_policy, after_value=after_deletion_policy
         )
-        if not isinstance(value, TerminalValue):
-            # TODO: decide where template schema validation should occur.
-            raise RuntimeError()
         return value
 
     def _visit_update_replace_policy(
         self, scope: Scope, before_update_replace_policy: Any, after_deletion_policy: Any
-    ) -> TerminalValue:
+    ) -> ChangeSetEntity:
         value = self._visit_value(
             scope=scope,
             before_value=before_update_replace_policy,
             after_value=after_deletion_policy,
         )
-        if not isinstance(value, TerminalValue):
-            # TODO: decide where template schema validation should occur.
-            raise RuntimeError()
         return value
 
     def _visit_resource(

--- a/tests/aws/services/cloudformation/engine/test_conditions.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_conditions.snapshot.json
@@ -949,5 +949,309 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_conditional[dev-Delete]": {
+    "recorded-date": "02-02-2026, 13:26:13",
+    "recorded-content": {
+      "stack-description": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastOperations": [
+              {
+                "OperationId": "<uuid:1>",
+                "OperationType": "CREATE_STACK"
+              }
+            ],
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "OutputKey": "TopicArn",
+                "OutputValue": "arn:<partition>:sns:<region>:111111111111:<resource:2>"
+              }
+            ],
+            "Parameters": [
+              {
+                "ParameterKey": "Environment",
+                "ParameterValue": "dev"
+              },
+              {
+                "ParameterKey": "TopicName",
+                "ParameterValue": "<resource:2>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack-resources": {
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "MyTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_conditional[prod-Retain]": {
+    "recorded-date": "02-02-2026, 13:27:15",
+    "recorded-content": {
+      "stack-description": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastOperations": [
+              {
+                "OperationId": "<uuid:1>",
+                "OperationType": "CREATE_STACK"
+              }
+            ],
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "OutputKey": "TopicArn",
+                "OutputValue": "arn:<partition>:sns:<region>:111111111111:<resource:2>"
+              }
+            ],
+            "Parameters": [
+              {
+                "ParameterKey": "Environment",
+                "ParameterValue": "prod"
+              },
+              {
+                "ParameterKey": "TopicName",
+                "ParameterValue": "<resource:2>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack-resources": {
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "MyTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_fn_find_in_map": {
+    "recorded-date": "02-02-2026, 13:45:02",
+    "recorded-content": {
+      "stack-description": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastOperations": [
+              {
+                "OperationId": "<uuid:1>",
+                "OperationType": "CREATE_STACK"
+              }
+            ],
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "OutputKey": "TopicArn",
+                "OutputValue": "arn:<partition>:sns:<region>:111111111111:<resource:2>"
+              }
+            ],
+            "Parameters": [
+              {
+                "ParameterKey": "Environment",
+                "ParameterValue": "staging"
+              },
+              {
+                "ParameterKey": "TopicName",
+                "ParameterValue": "<resource:2>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack-resources": {
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "MyTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_ref_parameter": {
+    "recorded-date": "02-02-2026, 13:46:15",
+    "recorded-content": {
+      "stack-description": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastOperations": [
+              {
+                "OperationId": "<uuid:1>",
+                "OperationType": "CREATE_STACK"
+              }
+            ],
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "OutputKey": "TopicArn",
+                "OutputValue": "arn:<partition>:sns:<region>:111111111111:<resource:2>"
+              }
+            ],
+            "Parameters": [
+              {
+                "ParameterKey": "DeletionPolicyParam",
+                "ParameterValue": "Retain"
+              },
+              {
+                "ParameterKey": "TopicName",
+                "ParameterValue": "<resource:2>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "stack-resources": {
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "MyTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:3>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_conditions.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_conditions.validation.json
@@ -1,4 +1,40 @@
 {
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_conditional[dev-Delete]": {
+    "last_validated_date": "2026-02-02T13:27:03+00:00",
+    "durations_in_seconds": {
+      "setup": 0.6,
+      "call": 9.96,
+      "teardown": 50.15,
+      "total": 60.71
+    }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_conditional[prod-Retain]": {
+    "last_validated_date": "2026-02-02T13:27:20+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 11.71,
+      "teardown": 4.94,
+      "total": 16.65
+    }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_fn_find_in_map": {
+    "last_validated_date": "2026-02-02T13:45:07+00:00",
+    "durations_in_seconds": {
+      "setup": 0.61,
+      "call": 12.1,
+      "teardown": 4.89,
+      "total": 17.6
+    }
+  },
+  "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_deletion_policy_with_ref_parameter": {
+    "last_validated_date": "2026-02-02T13:46:20+00:00",
+    "durations_in_seconds": {
+      "setup": 0.58,
+      "call": 12.2,
+      "teardown": 4.84,
+      "total": 17.62
+    }
+  },
   "tests/aws/services/cloudformation/engine/test_conditions.py::TestCloudFormationConditions::test_dependent_get_att": {
     "last_validated_date": "2025-09-30T19:25:10+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION

<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

As reported in https://github.com/localstack/localstack/issues/13549, CloudFormation templates using intrinsic functions (such as `Fn::If`, `Fn::FindInMap`, or `Ref`) in `DeletionPolicy` and `UpdateReplacePolicy` attributes were failing with a `RuntimeError` during stack creation. This prevented users from implementing environment-specific or parameter-driven resource lifecycle policies, which works correctly in AWS CloudFormation.


## Changes

- Modified `_visit_deletion_policy()` and `_visit_update_replace_policy()` methods in `change_set_model.py` to accept `ChangeSetEntity` instead of `TerminalValue`, allowing intrinsic functions


## Tests

Added validated tests to capture the previously failing scenarios.

## Related

Closes https://github.com/localstack/localstack/issues/13549