### PR TITLE
improve system information sent in session and container_info

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 
 from localstack import config
 from localstack.runtime import hooks
@@ -132,10 +133,21 @@ class LocalstackContainerInfo:
     def has_docker_socket(self) -> bool:
         return os.path.exists("/run/docker.sock")
 
+    def uname(self) -> dict:
+        result = platform.uname()
+        return {
+            "uname_system": result.system,
+            "uname_release": result.release,
+            "uname_version": result.version,
+            "uname_machine": result.machine,
+        }
+
     def to_dict(self):
         return {
             "variant": self.get_image_variant(),
             "has_docker_socket": self.has_docker_socket(),
+            "container_runtime": config.CONTAINER_RUNTIME,
+            **self.uname(),
         }
 
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Adding a bit more system information to telemetry.

* In #7855 we introduced a container_info event that we haven't really been using all that much because it doesn't container super useful information. I extended it to have more information about the container.
* The session payload mostly said "Linux" which wasn't all that helpful. This method that we already use in pro gives us finer-grained system information. instead of `Linux` it will now say something like `Linux,5.19.0-32-generic,x86_64`

Why both, and the seemingly duplicated data? I didn't want to send uname.version as part of the session payload. Most information we need is in the system string we generate with this new method, and having that in the session payload will be very useful. container_information has it's own utility and having access to the version field there may be helpful for some cases.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

* Add more system information to session data

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
