### PR TITLE
Migrate IAM Group tests from moto

### DIFF
--- a/tests/aws/services/iam/test_iam_groups.py
+++ b/tests/aws/services/iam/test_iam_groups.py
@@ -33,7 +33,7 @@ class TestIAMGroupsCRUD:
         """Test creating a group and duplicate detection."""
         group_name = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         response = create_group(GroupName=group_name)
         snapshot.match("create-group", response)
@@ -48,7 +48,7 @@ class TestIAMGroupsCRUD:
         """Test getting group details and error handling for non-existent groups."""
         group_name = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         created = create_group(GroupName=group_name)["Group"]
         snapshot.match("created-group", created)
@@ -68,8 +68,7 @@ class TestIAMGroupsCRUD:
         other_group_name = f"group-{short_uid()}"
         path = "/some/location/"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(other_group_name, "<other-group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         create_group(GroupName=group_name)
         result = aws_client.iam.get_group(GroupName=group_name)
@@ -84,8 +83,7 @@ class TestIAMGroupsCRUD:
         group_name_1 = f"group-{short_uid()}"
         group_name_2 = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name_1, "<group-name-1>"))
-        snapshot.add_transformer(snapshot.transform.regex(group_name_2, "<group-name-2>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         create_group(GroupName=group_name_1)
         create_group(GroupName=group_name_2)
@@ -125,8 +123,7 @@ class TestIAMGroupsCRUD:
         group_name = f"group-{short_uid()}"
         new_group_name = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(new_group_name, "<new-group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         aws_client.iam.create_group(GroupName=group_name)
         initial_group = aws_client.iam.get_group(GroupName=group_name)["Group"]
@@ -150,8 +147,7 @@ class TestIAMGroupsCRUD:
         original_path = "/path/"
         new_path = "/new-path/"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(new_group_name, "<new-group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         aws_client.iam.create_group(GroupName=group_name, Path=original_path)
         aws_client.iam.update_group(
@@ -182,8 +178,7 @@ class TestIAMGroupsCRUD:
         group_name_1 = f"group-{short_uid()}"
         group_name_2 = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name_1, "<group-name-1>"))
-        snapshot.add_transformer(snapshot.transform.regex(group_name_2, "<group-name-2>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         create_group(GroupName=group_name_1)
         create_group(GroupName=group_name_2)
@@ -203,8 +198,8 @@ class TestIAMGroupsMembership:
         group_name = f"group-{short_uid()}"
         user_name = f"user-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(user_name, "<user-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.key_value("UserName"))
 
         create_group(GroupName=group_name)
         create_user(UserName=user_name)
@@ -218,7 +213,7 @@ class TestIAMGroupsMembership:
         """Test error when adding non-existent user to group."""
         group_name = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
 
         create_group(GroupName=group_name)
 
@@ -247,8 +242,8 @@ class TestIAMGroupsMembership:
         group_name = f"group-{short_uid()}"
         user_name = f"user-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(user_name, "<user-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.key_value("UserName"))
 
         create_group(GroupName=group_name)
         create_user(UserName=user_name)
@@ -280,8 +275,8 @@ class TestIAMGroupsMembership:
         group_name = f"group-{short_uid()}"
         user_name = f"user-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(user_name, "<user-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.key_value("UserName"))
 
         create_group(GroupName=group_name)
         create_user(UserName=user_name)
@@ -307,10 +302,8 @@ class TestIAMGroupsMembership:
         group_name_3 = f"group-{short_uid()}"
         user_name = f"user-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name_1, "<group-name-1>"))
-        snapshot.add_transformer(snapshot.transform.regex(group_name_2, "<group-name-2>"))
-        snapshot.add_transformer(snapshot.transform.regex(group_name_3, "<group-name-3>"))
-        snapshot.add_transformer(snapshot.transform.regex(user_name, "<user-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.key_value("UserName"))
 
         create_group(GroupName=group_name_1)
         create_group(GroupName=group_name_2)
@@ -333,8 +326,8 @@ class TestIAMGroupsPolicies:
         group_name = f"group-{short_uid()}"
         policy_name = f"policy-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(policy_name, "<policy-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.key_value("PolicyName"))
 
         create_group(GroupName=group_name)
         response = aws_client.iam.put_group_policy(
@@ -349,8 +342,8 @@ class TestIAMGroupsPolicies:
         group_name = f"group-{short_uid()}"
         policy_name = f"policy-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
-        snapshot.add_transformer(snapshot.transform.regex(policy_name, "<policy-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.key_value("PolicyName"))
 
         create_group(GroupName=group_name)
 
@@ -373,7 +366,7 @@ class TestIAMGroupsPolicies:
         group_name = f"group-{short_uid()}"
         policy_name = f"policy-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
         snapshot.add_transformer(snapshot.transform.regex(policy_name, "<policy-name>"))
 
         create_group(GroupName=group_name)
@@ -394,7 +387,7 @@ class TestIAMGroupsPolicies:
         group_name = f"group-{short_uid()}"
         policy_name = f"policy-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
         snapshot.add_transformer(snapshot.transform.regex(policy_name, "<policy-name>"))
 
         create_group(GroupName=group_name)
@@ -427,7 +420,7 @@ class TestIAMGroupsPolicies:
         group_name = f"group-{short_uid()}"
         policy_name = f"policy-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.regex(group_name, "<group-name>"))
+        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
         snapshot.add_transformer(snapshot.transform.regex(policy_name, "<policy-name>"))
 
         create_group(GroupName=group_name)

--- a/tests/aws/services/iam/test_iam_groups.snapshot.json
+++ b/tests/aws/services/iam/test_iam_groups.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_create_group": {
-    "recorded-date": "12-02-2026, 18:20:27",
+    "recorded-date": "12-02-2026, 21:51:36",
     "recorded-content": {
       "create-group": {
         "Group": {
@@ -29,7 +29,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_get_group": {
-    "recorded-date": "12-02-2026, 18:23:41",
+    "recorded-date": "12-02-2026, 21:51:37",
     "recorded-content": {
       "created-group": {
         "Arn": "arn:<partition>:iam::111111111111:group/<group-name:1>",
@@ -59,7 +59,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_get_group_with_path": {
-    "recorded-date": "12-02-2026, 18:24:27",
+    "recorded-date": "12-02-2026, 21:51:38",
     "recorded-content": {
       "get-group-default-path": {
         "Group": {
@@ -92,7 +92,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_list_groups": {
-    "recorded-date": "12-02-2026, 18:25:47",
+    "recorded-date": "12-02-2026, 21:51:40",
     "recorded-content": {
       "list-groups": [
         {
@@ -113,7 +113,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_delete_group": {
-    "recorded-date": "12-02-2026, 18:26:33",
+    "recorded-date": "12-02-2026, 21:51:41",
     "recorded-content": {
       "delete-response": {
         "ResponseMetadata": {
@@ -124,7 +124,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_delete_unknown_group": {
-    "recorded-date": "12-02-2026, 18:28:15",
+    "recorded-date": "12-02-2026, 21:51:41",
     "recorded-content": {
       "delete-unknown-group": {
         "Error": {
@@ -140,7 +140,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_name": {
-    "recorded-date": "12-02-2026, 18:33:38",
+    "recorded-date": "12-02-2026, 21:51:42",
     "recorded-content": {
       "original_group": {
         "Arn": "arn:<partition>:iam::111111111111:group/<group-name:1>",
@@ -170,7 +170,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_path": {
-    "recorded-date": "12-02-2026, 18:42:07",
+    "recorded-date": "12-02-2026, 21:51:43",
     "recorded-content": {
       "updated-group-with-new-path": {
         "Arn": "arn:<partition>:iam::111111111111:group/new-path/<group-name:1>",
@@ -214,7 +214,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_user_to_group": {
-    "recorded-date": "12-02-2026, 18:48:49",
+    "recorded-date": "12-02-2026, 21:55:23",
     "recorded-content": {
       "group-with-user": {
         "Group": {
@@ -242,7 +242,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_unknown_user_to_group": {
-    "recorded-date": "12-02-2026, 18:50:03",
+    "recorded-date": "12-02-2026, 21:55:24",
     "recorded-content": {
       "add-unknown-user": {
         "Error": {
@@ -258,7 +258,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_user_to_unknown_group": {
-    "recorded-date": "12-02-2026, 18:50:29",
+    "recorded-date": "12-02-2026, 21:55:25",
     "recorded-content": {
       "add-user-unknown-group": {
         "Error": {
@@ -274,7 +274,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_remove_user_from_group": {
-    "recorded-date": "12-02-2026, 18:51:52",
+    "recorded-date": "12-02-2026, 21:55:26",
     "recorded-content": {
       "group-before-remove": {
         "Group": {
@@ -317,7 +317,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_remove_user_from_unknown_group": {
-    "recorded-date": "12-02-2026, 18:52:55",
+    "recorded-date": "12-02-2026, 21:55:27",
     "recorded-content": {
       "remove-from-unknown-group": {
         "Error": {
@@ -333,7 +333,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_user_to_group_idempotent": {
-    "recorded-date": "12-02-2026, 18:57:52",
+    "recorded-date": "12-02-2026, 21:55:28",
     "recorded-content": {
       "groups-before-remove": [
         {
@@ -348,7 +348,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_list_groups_for_user": {
-    "recorded-date": "12-02-2026, 18:58:40",
+    "recorded-date": "12-02-2026, 21:55:30",
     "recorded-content": {
       "list-groups-for-user": [
         {
@@ -369,7 +369,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_put_group_policy": {
-    "recorded-date": "12-02-2026, 19:15:29",
+    "recorded-date": "12-02-2026, 21:59:32",
     "recorded-content": {
       "put-group-policy": {
         "ResponseMetadata": {
@@ -380,7 +380,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_get_group_policy": {
-    "recorded-date": "12-02-2026, 19:16:47",
+    "recorded-date": "12-02-2026, 21:59:33",
     "recorded-content": {
       "get-nonexistent-policy": {
         "Error": {
@@ -414,7 +414,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_list_group_policies": {
-    "recorded-date": "12-02-2026, 19:18:02",
+    "recorded-date": "12-02-2026, 21:59:34",
     "recorded-content": {
       "list-empty-policies": {
         "IsTruncated": false,
@@ -437,7 +437,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_attach_detach_group_policy": {
-    "recorded-date": "12-02-2026, 19:19:18",
+    "recorded-date": "12-02-2026, 21:59:36",
     "recorded-content": {
       "no-attached-policies": {
         "AttachedPolicies": [],
@@ -471,7 +471,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_detach_unattached_group_policy": {
-    "recorded-date": "12-02-2026, 19:28:03",
+    "recorded-date": "12-02-2026, 21:59:37",
     "recorded-content": {
       "detach-unattached-error": {
         "Error": {

--- a/tests/aws/services/iam/test_iam_groups.validation.json
+++ b/tests/aws/services/iam/test_iam_groups.validation.json
@@ -1,56 +1,56 @@
 {
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_create_group": {
-    "last_validated_date": "2026-02-12T18:20:28+00:00",
+    "last_validated_date": "2026-02-12T21:51:37+00:00",
     "durations_in_seconds": {
-      "setup": 0.37,
-      "call": 0.47,
-      "teardown": 0.41,
-      "total": 1.25
+      "setup": 0.45,
+      "call": 0.65,
+      "teardown": 0.52,
+      "total": 1.62
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_delete_group": {
-    "last_validated_date": "2026-02-12T18:26:33+00:00",
+    "last_validated_date": "2026-02-12T21:51:41+00:00",
     "durations_in_seconds": {
-      "setup": 0.37,
-      "call": 0.65,
+      "setup": 0.0,
+      "call": 0.5,
       "teardown": 0.0,
-      "total": 1.02
+      "total": 0.5
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_delete_unknown_group": {
-    "last_validated_date": "2026-02-12T18:28:15+00:00",
+    "last_validated_date": "2026-02-12T21:51:41+00:00",
     "durations_in_seconds": {
-      "setup": 0.37,
-      "call": 0.37,
+      "setup": 0.0,
+      "call": 0.13,
       "teardown": 0.0,
-      "total": 0.74
+      "total": 0.13
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_get_group": {
-    "last_validated_date": "2026-02-12T18:23:41+00:00",
+    "last_validated_date": "2026-02-12T21:51:38+00:00",
     "durations_in_seconds": {
-      "setup": 0.38,
-      "call": 0.56,
-      "teardown": 0.39,
-      "total": 1.33
+      "setup": 0.0,
+      "call": 0.4,
+      "teardown": 0.54,
+      "total": 0.94
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_get_group_with_path": {
-    "last_validated_date": "2026-02-12T18:24:28+00:00",
+    "last_validated_date": "2026-02-12T21:51:39+00:00",
     "durations_in_seconds": {
-      "setup": 0.37,
-      "call": 0.56,
-      "teardown": 0.82,
-      "total": 1.75
+      "setup": 0.0,
+      "call": 0.43,
+      "teardown": 1.05,
+      "total": 1.48
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_list_groups": {
-    "last_validated_date": "2026-02-12T18:25:47+00:00",
+    "last_validated_date": "2026-02-12T21:51:41+00:00",
     "durations_in_seconds": {
-      "setup": 0.37,
-      "call": 0.58,
-      "teardown": 0.84,
-      "total": 1.79
+      "setup": 0.0,
+      "call": 0.38,
+      "teardown": 1.02,
+      "total": 1.4
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_duplicate_name": {
@@ -63,12 +63,12 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_name": {
-    "last_validated_date": "2026-02-12T18:33:38+00:00",
+    "last_validated_date": "2026-02-12T21:51:42+00:00",
     "durations_in_seconds": {
-      "setup": 0.48,
-      "call": 0.84,
-      "teardown": 0.12,
-      "total": 1.44
+      "setup": 0.0,
+      "call": 0.67,
+      "teardown": 0.15,
+      "total": 0.82
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_not_found": {
@@ -81,120 +81,120 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_path": {
-    "last_validated_date": "2026-02-12T18:42:07+00:00",
+    "last_validated_date": "2026-02-12T21:51:43+00:00",
     "durations_in_seconds": {
-      "setup": 0.42,
-      "call": 0.75,
-      "teardown": 0.13,
-      "total": 1.3
+      "setup": 0.0,
+      "call": 0.38,
+      "teardown": 0.14,
+      "total": 0.52
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_unknown_user_to_group": {
-    "last_validated_date": "2026-02-12T18:50:04+00:00",
+    "last_validated_date": "2026-02-12T21:55:25+00:00",
     "durations_in_seconds": {
-      "setup": 0.49,
-      "call": 0.61,
-      "teardown": 0.54,
-      "total": 1.64
+      "setup": 0.0,
+      "call": 0.24,
+      "teardown": 0.52,
+      "total": 0.76
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_user_to_group": {
-    "last_validated_date": "2026-02-12T18:48:51+00:00",
+    "last_validated_date": "2026-02-12T21:55:24+00:00",
     "durations_in_seconds": {
-      "setup": 0.51,
-      "call": 1.04,
-      "teardown": 1.3,
-      "total": 2.85
+      "setup": 0.47,
+      "call": 0.93,
+      "teardown": 1.15,
+      "total": 2.55
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_user_to_group_idempotent": {
-    "last_validated_date": "2026-02-12T18:57:53+00:00",
+    "last_validated_date": "2026-02-12T21:55:29+00:00",
     "durations_in_seconds": {
-      "setup": 0.45,
-      "call": 1.28,
-      "teardown": 1.06,
-      "total": 2.79
+      "setup": 0.0,
+      "call": 0.81,
+      "teardown": 1.0,
+      "total": 1.81
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_add_user_to_unknown_group": {
-    "last_validated_date": "2026-02-12T18:50:30+00:00",
+    "last_validated_date": "2026-02-12T21:55:25+00:00",
     "durations_in_seconds": {
-      "setup": 0.55,
-      "call": 0.7,
-      "teardown": 0.67,
-      "total": 1.92
+      "setup": 0.0,
+      "call": 0.25,
+      "teardown": 0.51,
+      "total": 0.76
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_list_groups_for_user": {
-    "last_validated_date": "2026-02-12T18:58:42+00:00",
+    "last_validated_date": "2026-02-12T21:55:32+00:00",
     "durations_in_seconds": {
-      "setup": 0.46,
-      "call": 1.24,
-      "teardown": 2.33,
-      "total": 4.03
+      "setup": 0.0,
+      "call": 0.94,
+      "teardown": 2.15,
+      "total": 3.09
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_remove_user_from_group": {
-    "last_validated_date": "2026-02-12T18:51:53+00:00",
+    "last_validated_date": "2026-02-12T21:55:27+00:00",
     "durations_in_seconds": {
-      "setup": 0.41,
-      "call": 1.18,
-      "teardown": 1.15,
-      "total": 2.74
+      "setup": 0.0,
+      "call": 0.74,
+      "teardown": 1.01,
+      "total": 1.75
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsMembership::test_remove_user_from_unknown_group": {
-    "last_validated_date": "2026-02-12T18:52:55+00:00",
+    "last_validated_date": "2026-02-12T21:55:27+00:00",
     "durations_in_seconds": {
-      "setup": 0.45,
-      "call": 0.49,
+      "setup": 0.0,
+      "call": 0.12,
       "teardown": 0.0,
-      "total": 0.94
+      "total": 0.12
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_attach_detach_group_policy": {
-    "last_validated_date": "2026-02-12T19:19:18+00:00",
+    "last_validated_date": "2026-02-12T21:59:37+00:00",
     "durations_in_seconds": {
-      "setup": 0.47,
-      "call": 1.17,
-      "teardown": 0.71,
-      "total": 2.35
+      "setup": 0.0,
+      "call": 0.88,
+      "teardown": 0.84,
+      "total": 1.72
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_detach_unattached_group_policy": {
-    "last_validated_date": "2026-02-12T19:28:04+00:00",
+    "last_validated_date": "2026-02-12T21:59:38+00:00",
     "durations_in_seconds": {
-      "setup": 0.44,
-      "call": 0.88,
-      "teardown": 0.84,
-      "total": 2.16
+      "setup": 0.0,
+      "call": 0.59,
+      "teardown": 0.81,
+      "total": 1.4
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_get_group_policy": {
-    "last_validated_date": "2026-02-12T19:16:47+00:00",
+    "last_validated_date": "2026-02-12T21:59:34+00:00",
     "durations_in_seconds": {
-      "setup": 0.43,
-      "call": 0.77,
-      "teardown": 0.59,
-      "total": 1.79
+      "setup": 0.0,
+      "call": 0.55,
+      "teardown": 0.69,
+      "total": 1.24
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_list_group_policies": {
-    "last_validated_date": "2026-02-12T19:18:03+00:00",
+    "last_validated_date": "2026-02-12T21:59:35+00:00",
     "durations_in_seconds": {
-      "setup": 0.47,
-      "call": 0.84,
-      "teardown": 0.67,
-      "total": 1.98
+      "setup": 0.0,
+      "call": 0.52,
+      "teardown": 0.66,
+      "total": 1.18
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsPolicies::test_put_group_policy": {
-    "last_validated_date": "2026-02-12T19:15:29+00:00",
+    "last_validated_date": "2026-02-12T21:59:33+00:00",
     "durations_in_seconds": {
-      "setup": 0.5,
-      "call": 0.63,
-      "teardown": 0.64,
-      "total": 1.77
+      "setup": 0.48,
+      "call": 0.64,
+      "teardown": 0.66,
+      "total": 1.78
     }
   }
 }


### PR DESCRIPTION
## Motivation
For internalizing the IAM provider, we need to migrate the tests as well. This PR migrates the tests regarding IAM groups 


## IAM Groups Tests Migration Report

### Summary

| Metric | Count |
|--------|-------|
| Tests migrated | **22** |
| Tests excluded | **3** |
| Tests skipped (TODO) | **2** |
| Source files | 2 |
| Target file | 1 |
| Test classes | 3 |

### File Locations

| Type | Path |
|------|------|
| **Target** | `localstack/tests/aws/services/iam/test_iam_groups.py` |
| **Source 1** | `moto-repo/tests/test_iam/test_iam_groups.py` |
| **Source 2** | `moto-repo/tests/test_iam/test_iam.py` |

---

### Test Class: `TestIAMGroupsCRUD` (10 tests)

| # | Test | Moto Source | Line | Status |
|---|------|-------------|------|--------|
| 1 | `test_create_group` | `test_create_group` | 29 | Migrated |
| 2 | `test_get_group` | `test_get_group` | 40 | Migrated |
| 3 | `test_get_group_with_path` | `test_get_group_current` | 60 | Migrated |
| 4 | `test_list_groups` | `test_get_all_groups` | 82 | Migrated |
| 5 | `test_delete_group` | `test_delete_group` | 277 | Migrated |
| 6 | `test_delete_unknown_group` | `test_delete_unknown_group` | 288 | Migrated |
| 7 | `test_update_group_name` | `test_update_group_name` | 300 | Migrated |
| 8 | `test_update_group_path` | `test_update_group_path` | 332 | Migrated |
| 9 | `test_update_group_not_found` | `test_update_group_that_does_not_exist` | 346 | Skipped (TODO) |
| 10 | `test_update_group_duplicate_name` | `test_update_group_with_existing_name` | 357 | Skipped (TODO) |

---

### Test Class: `TestIAMGroupsMembership` (7 tests)

| # | Test | Moto Source | Line | Status |
|---|------|-------------|------|--------|
| 1 | `test_add_user_to_group` | `test_add_user_to_group` | 114 | Migrated |
| 2 | `test_add_unknown_user_to_group` | `test_add_unknown_user_to_group` | 93 | Migrated |
| 3 | `test_add_user_to_unknown_group` | `test_add_user_to_unknown_group` | 103 | Migrated |
| 4 | `test_remove_user_from_group` | `test_remove_user_from_group` | 169 | Migrated |
| 5 | `test_remove_user_from_unknown_group` | `test_remove_user_from_unknown_group` | 147 | Migrated |
| 6 | `test_add_user_to_group_idempotent` | `test_add_user_should_be_idempotent` | 178 | Migrated |
| 7 | `test_list_groups_for_user` | `test_get_groups_for_user` | 195 | Migrated |

---

### Test Class: `TestIAMGroupsPolicies` (5 tests)

| # | Test | Moto Source | File | Line | Status |
|---|------|-------------|------|------|--------|
| 1 | `test_put_group_policy` | `test_put_group_policy` | test_iam_groups.py | 209 | Migrated |
| 2 | `test_get_group_policy` | `test_get_group_policy` | test_iam_groups.py | 245 | Migrated |
| 3 | `test_list_group_policies` | `test_list_group_policies` | test_iam_groups.py | 264 | Migrated |
| 4 | `test_attach_detach_group_policy` | `test_attach_group_policies` | test_iam_groups.py | 218 | Migrated |
| 5 | `test_detach_unattached_group_policy` | `test_only_detach_group_policy` | test_iam.py | 2249 | Migrated |

---

### Excluded Tests

| Moto Test | Reason |
|-----------|--------|
| `test_update_group_name_that_has_a_path` | Path conservation covered by previous test and not working |
| `test_remove_nonattached_user_from_group` | AWS doesn't raise this issue |
| `test_group_policy_encoding` | AWS IAM rejects the policy with URL encoded values |

---

### Skipped Tests (TODO)

| Test | Reason |
|------|--------|
| `test_update_group_duplicate_name` | Exception not raised - needs investigation |
| `test_update_group_not_found` | Test fails against PRO - needs investigation |

---

### Tests NOT Migrated (Out of Scope)

| Moto Test | Reason |
|-----------|--------|
| `test_iam_cloudformation_create_managed_policy_attached_to_a_group` | CloudFormation - out of scope |
| `test_iam_cloudformation_create_group_policy` | CloudFormation - out of scope |
| `test_iam_cloudformation_update_group_policy` | CloudFormation - out of scope |
| `test_iam_cloudformation_delete_group_policy_having_generated_name` | CloudFormation - out of scope |

---

### API Coverage

| API Operation | Tests |
|---------------|-------|
| `create_group` | `test_create_group` |
| `get_group` | `test_get_group`, `test_get_group_with_path` |
| `list_groups` | `test_list_groups` |
| `delete_group` | `test_delete_group`, `test_delete_unknown_group` |
| `update_group` | `test_update_group_name`, `test_update_group_path`, `test_update_group_not_found`, `test_update_group_duplicate_name` |
| `add_user_to_group` | `test_add_user_to_group`, `test_add_unknown_user_to_group`, `test_add_user_to_unknown_group`, `test_add_user_to_group_idempotent` |
| `remove_user_from_group` | `test_remove_user_from_group`, `test_remove_user_from_unknown_group` |
| `list_groups_for_user` | `test_list_groups_for_user` |
| `put_group_policy` | `test_put_group_policy` |
| `get_group_policy` | `test_get_group_policy` |
| `list_group_policies` | `test_list_group_policies` |
| `attach_group_policy` | `test_attach_detach_group_policy` |
| `detach_group_policy` | `test_attach_detach_group_policy`, `test_detach_unattached_group_policy` |
| `list_attached_group_policies` | `test_attach_detach_group_policy`, `test_detach_unattached_group_policy` |