### PR TITLE
RGTA/EC2: skip RGTA EC2 test in Pro

### DIFF
--- a/tests/aws/services/resourcegroupstaggingapi/test_rgsa.py
+++ b/tests/aws/services/resourcegroupstaggingapi/test_rgsa.py
@@ -1,7 +1,12 @@
+import pytest
+
 from localstack.testing.pytest import markers
+from localstack.utils.analytics.metadata import is_license_activated
 
 
 class TestRGSAIntegrations:
+    # TODO: figure out a better way, maybe via marker? e.g. @markers.localstack.ext
+    @pytest.mark.skipif(condition=not is_license_activated(), reason="integration test with pro")
     @markers.aws.validated
     @markers.snapshot.skip_snapshot_verify(paths=["$..PaginationToken"])
     def test_get_resources(self, aws_client, cleanups, snapshot):


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

As we don't have EC2 yet implemented in the new version of RGTA, we need to skip the tests. The way to skip is not ideal, but it works 👍 this was taken from `tests.aws.services.stepfunctions.v2.services.test_ecs_task_service.TestTaskServiceECS`

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- skip EC2 RGTA test

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
