### PR TITLE
optimize config analytics event before sending

### DIFF
--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -122,6 +122,10 @@ def _publish_config_as_analytics_event():
     env_vars = {key: os.getenv(key) for key in env_vars}
     present_env_vars = {env_var: 1 for env_var in PRESENCE_ENV_VAR if os.getenv(env_var)}
 
+    # filter out irrelevant None values, making the payload significantly smaller.
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+    present_env_vars = {k: v for k, v in present_env_vars.items() if v is not None}
+
     log.event("config", env_vars=env_vars, set_vars=present_env_vars)
 
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

<!--
Elaborate the background and intent for raising this PR.
-->

In the `config` analytics event, we are sending config variables as dictionaries with all listed variables, even if their values are None. In our data backend, we actually discard all of those None values anyway, so there's no point in sending them.

A quick analysis shows that we can reduce the overall size of this event category by an order of magnitude this way.

## Changes

* `config` analytics payload now only sends config vars whose value are not None

## Tests

<!--
Optional: How are the proposed changes tested?
-->

We tested this manually in a session with @valentinarmo and @ackdav 

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
