### PR TITLE
fix(SFN): prevent .waitForTaskToken cleanup in states that don't support it

### DIFF
--- a/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
+++ b/localstack-core/localstack/services/stepfunctions/asl/component/state/state_execution/state_task/service/state_task_service_callback.py
@@ -217,7 +217,8 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
             # finished, ensure all waiting # threads on this endpoint (or task) will stop. This is in an effort to
             # release resources sooner than when these would eventually synchronise with the updated environment
             # state of this task.
-            callback_endpoint.interrupt_all()
+            if callback_endpoint:
+                callback_endpoint.interrupt_all()
 
         # Handle Callback outcome types.
         if isinstance(outcome, CallbackOutcomeTimedOut):


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

https://github.com/localstack/localstack/pull/11987 made `callback_endpoint` optional to correctly process states that support `.sync` but not `.waitForTaskToken` service integration pattern, e.g. [AWS Glue service task](https://docs.aws.amazon.com/step-functions/latest/dg/connect-glue.html).

However, one codepath was left without null check, causing a runtime error.

Closes DRG-442.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Add null check on accessing an optional `callback_endpoint` field.

## Note

`StateTaskServiceGlue` inherits from `StateTaskServiceCallback`. Even though `.sync` is not a callback-style pattern, it supports passing the token along to enable continuing the workflow before the job is fully complete, as explained in its [docs](https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync). Therefore, effectively the support for a callback is needed, and it was introduced in #11197.

However, .sync and .waitForTaskToken code paths are quite coupled right now, we might consider breaking the inheritance here and rather use composition to support different integration patterns.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
