### PR TITLE
SNS: fix existing topic attr check

### DIFF
--- a/localstack-core/localstack/services/sns/provider.py
+++ b/localstack-core/localstack/services/sns/provider.py
@@ -190,11 +190,25 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         topic_arn = sns_topic_arn(
             topic_name=name, region_name=context.region, account_id=context.account_id
         )
-        topic: Topic = store.topics.get(topic_arn)
-        attributes = attributes or {}
-        if topic:
-            existing_attrs = topic["attributes"]
+        attributes = dict(attributes) if attributes else {}
+        if attributes.get("FifoTopic") and attributes["FifoTopic"].lower() == "true":
+            pattern = SNS_TOPIC_NAME_PATTERN_FIFO
+        else:
+            # AWS does not seem to save explicit settings of fifo = false
+            attributes.pop("FifoTopic", None)
+            pattern = SNS_TOPIC_NAME_PATTERN
+
+        if not re.match(pattern, name):
+            raise InvalidParameterException("Invalid parameter: Topic Name")
+
+        if existing_topic := store.topics.get(topic_arn):
+            existing_attrs = existing_topic["attributes"]
+            # TODO: validate attribute names
             for k, v in attributes.items():
+                # special case for FifoTopic
+                if k == "FifoTopic" and v == "false" and "FifoTopic" not in existing_attrs:
+                    continue
+
                 if not existing_attrs.get(k) or not existing_attrs.get(k) == v:
                     raise InvalidParameterException(
                         "Invalid parameter: Attributes Reason: Topic already exists with different attributes"
@@ -205,21 +219,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     "Invalid parameter: Tags Reason: Topic already exists with different tags"
                 )
             return CreateTopicResponse(TopicArn=topic_arn)
-
-        if attributes.get("FifoTopic") and attributes["FifoTopic"].lower() == "true":
-            fifo_match = re.match(SNS_TOPIC_NAME_PATTERN_FIFO, name)
-            if not fifo_match:
-                # TODO: check this with a separate test
-                raise InvalidParameterException(
-                    "Fifo Topic names must end with .fifo and must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long."
-                )
-        else:
-            # AWS does not seem to save explicit settings of fifo = false
-
-            attributes.pop("FifoTopic", None)
-            name_match = re.match(SNS_TOPIC_NAME_PATTERN, name)
-            if not name_match:
-                raise InvalidParameterException("Invalid parameter: Topic Name")
 
         attributes["EffectiveDeliveryPolicy"] = _create_default_effective_delivery_policy()
 

--- a/tests/aws/services/sns/test_sns.snapshot.json
+++ b/tests/aws/services/sns/test_sns.snapshot.json
@@ -5296,7 +5296,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_name_constraints": {
-    "recorded-date": "07-10-2025, 09:49:48",
+    "recorded-date": "06-02-2026, 19:15:23",
     "recorded-content": {
       "valid-name-max-length": {
         "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
@@ -5317,6 +5317,28 @@
         }
       },
       "name-too-long": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "name-contains-fifo": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "fifo-name-not-contains-fifo": {
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: Topic Name",
@@ -7346,7 +7368,7 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_different_attrs": {
-    "recorded-date": "06-02-2026, 18:59:44",
+    "recorded-date": "06-02-2026, 19:09:15",
     "recorded-content": {
       "create-topic": {
         "TopicArn": "arn:<partition>:sns:<region>:111111111111:<resource:1>",
@@ -7423,6 +7445,39 @@
         }
       },
       "create-topic-diff-attrs": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: Topic already exists with different attributes",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-topic-new-attrs-fifo": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Topic Name",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-topic-new-attrs": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Attributes Reason: Topic already exists with different attributes",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-topic-new-and-same-attrs": {
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: Attributes Reason: Topic already exists with different attributes",

--- a/tests/aws/services/sns/test_sns.validation.json
+++ b/tests/aws/services/sns/test_sns.validation.json
@@ -1389,12 +1389,12 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_different_attrs": {
-    "last_validated_date": "2026-02-06T18:59:44+00:00",
+    "last_validated_date": "2026-02-06T19:09:15+00:00",
     "durations_in_seconds": {
-      "setup": 0.46,
-      "call": 0.94,
-      "teardown": 0.38,
-      "total": 1.78
+      "setup": 0.45,
+      "call": 1.36,
+      "teardown": 0.5,
+      "total": 2.31
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_in_multiple_regions": {
@@ -1407,12 +1407,12 @@
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_name_constraints": {
-    "last_validated_date": "2025-10-07T09:49:48+00:00",
+    "last_validated_date": "2026-02-06T19:15:23+00:00",
     "durations_in_seconds": {
-      "setup": 1.02,
-      "call": 2.27,
-      "teardown": 0.26,
-      "total": 3.55
+      "setup": 0.46,
+      "call": 1.71,
+      "teardown": 0.21,
+      "total": 2.38
     }
   },
   "tests/aws/services/sns/test_sns.py::TestSNSTopicCrudV2::test_create_topic_should_be_idempotent": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
As reported by #13713, we have a regression when creating a topic that already exists with attributes specified in the request. 

This PR fixes it, and adds more validation around attributes, and validation order. 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- add test around `CreateTopic` behavior when topic already exists with same or different attributes
- add test around topic naming with Fifo
- add more validation/remove TODO around FifoTopic naming issues

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related
fixes #13713

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
