### PR TITLE
Test STS GetCallerIdentity

### DIFF
--- a/tests/aws/services/sts/test_sts.snapshot.json
+++ b/tests/aws/services/sts/test_sts.snapshot.json
@@ -278,5 +278,46 @@
         }
       }
     }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSCallerIdentity::test_get_caller_identity_with_iam_user_credentials": {
+    "recorded-date": "09-02-2026, 18:56:35",
+    "recorded-content": {
+      "create-user": {
+        "User": {
+          "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "caller-identity-user": {
+        "Account": "111111111111",
+        "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
+        "UserId": "<user-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSCallerIdentity::test_get_caller_identity_with_assumed_role_credentials": {
+    "recorded-date": "09-02-2026, 19:00:19",
+    "recorded-content": {
+      "caller-identity-assumed-role": {
+        "Account": "111111111111",
+        "Arn": "arn:<partition>:sts::111111111111:assumed-role/<role-name>/<session-name>",
+        "UserId": "<user-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sts/test_sts.validation.json
+++ b/tests/aws/services/sts/test_sts.validation.json
@@ -14,6 +14,24 @@
       "total": 1.88
     }
   },
+  "tests/aws/services/sts/test_sts.py::TestSTSCallerIdentity::test_get_caller_identity_with_assumed_role_credentials": {
+    "last_validated_date": "2026-02-09T19:00:19+00:00",
+    "durations_in_seconds": {
+      "setup": 0.38,
+      "call": 11.02,
+      "teardown": 0.35,
+      "total": 11.75
+    }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSCallerIdentity::test_get_caller_identity_with_iam_user_credentials": {
+    "last_validated_date": "2026-02-09T18:56:35+00:00",
+    "durations_in_seconds": {
+      "setup": 0.37,
+      "call": 11.65,
+      "teardown": 0.13,
+      "total": 12.15
+    }
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role": {
     "last_validated_date": "2024-06-05T17:23:49+00:00"
   },


### PR DESCRIPTION
## Motivation
As a part of the internalization project of STS. This PR reorganizes the tests related to the `GetCallerIdentity` feature and adds tests inspired by the test in the Moto library respository.

## Changes
- New test class `TestSTSCallerIdentity`
- Test moved `test_get_caller_identity_root` moved
- `test_get_caller_identity_user_access_key_cross_account` moved and renamed 
- `test_get_caller_identity_role_access_key_cross_account` moved and renamed
- New test `test_get_caller_identity_with_iam_user_credentials` inspired by moto
- New test `test_get_caller_identity_with_assumed_role_credentials` inspired by moto