### PR TITLE
CFn: Handle Fn::Sub returning JSON strings for IAM policies

### DIFF
--- a/localstack-core/localstack/services/iam/resource_providers/aws_iam_managedpolicy.py
+++ b/localstack-core/localstack/services/iam/resource_providers/aws_iam_managedpolicy.py
@@ -61,7 +61,13 @@ class IAMManagedPolicyProvider(ResourceProvider[IAMManagedPolicyProperties]):
             group_name = util.generate_default_name(request.stack_name, request.logical_resource_id)
             model["ManagedPolicyName"] = group_name
 
-        policy_doc = json.dumps(util.remove_none_values(model["PolicyDocument"]))
+        # PolicyDocument can be either a dict or a JSON string (e.g., from Fn::Sub)
+        policy_document = model["PolicyDocument"]
+        if isinstance(policy_document, str):
+            policy_doc = policy_document
+        else:
+            policy_doc = json.dumps(util.remove_none_values(policy_document))
+
         policy = iam_client.create_policy(
             PolicyName=model["ManagedPolicyName"], PolicyDocument=policy_doc
         )

--- a/localstack-core/localstack/services/iam/resource_providers/aws_iam_policy.py
+++ b/localstack-core/localstack/services/iam/resource_providers/aws_iam_policy.py
@@ -53,7 +53,13 @@ class IAMPolicyProvider(ResourceProvider[IAMPolicyProperties]):
         model = request.desired_state
         iam_client = request.aws_client_factory.iam
 
-        policy_doc = json.dumps(util.remove_none_values(model["PolicyDocument"]))
+        # PolicyDocument can be either a dict or a JSON string (e.g., from Fn::Sub)
+        policy_document = model["PolicyDocument"]
+        if isinstance(policy_document, str):
+            policy_doc = policy_document
+        else:
+            policy_doc = json.dumps(util.remove_none_values(policy_document))
+
         policy_name = model["PolicyName"]
 
         if not any([model.get("Roles"), model.get("Users"), model.get("Groups")]):
@@ -122,7 +128,14 @@ class IAMPolicyProvider(ResourceProvider[IAMPolicyProperties]):
         iam_client = request.aws_client_factory.iam
         model = request.desired_state
         # FIXME: this wasn't properly implemented before as well, still needs to be rewritten
-        policy_doc = json.dumps(util.remove_none_values(model["PolicyDocument"]))
+
+        # PolicyDocument can be either a dict or a JSON string (e.g., from Fn::Sub)
+        policy_document = model["PolicyDocument"]
+        if isinstance(policy_document, str):
+            policy_doc = policy_document
+        else:
+            policy_doc = json.dumps(util.remove_none_values(policy_document))
+
         policy_name = model["PolicyName"]
 
         for role in model.get("Roles", []):

