### PR TITLE
dev: lazy import live reload dependencies

### DIFF
--- a/localstack-core/localstack/dev/run/__main__.py
+++ b/localstack-core/localstack/dev/run/__main__.py
@@ -16,7 +16,6 @@ from localstack.dev.run.configurators import (
     SourceVolumeMountConfigurator,
 )
 from localstack.dev.run.paths import HOST_PATH_MAPPINGS, HostPaths
-from localstack.dev.run.watcher import collect_watch_directories, start_file_watcher
 from localstack.runtime import hooks
 from localstack.utils.bootstrap import Container, ContainerConfigurators
 from localstack.utils.container_utils.container_client import (
@@ -356,6 +355,12 @@ def run(
     stop_live_reload_watcher = None
     try:
         if live_reload and mount_source:
+            # Some install targets don't include the `watchdog` dependency, and some developers
+            # don't install LocalStack using the `Makefile`, so they find that they don't have
+            # the `watchdog` dependency. We lazy import these functions so that we don't trigger
+            # an import error for these developers.
+            from localstack.dev.run.watcher import collect_watch_directories, start_file_watcher
+
             if watch_dirs := collect_watch_directories(host_paths, pro, local_packages):
                 stop_live_reload_watcher = start_file_watcher(watch_dirs, docker, container_id)
 


### PR DESCRIPTION
# Motivation

In #13718 we added live reload support to the `localstack.dev.run` script, however the additional dependency added (`watchdog`) was added to the `dev` extras section.

This section is not installed with our Pro setup make targets, or at least not everyone installs _this_ repo with the `dev` target, meaning that people who were using `localstack.dev.run` got an import error.

# Changes

Defer import of the module that itself imports `watchdog` so it is only required for people who actually want to use the `--live-reload` flag. This at least means a fewer number of people will be directly affected, and it is clearer what the issue is in this case.

In addition, a PR to the Pro repo will correct the packaging process so `localstack[dev]` is installed with our `test` dependencies, which is a very common install target for developers.
