### PR TITLE
CloudFormation: make test_fn_find_in_map_with_nested_ref_change_mapping region-agnostic

### DIFF
--- a/tests/aws/services/cloudformation/test_change_set_mappings.py
+++ b/tests/aws/services/cloudformation/test_change_set_mappings.py
@@ -370,6 +370,8 @@ class TestChangeSetMappings:
         self,
         snapshot,
         capture_update_process,
+        region_name,
+        secondary_region_name,
     ):
         name1 = f"topic-name-1-{long_uid()}"
         snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
@@ -377,8 +379,8 @@ class TestChangeSetMappings:
         template_1 = {
             "Mappings": {
                 "RegionMap": {
-                    "us-east-1": {"value": "east-value-1"},
-                    "us-west-2": {"value": "west-value-1"},
+                    region_name: {"value": "value-1"},
+                    secondary_region_name: {"value": "value-2"},
                 }
             },
             "Resources": {
@@ -402,8 +404,8 @@ class TestChangeSetMappings:
         template_2 = {
             "Mappings": {
                 "RegionMap": {
-                    "us-east-1": {"value": "east-value-2"},  # Changed
-                    "us-west-2": {"value": "west-value-2"},  # Changed
+                    region_name: {"value": "value-3"},  # changed
+                    secondary_region_name: {"value": "value-4"},  # changed
                 }
             },
             "Resources": {

--- a/tests/aws/services/cloudformation/test_change_set_mappings.snapshot.json
+++ b/tests/aws/services/cloudformation/test_change_set_mappings.snapshot.json
@@ -2834,7 +2834,7 @@
     }
   },
   "tests/aws/services/cloudformation/test_change_set_mappings.py::TestChangeSetMappings::test_fn_find_in_map_with_nested_ref_change_mapping": {
-    "recorded-date": "02-02-2026, 11:43:11",
+    "recorded-date": "04-02-2026, 11:54:54",
     "recorded-content": {
       "create-change-set-1": {
         "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
@@ -2858,7 +2858,7 @@
               "Action": "Add",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "east-value-1",
+                  "DisplayName": "value-1",
                   "TopicName": "topic-name-1"
                 }
               },
@@ -2971,13 +2971,13 @@
               "Action": "Modify",
               "AfterContext": {
                 "Properties": {
-                  "DisplayName": "east-value-2",
+                  "DisplayName": "value-3",
                   "TopicName": "topic-name-1"
                 }
               },
               "BeforeContext": {
                 "Properties": {
-                  "DisplayName": "east-value-1",
+                  "DisplayName": "value-1",
                   "TopicName": "topic-name-1"
                 }
               },
@@ -2986,10 +2986,10 @@
                   "ChangeSource": "DirectModification",
                   "Evaluation": "Static",
                   "Target": {
-                    "AfterValue": "east-value-2",
+                    "AfterValue": "value-3",
                     "Attribute": "Properties",
                     "AttributeChangeType": "Modify",
-                    "BeforeValue": "east-value-1",
+                    "BeforeValue": "value-1",
                     "Name": "DisplayName",
                     "Path": "/Properties/DisplayName",
                     "RequiresRecreation": "Never"

--- a/tests/aws/services/cloudformation/test_change_set_mappings.validation.json
+++ b/tests/aws/services/cloudformation/test_change_set_mappings.validation.json
@@ -18,12 +18,12 @@
     }
   },
   "tests/aws/services/cloudformation/test_change_set_mappings.py::TestChangeSetMappings::test_fn_find_in_map_with_nested_ref_change_mapping": {
-    "last_validated_date": "2026-02-02T11:43:11+00:00",
+    "last_validated_date": "2026-02-04T11:54:54+00:00",
     "durations_in_seconds": {
       "setup": 0.61,
-      "call": 90.09,
+      "call": 91.81,
       "teardown": 0.32,
-      "total": 91.02
+      "total": 92.74
     }
   },
   "tests/aws/services/cloudformation/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_addition_with_resource": {


### PR DESCRIPTION
## Motivation

The test `test_fn_find_in_map_with_nested_ref_change_mapping` was failing in the MA/MR pipeline.
The test was hardcoded to use us-east-1 and us-west-2 in its CloudFormation mapping definitions, which caused it to fail when the pipeline selected a different region.


## Changes

Replaced hardcoded "us-east-1" and "us-west-2" with the fixture values