--- a/tests/aws/services/cloudformation/resource_providers/iam/test_iam.snapshot.json
+++ b/tests/aws/services/cloudformation/resource_providers/iam/test_iam.snapshot.json
@@ -1,24 +1,24 @@
 {
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_iam_username_defaultname": {
-    "recorded-date": "31-05-2022, 11:29:45",
+    "recorded-date": "10-02-2026, 15:51:18",
     "recorded-content": {
       "get_iam_user": {
         "User": {
-          "Path": "/",
-          "UserName": "<user-name:1>",
-          "UserId": "<user-id:1>",
           "Arn": "arn:<partition>:iam::111111111111:user/<user-name:1>",
-          "CreateDate": "datetime"
+          "CreateDate": "datetime",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
         },
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managed_policy_with_empty_resource": {
-    "recorded-date": "11-07-2023, 18:10:41",
+    "recorded-date": "10-02-2026, 15:56:19",
     "recorded-content": {
       "outputs": {
         "PolicyArn": "arn:<partition>:iam::111111111111:policy/<policy-name:1>",
@@ -48,7 +48,7 @@
     }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_iam_user_access_key": {
-    "recorded-date": "11-07-2023, 08:23:54",
+    "recorded-date": "10-02-2026, 15:52:59",
     "recorded-content": {
       "key_outputs": {
         "AccessKeyId": "<key-id:1>",
@@ -69,7 +69,7 @@
     }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_update_inline_policy": {
-    "recorded-date": "05-04-2023, 11:55:22",
+    "recorded-date": "10-02-2026, 15:54:55",
     "recorded-content": {
       "user_inline_policy": {
         "PolicyDocument": {
@@ -156,7 +156,7 @@
     }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_server_certificate": {
-    "recorded-date": "13-03-2024, 20:20:07",
+    "recorded-date": "10-02-2026, 15:58:53",
     "recorded-content": {
       "outputs": {
         "Arn": "arn:<partition>:iam::111111111111:server-certificate/<server-certificate-name:1>",
@@ -190,6 +190,72 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
         }
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managedpolicy_with_fn_sub_json_string": {
+    "recorded-date": "10-02-2026, 16:02:06",
+    "recorded-content": {
+      "policy_document": {
+        "Statement": [
+          {
+            "Action": "s3:GetObject",
+            "Effect": "Allow",
+            "Resource": "arn:<partition>:s3:::bucket-my-cluster-<region>/*"
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managedpolicy_with_fn_sub_multiline_yaml": {
+    "recorded-date": "10-02-2026, 16:02:38",
+    "recorded-content": {
+      "policy_document_multiline": {
+        "Statement": [
+          {
+            "Action": "eks:DescribeCluster",
+            "Effect": "Allow",
+            "Resource": "arn:<partition>:eks:<region>:111111111111:cluster/my-cluster"
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managedpolicy_with_fn_sub_and_arrays": {
+    "recorded-date": "10-02-2026, 16:03:09",
+    "recorded-content": {
+      "policy_with_arrays": {
+        "Statement": [
+          {
+            "Action": [
+              "s3:GetObject",
+              "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+              "arn:<partition>:s3:::test-bucket/*",
+              "arn:<partition>:s3:::test-bucket-<region>/*"
+            ]
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_inline_policy_with_fn_sub_json_string": {
+    "recorded-date": "10-02-2026, 16:03:58",
+    "recorded-content": {
+      "inline_policy_document": {
+        "Statement": [
+          {
+            "Action": "s3:GetObject",
+            "Effect": "Allow",
+            "Resource": "arn:<partition>:s3:::my-bucket-<region>/*"
+          }
+        ],
+        "Version": "2012-10-17"
       }
     }
   }

--- a/tests/aws/services/cloudformation/resource_providers/iam/test_iam.validation.json
+++ b/tests/aws/services/cloudformation/resource_providers/iam/test_iam.validation.json
@@ -1,29 +1,119 @@
 {
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_cfn_handle_iam_role_resource_no_role_name": {
-    "last_validated_date": "2024-06-18T20:29:57+00:00"
+    "last_validated_date": "2026-02-10T15:59:36+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 42.14,
+      "teardown": 0.29,
+      "total": 42.43
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_delete_role_detaches_role_policy": {
+    "last_validated_date": "2026-02-10T15:48:42+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 81.93,
+      "teardown": 13.76,
+      "total": 95.69
+    }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_iam_user_access_key": {
-    "last_validated_date": "2023-07-11T06:23:54+00:00"
+    "last_validated_date": "2026-02-10T15:53:40+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 61.62,
+      "teardown": 41.76,
+      "total": 103.38
+    }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_iam_username_defaultname": {
-    "last_validated_date": "2022-05-31T09:29:45+00:00"
+    "last_validated_date": "2026-02-10T15:51:57+00:00",
+    "durations_in_seconds": {
+      "setup": 0.55,
+      "call": 46.37,
+      "teardown": 39.4,
+      "total": 86.32
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_inline_policy_with_fn_sub_json_string": {
+    "last_validated_date": "2026-02-10T16:04:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 43.9,
+      "teardown": 16.02,
+      "total": 59.92
+    }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managed_policy_with_empty_resource": {
-    "last_validated_date": "2025-08-01T09:44:24+00:00",
+    "last_validated_date": "2026-02-10T15:56:37+00:00",
     "durations_in_seconds": {
-      "setup": 1.31,
-      "call": 41.85,
-      "teardown": 16.77,
-      "total": 59.93
+      "setup": 0.0,
+      "call": 42.49,
+      "teardown": 17.74,
+      "total": 60.23
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managedpolicy_with_fn_sub_and_arrays": {
+    "last_validated_date": "2026-02-10T16:03:14+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 26.86,
+      "teardown": 4.79,
+      "total": 31.65
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managedpolicy_with_fn_sub_json_string": {
+    "last_validated_date": "2026-02-10T16:02:11+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 27.12,
+      "teardown": 4.76,
+      "total": 31.88
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_managedpolicy_with_fn_sub_multiline_yaml": {
+    "last_validated_date": "2026-02-10T16:02:43+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 26.71,
+      "teardown": 4.78,
+      "total": 31.49
+    }
+  },
+  "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_policy_attachments": {
+    "last_validated_date": "2026-02-10T15:50:31+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 66.78,
+      "teardown": 41.88,
+      "total": 108.66
     }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_server_certificate": {
-    "last_validated_date": "2024-03-13T20:20:07+00:00"
+    "last_validated_date": "2026-02-10T15:58:54+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 136.18,
+      "teardown": 0.72,
+      "total": 136.9
+    }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_update_inline_policy": {
-    "last_validated_date": "2023-04-05T09:55:22+00:00"
+    "last_validated_date": "2026-02-10T15:55:37+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 74.43,
+      "teardown": 41.78,
+      "total": 116.21
+    }
   },
   "tests/aws/services/cloudformation/resource_providers/iam/test_iam.py::test_updating_stack_with_iam_role": {
-    "last_validated_date": "2024-06-18T21:02:59+00:00"
+    "last_validated_date": "2026-02-10T16:01:39+00:00",
+    "durations_in_seconds": {
+      "setup": 0.0,
+      "call": 95.95,
+      "teardown": 27.18,
+      "total": 123.13
+    }
   }
 }


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

While trying to deploy [sample Cloud Formation templates for Karpenter](https://karpenter.sh/docs/reference/cloudformation/) against localstack, the CFn stack is failing with 

```
An error occurred (MalformedPolicyDocument) when calling the CreatePolicy operation: Syntax errors in policy.
```

The pattern `PolicyDocument: !Sub | {...JSON...}` returns a JSON string, but LocalStack's IAM resource providers only accepted dict objects.


## Changes

- Modified IAM `ManagedPolicy` and `Policy` resource providers to accept `PolicyDocument` as either a dict or JSON string


## Tests

- Added 4 new AWS-validated tests in `test_iam.py`:
  - ManagedPolicy with Fn::Sub (JSON template format)
  - ManagedPolicy with Fn::Sub multiline YAML (exact Karpenter pattern)
  - ManagedPolicy with Fn::Sub and arrays
  - Inline Policy with Fn::Sub

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
