### PR TITLE
Follow-up for ruff target-version upgrade

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from functools import lru_cache, partial
 from random import choice
 from socket import socket
-from typing import Any, TypedDict
+from typing import Any, Generic, TypedDict, TypeVar
 
 import dns.message
 import dns.query
@@ -165,7 +165,10 @@ def load_dto(data: str) -> InternalRequestParameters:
     return json.loads(data)
 
 
-class MetadataRequestInjector[T]:
+T = TypeVar("T")
+
+
+class MetadataRequestInjector(Generic[T]):
     def __init__(self, client: T, params: dict[str, str] | None = None):
         self._client = client
         self._params = params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ exclude = [
 "localstack-core/localstack/constants.py" = "py310"
 "localstack-core/localstack/utils/**" = "py310"  # imported by CLI tests
 "localstack-core/localstack/testing/pytest/**" = "py310" # imported by CLI tests
+"localstack-core/localstack/aws/connect.py" = "py310" # imported by CLI tests
 
 [tool.deptry]
 known_first_party = [


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
With https://github.com/localstack/localstack/pull/13688 we upgraded the target version of `ruff` to Python 3.13.
Therefore, we upgraded some `Generic` syntax. Unfortunately, `localstack.aws.connect` is imported from the `bootstrap` module in Pro. This led to failures in the CLI tests.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- Revert 3.12 generic syntax for `localstack.aws.connect`.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
