### PR TITLE
transcribe: Skip test in k8s pipeline

### DIFF
--- a/tests/aws/services/transcribe/test_transcribe.py
+++ b/tests/aws/services/transcribe/test_transcribe.py
@@ -446,6 +446,7 @@ class TestTranscribe:
             transcribe_create_job(audio_file=file_path, params=settings)
         snapshot.match("err_speaker_labels_diarization", e.value)
 
+    @markers.requires_in_process  # test relies on the installation of ffmpeg
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(
         paths=[


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Test requires installation of ffmpeg which is currently skipped in k8s pipeline (when TEST_SKIP_LOCALSTACK_START is set)

## Changes

Add marker to skip the test

