### PR TITLE
SNS: add missing `requires_in_process` test markers

### DIFF
--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -4852,6 +4852,7 @@ class TestSNSSMS:
         snapshot.match("invalid-attribute", e.value.response)
 
     @markers.aws.manual_setup_required
+    @markers.requires_in_process
     def test_is_phone_number_opted_out(
         self, phone_number, aws_client, snapshot, account_id, region_name, cleanups
     ):
@@ -4871,6 +4872,7 @@ class TestSNSSMS:
         snapshot.match("phone-number-opted-out", response)
 
     @markers.aws.manual_setup_required
+    @markers.requires_in_process
     def test_list_phone_numbers_opted_out(
         self, phone_number, aws_client, snapshot, account_id, region_name, cleanups
     ):
@@ -4896,6 +4898,7 @@ class TestSNSSMS:
         snapshot.match("list-phone-numbers-opted-out", response)
 
     @markers.aws.manual_setup_required
+    @markers.requires_in_process
     def test_opt_in_phone_number(
         self, phone_number, aws_client, snapshot, account_id, region_name, cleanups
     ):


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

In a k8s test run, realized we were missing those markers as they access SNS state in process. 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- add skip markers to the 3 failing tests

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
