### PR TITLE
Bump Moto-Ext to 5.1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ runtime = [
     "jsonpath-rw>=1.4.0",
     # version that has a built wheel
     "kclpy-ext>=3.0.0",
-    "moto-ext[all]>=5.1.20.post44",
+    "moto-ext[all]>=5.1.22",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,6 +41,7 @@ aws-sam-translator==1.107.0
     # via
     #   cfn-lint
     #   localstack-core
+    #   moto-ext
 aws-xray-sdk==2.15.0
     # via moto-ext
 awscli==1.44.30
@@ -258,7 +259,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.20.post44
+moto-ext==5.1.22
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -483,7 +484,6 @@ typing-extensions==4.15.0
     #   cfn-lint
     #   grpcio
     #   jsii
-    #   localstack-core
     #   localstack-twisted
     #   mypy
     #   openapi-core

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -29,6 +29,7 @@ aws-sam-translator==1.107.0
     # via
     #   cfn-lint
     #   localstack-core (pyproject.toml)
+    #   moto-ext
 aws-xray-sdk==2.15.0
     # via moto-ext
 awscli==1.44.30
@@ -191,7 +192,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.20.post44
+moto-ext==5.1.22
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy
@@ -341,7 +342,6 @@ typing-extensions==4.15.0
     #   aws-sam-translator
     #   cfn-lint
     #   grpcio
-    #   localstack-core
     #   localstack-twisted
     #   openapi-core
     #   pydantic

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -41,6 +41,7 @@ aws-sam-translator==1.107.0
     # via
     #   cfn-lint
     #   localstack-core
+    #   moto-ext
 aws-xray-sdk==2.15.0
     # via moto-ext
 awscli==1.44.30
@@ -237,7 +238,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.20.post44
+moto-ext==5.1.22
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -430,7 +431,6 @@ typing-extensions==4.15.0
     #   cfn-lint
     #   grpcio
     #   jsii
-    #   localstack-core
     #   localstack-twisted
     #   openapi-core
     #   pydantic

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -41,6 +41,7 @@ aws-sam-translator==1.107.0
     # via
     #   cfn-lint
     #   localstack-core
+    #   moto-ext
 aws-xray-sdk==2.15.0
     # via moto-ext
 awscli==1.44.30
@@ -262,7 +263,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.8.0
     # via openapi-core
-moto-ext==5.1.20.post44
+moto-ext==5.1.22
     # via localstack-core
 mpmath==1.3.0
     # via sympy
@@ -687,7 +688,6 @@ typing-extensions==4.15.0
     #   cfn-lint
     #   grpcio
     #   jsii
-    #   localstack-core
     #   localstack-twisted
     #   mypy
     #   openapi-core


### PR DESCRIPTION
This fixes the recent dependency resolution errors caused by `moto-ext`, `cfn-lint` and `pydantic`.

See [successful run](https://github.com/localstack/localstack/actions/runs/21862855232/job/63096283405) that triggered https://github.com/localstack/localstack/pull/13731.