### PR TITLE
tests: Fix pre-install fixtures logic

### DIFF
--- a/tests/aws/services/es/test_es.py
+++ b/tests/aws/services/es/test_es.py
@@ -60,7 +60,6 @@ def elasticsearch():
         install_async()
 
     assert installed.wait(timeout=5 * 60), "gave up waiting for elasticsearch to install"
-    yield
 
 
 def try_cluster_health(cluster_url: str):

--- a/tests/aws/services/opensearch/test_opensearch.py
+++ b/tests/aws/services/opensearch/test_opensearch.py
@@ -90,7 +90,6 @@ def opensearch():
         install_async()
 
     assert installed.wait(timeout=5 * 60), "gave up waiting for opensearch to install"
-    yield
 
 
 def try_cluster_health(cluster_url: str):

--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -116,7 +116,6 @@ class TestTranscribe:
         LOG.info("Spent %s seconds downloading transcribe dependencies", int(time.time() - start))
 
         assert not installation_errored.is_set(), "installation of transcribe dependencies failed"
-        yield
 
     @staticmethod
     def _wait_transcription_job(


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Follow up from #13701, the fixture logic was wrong and I could not use early returns, because they were `yield` fixtures, aka generators. See https://docs.pytest.org/en/stable/how-to/fixtures.html#yield-fixtures-recommended

I've updated the fixture to not use `yield` anymore, allowing me to use early returns which makes more sense 👍 

I've now tested properly the change and it works with no errors 👍 thanks @nik-localstack for surfacing this so quickly!

We got the following error before:
```python
ValueError: opensearch did not yield a value
```

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- update the type of the fixtures by remove the `yield` as they do not have any clean up logic, so that can use early return

<!--
Summarise the changes proposed in the PR.
-->

## Tests
Start LocalStack in an external container and run a test from each service like `tests.aws.services.opensearch.test_opensearch.TestOpensearchProvider.test_list_versions` and see that it works 👍 
<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
