### PR TITLE
Fix hardcoded AWS user

### DIFF
--- a/localstack-core/localstack/testing/config.py
+++ b/localstack-core/localstack/testing/config.py
@@ -6,7 +6,6 @@ from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 # Credentials used in the test suite
 # These can be overridden if the tests are being run against AWS
 TEST_AWS_ACCOUNT_ID = os.getenv("TEST_AWS_ACCOUNT_ID") or DEFAULT_AWS_ACCOUNT_ID
-TEST_AWS_USER = os.getenv("TEST_AWS_USER") or "user/localstack-testing"
 # If a structured access key ID is used, it must correspond to the account ID
 TEST_AWS_ACCESS_KEY_ID = os.getenv("TEST_AWS_ACCESS_KEY_ID") or "test"
 TEST_AWS_SECRET_ACCESS_KEY = os.getenv("TEST_AWS_SECRET_ACCESS_KEY") or "test"

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -40,10 +40,9 @@ from localstack.testing.config import (
     SECONDARY_TEST_AWS_REGION_NAME,
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
-    TEST_AWS_USER,
 )
 from localstack.utils import testutil
-from localstack.utils.aws.arns import extract_resource_from_arn, get_partition
+from localstack.utils.aws.arns import get_partition
 from localstack.utils.aws.client import SigningHttpClient
 from localstack.utils.aws.resources import create_dynamodb_table
 from localstack.utils.bootstrap import is_api_enabled
@@ -2167,15 +2166,6 @@ def account_id(aws_client):
         return aws_client.sts.get_caller_identity()["Account"]
     else:
         return TEST_AWS_ACCOUNT_ID
-
-
-@pytest.fixture(scope="session")
-def user(aws_client):
-    if is_aws_cloud() or is_api_enabled("sts"):
-        arn = aws_client.sts.get_caller_identity()["Arn"]
-        return extract_resource_from_arn(arn)
-    else:
-        return TEST_AWS_USER
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Snapshot re-validation with another IAM user (e.g., used for AWS preview access) causes a user mismatch. We can solve this dynamically as suggested in this PR review https://github.com/localstack/localstack-pro/pull/5668#discussion_r2565243420

Use cases:
* We need to create and share a new AWS user for AWS parity testing and cannot choose `user/localstack-testing` (e.g., specific allow-listed AWS accounts)
* Some developers might use a different name for the AWS user causing flakiness in our parity testing approach

## Changes

* Add global snapshot transformer for AWS user called `:<user>`
   * Alternative names could be `:<user-role>`, or `:<aws-user-role`
   * This transformer only applies in the ARN context, hence reducing potential false positive with other `<USER>` transformers used for example for database authentication
* ~~Add AWS `user` fixture~~ -> removed in favor of global snapshot transformer
* Reduce hardcoded user duplication in Lambda code

## Related

Fixes DRG-447
