### PR TITLE
Migration of iam account aliases tests

### DIFF
--- a/tests/aws/services/iam/test_iam_account_aliases.py
+++ b/tests/aws/services/iam/test_iam_account_aliases.py
@@ -4,43 +4,21 @@ Tests for IAM Account Alias operations.
 Migrated from moto's test suite to LocalStack with snapshot testing for AWS parity validation.
 """
 
-import pytest
-
 from localstack.testing.pytest import markers
 from localstack.utils.common import short_uid
-
-
-@pytest.fixture
-def account_alias(aws_client):
-    """Fixture to create and cleanup account aliases."""
-    aliases_created = []
-
-    def _create_alias(alias: str):
-        aws_client.iam.create_account_alias(AccountAlias=alias)
-        aliases_created.append(alias)
-        return alias
-
-    yield _create_alias
-
-    # Cleanup: delete any aliases created during the test
-    for alias in aliases_created:
-        try:
-            aws_client.iam.delete_account_alias(AccountAlias=alias)
-        except Exception:
-            pass
 
 
 class TestIAMAccountAliases:
     """Tests for IAM Account Alias operations."""
 
     @markers.aws.validated
-    def test_account_alias_lifecycle(self, aws_client, snapshot, account_alias):
+    def test_account_alias_lifecycle(self, aws_client, snapshot):
         """Test create, list, and delete account alias operations."""
         alias = f"alias-{short_uid()}"
 
-        # List aliases - should be empty initially
+        # List aliases - alias should not be found
         list_response = aws_client.iam.list_account_aliases()
-        snapshot.match("list-empty", list_response)
+        assert alias not in list_response["AccountAliases"]
 
         # Create account alias
         create_response = aws_client.iam.create_account_alias(AccountAlias=alias)
@@ -48,7 +26,7 @@ class TestIAMAccountAliases:
 
         # List aliases - should contain the created alias
         list_response = aws_client.iam.list_account_aliases()
-        snapshot.match("list-after-create", list_response)
+        assert alias in list_response["AccountAliases"]
 
         # Delete account alias
         delete_response = aws_client.iam.delete_account_alias(AccountAlias=alias)
@@ -56,4 +34,4 @@ class TestIAMAccountAliases:
 
         # List aliases - should be empty again
         list_response = aws_client.iam.list_account_aliases()
-        snapshot.match("list-after-delete", list_response)
+        assert alias not in list_response["AccountAliases"]

--- a/tests/aws/services/iam/test_iam_account_aliases.snapshot.json
+++ b/tests/aws/services/iam/test_iam_account_aliases.snapshot.json
@@ -1,0 +1,19 @@
+{
+  "tests/aws/services/iam/test_iam_account_aliases.py::TestIAMAccountAliases::test_account_alias_lifecycle": {
+    "recorded-date": "13-02-2026, 18:04:41",
+    "recorded-content": {
+      "create-alias": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-alias": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/aws/services/iam/test_iam_account_aliases.validation.json
+++ b/tests/aws/services/iam/test_iam_account_aliases.validation.json
@@ -1,0 +1,11 @@
+{
+  "tests/aws/services/iam/test_iam_account_aliases.py::TestIAMAccountAliases::test_account_alias_lifecycle": {
+    "last_validated_date": "2026-02-13T18:04:41+00:00",
+    "durations_in_seconds": {
+      "setup": 0.39,
+      "call": 0.83,
+      "teardown": 0.0,
+      "total": 1.22
+    }
+  }
+}


### PR DESCRIPTION
## Motivation
This PR migrates the only test related to IAM account aliases from Moto into LocalStack

## Changes
- `test_account_aliases` migrated to `TestIAMAccountAliases::test_account_alias_lifecycle`
