### PR TITLE
fix(stepfunctions): prevent crash upon calling `interrupt_all()` on an uninitialized `callback_endpoint`

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
@@ -217,7 +217,8 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
             # finished, ensure all waiting # threads on this endpoint (or task) will stop. This is in an effort to
             # release resources sooner than when these would eventually synchronise with the updated environment
             # state of this task.
-            callback_endpoint.interrupt_all()
+            if callback_endpoint:
+                callback_endpoint.interrupt_all()
 
         # Handle Callback outcome types.
         if isinstance(outcome, CallbackOutcomeTimedOut):


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
