### PR TITLE
Fix: Update Dev Run to mount `plux.ini` instead of `entry_points.txt` for `localstack` dependencies

### DIFF
--- a/localstack-core/localstack/dev/run/configurators.py
+++ b/localstack-core/localstack/dev/run/configurators.py
@@ -192,7 +192,17 @@ class EntryPointMountConfigurator:
     For example, when starting the pro container, the entrypoints of localstack-pro on the host would be in
     ``~/workspace/localstack-pro/localstack-pro-core/localstack_ext.egg-info/entry_points.txt``
     which needs to be mounted into the distribution info of the installed dependency within the container:
-    ``/opt/code/localstack/.venv/.../site-packages/localstack_ext-2.1.0.dev0.dist-info/entry_points.txt``.
+   Mounts ``plux.ini`` files of localstack and localstack-pro into the venv in the container.
+   For other dependencies, we mount the ``entry_points.txt`` build artifacts.
+
+   For example, when starting the pro container, the entrypoints of localstack-pro on the host would be in
+   ``~/workspace/localstack-pro/localstack-pro-core/plux.ini`` which needs to be mounted into the distribution info of the installed dependency within the container:
+   ``/opt/code/localstack/.venv/.../site-packages/localstack_ext-4.13.0.dev0.dist-info/entry_points.txt``.
+
+   For a dependency using plugins, the entrypoints would be in the build artifact at 
+   ``~/workspace/<dependency>/<package-name>.egg-info/entry_points.txt``
+   which also needs to be mounted into the distribution info of the installed dependency within the container:
+   ``/opt/code/localstack/.venv/.../site-packages/<package-name>.dist-info/entry_points.txt``.
     """
 
     entry_point_glob = (


### PR DESCRIPTION
## Changes + Motivation
**_Co-Authored by_: @bentsku**
- When testing OpenSearch against `localstack` running in a container I noticed that it wasn't mounting the updated `plux.ini` changes when using `--mount-entrypoints` since it was still looking for the `entry_points.txt` file and mounting that instead.
- The code has now been updated to add the `plux.ini` file.
- Still will look for `entry_points.txt` for dependencies that aren't `localstack_core` and `localstack_ext` keeping the old behavior for these cases.