### PR TITLE
Lambda: Update CapacityProviderArn for managed instances

### DIFF
--- a/localstack-core/localstack/services/lambda_/provider.py
+++ b/localstack-core/localstack/services/lambda_/provider.py
@@ -1439,6 +1439,14 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     Type="User",
                 )
 
+            default_config = CapacityProviderConfig(
+                LambdaManagedInstancesCapacityProviderConfig=LambdaManagedInstancesCapacityProviderConfig(
+                    ExecutionEnvironmentMemoryGiBPerVCpu=2.0,
+                    PerExecutionEnvironmentMaxConcurrency=16,
+                )
+            )
+            capacity_provider_config = merge_recursive(default_config, capacity_provider_config)
+            replace_kwargs["CapacityProviderConfig"] = capacity_provider_config
         new_latest_version = dataclasses.replace(
             latest_version,
             config=dataclasses.replace(


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Support update of `CapacityProviderArn` for managed instances for UpdateFunctionConfiguration API.
There is some existing validation upon removing and adding a capacity provider from/to a lambda function.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
Closes DRG-169