### PR TITLE
pin `upgrade-pinned-dependencies` target to `pip<26`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ freeze:                   ## Run pip freeze -l in the virtual environment
 
 upgrade-pinned-dependencies: venv
 	# TODO: Avoid pip 26.0 for now due to https://github.com/jazzband/pip-tools/issues/2319
-	$(VENV_RUN); $(PIP_CMD) install --upgrade "pip!=26.0" pip-tools pre-commit
+	$(VENV_RUN); $(PIP_CMD) install --upgrade "pip<26.0" pip-tools pre-commit
 	$(VENV_RUN); pip-compile --strip-extras --upgrade -o requirements-basic.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra runtime -o requirements-runtime.txt pyproject.toml
 	$(VENV_RUN); pip-compile --strip-extras --upgrade --extra test -o requirements-test.txt pyproject.toml


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Follow-up from #13674, fixing the make target to pin `pip` to a version inferior to `26`

The issue was raised in #13718 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- upgrade make target 

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
