### PR TITLE
APIGW: update CFN template for Stage test

### DIFF
--- a/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.snapshot.json
@@ -793,7 +793,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::TestServerlessApigwLambda::test_serverless_like_deployment_stage_survives_update": {
-    "recorded-date": "11-02-2026, 20:08:58",
+    "recorded-date": "12-02-2026, 18:32:14",
     "recorded-content": {
       "stages-after-create": {
         "item": [

--- a/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_apigateway.validation.json
@@ -1,11 +1,11 @@
 {
   "tests/aws/services/cloudformation/resources/test_apigateway.py::TestServerlessApigwLambda::test_serverless_like_deployment_stage_survives_update": {
-    "last_validated_date": "2026-02-11T20:09:05+00:00",
+    "last_validated_date": "2026-02-12T18:32:21+00:00",
     "durations_in_seconds": {
-      "setup": 0.46,
-      "call": 28.84,
-      "teardown": 7.06,
-      "total": 36.36
+      "setup": 0.49,
+      "call": 32.79,
+      "teardown": 7.04,
+      "total": 40.32
     }
   },
   "tests/aws/services/cloudformation/resources/test_apigateway.py::TestServerlessApigwLambda::test_serverless_like_deployment_with_update": {

--- a/tests/aws/templates/apigateway-mock-cors-deployment.json
+++ b/tests/aws/templates/apigateway-mock-cors-deployment.json
@@ -52,7 +52,7 @@
                 "method.response.header.Access-Control-Allow-Origin": "'*'"
               },
               "ResponseTemplates": {
-                "application/json": ""
+                "application/json": "{\"statusCode\":200}"
               }
             }
           ]


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Follow up from #13736, it introduces a regression in Community against Pro pipeline because it triggered an edge case around the Avro serialization. 

The types declared in the API Gateway specs are wrong, a specific value is declared a `dict[str, str]` but can actually contain `None` values, validated with AWS. 

This change has no influence on the test itself, and the serialization issue is being tackled on its on PR as it needs quite some work, and I'd like to unblock the pipeline. See #13753

This issue can only be triggered with validation disabled on the SDK, or with somewhat bad CFN templates that are accepted by AWS. The PR linked is adding a test recreating the same conditions to trigger the error and will act as a regression test. 

See the failing run: https://github.com/localstack/localstack/runs/63392649703

This was not caught because Community against Pro are not run on community contributions.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- update CloudFormation template to not contain APIGW edge case

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
