### PR TITLE
Deprecate TaggingService

### DIFF
--- a/localstack-core/localstack/utils/tagging.py
+++ b/localstack-core/localstack/utils/tagging.py
@@ -1,3 +1,7 @@
+from warnings import deprecated
+
+
+@deprecated("`TaggingService` is deprecated. Please use the `RGTAPlugin`/`Tagger` system.")
 class TaggingService:
     key_field: str
     value_field: str


### PR DESCRIPTION
## Changes

This PR adds a deprecation warning to the `TaggingService` which highlights its use in static type checkers.

<img width="969" height="199" alt="image" src="https://github.com/user-attachments/assets/cd85f812-bf0b-4bb6-a6b3-6a39c10535fa" />


This change solely targets developers. End user UX is not affected.