### PR TITLE
optimize analytics event batching window

### DIFF
--- a/localstack-core/localstack/utils/analytics/service_request_aggregator.py
+++ b/localstack-core/localstack/utils/analytics/service_request_aggregator.py
@@ -11,7 +11,7 @@ from localstack.utils.scheduler import Scheduler
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_FLUSH_INTERVAL_SECS = 15
+DEFAULT_FLUSH_INTERVAL_SECS = 60
 EVENT_NAME = "aws_request_agg"
 OPTIONAL_FIELDS = ["err_type"]
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation                                                                 
                                                                                
Increase analytics batching window from 15s to 60s for better event compression (~2.6× improvement) and reduced backend load.     
                                                                                
  ## Changes                                                                    
                                                                                
  - Increase `DEFAULT_FLUSH_INTERVAL_SECS` from 15 to 60 seconds in `ServiceRequestAggregator` 
