### PR TITLE
fix cli import in watcher

### DIFF
--- a/localstack-core/localstack/dev/run/watcher.py
+++ b/localstack-core/localstack/dev/run/watcher.py
@@ -5,15 +5,18 @@ import threading
 import time
 from pathlib import Path
 
+from rich.console import Console
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
-from localstack.cli import console
 from localstack.dev.run.paths import HOST_PATH_MAPPINGS, HostPaths
 from localstack.utils.container_utils.container_client import ContainerClient
 from localstack.utils.threads import TMP_THREADS, FuncThread
 
 DEBOUNCE_WINDOW = 0.5
+
+
+console = Console()
 
 
 class ChangeHandler(FileSystemEventHandler):


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13704, the CLI code was removed from this repo.
However, due to the timing of the merges, one import of the CLI introduced in https://github.com/localstack/localstack/pull/13718 was not updated in the PR.
This causes the new watcher to fail:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/nikosmichas/PycharmProjects/localstack/localstack-core/localstack/dev/run/__main__.py", line 19, in <module>
    from localstack.dev.run.watcher import collect_watch_directories, start_file_watcher
  File "/Users/nikosmichas/PycharmProjects/localstack/localstack-core/localstack/dev/run/watcher.py", line 11, in <module>
    from localstack.cli import console
ImportError: cannot import name 'console' from 'localstack.cli' (/.../localstack/cli/__init__.py)
```

This PR fixes this import.

## Changes
- Update the console import to fix the watcher script.