### PR TITLE
Fix capture not implemented by installing localstack

### DIFF
--- a/.github/workflows/aws-tests.yml
+++ b/.github/workflows/aws-tests.yml
@@ -950,6 +950,7 @@ jobs:
           IMAGE_NAME: "localstack/localstack:latest"
         run: |
           source .venv/bin/activate
+          pip install --pre localstack
           localstack start -d
           localstack wait -t 120 || (localstack logs && false)
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

The cli is not part of this repo anymore so we need to install it where we use it. The main pipeline uses it in the `capture-not-implemented` step so we need to install it there.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

- add an install for the localstack cli in the capture not implemented step

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
