### PR TITLE
Upgrade lambda-runtime-init

### DIFF
--- a/localstack-core/localstack/services/lambda_/packages.py
+++ b/localstack-core/localstack/services/lambda_/packages.py
@@ -12,7 +12,7 @@ from localstack.utils.platform import get_arch
 """Customized LocalStack version of the AWS Lambda Runtime Interface Emulator (RIE).
 https://github.com/localstack/lambda-runtime-init/blob/localstack/README-LOCALSTACK.md
 """
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.39-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.40-pre"
 LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

<!--
Elaborate the background and intent for raising this PR.
-->

Upgrades the `lambda-runtime-init` to `v0.1.40-pre`.

## Changes

<!--
Summarise the changes proposed in the PR.
-->

The new version uses go v2.25.6, which fixes some CVEs.

Closes DRG-422.