### PR TITLE
fix(sqs): reconcile SqsManagedSseEnabled when KmsMasterKeyId is set

### DIFF
--- a/localstack-core/localstack/services/sqs/models.py
+++ b/localstack-core/localstack/services/sqs/models.py
@@ -343,6 +343,7 @@ class SqsQueue:
         if attributes:
             self.validate_queue_attributes(attributes)
             self.attributes.update(attributes)
+            self._reconcile_sse_attributes()
 
         self.purge_in_progress = False
         self.purge_timestamp = None
@@ -365,6 +366,19 @@ class SqsQueue:
             QueueAttributeName.VisibilityTimeout: "30",
             QueueAttributeName.SqsManagedSseEnabled: "true",
         }
+
+    def _reconcile_sse_attributes(self):
+        """Ensure SqsManagedSseEnabled and KmsMasterKeyId are mutually exclusive.
+
+        On AWS, when KmsMasterKeyId is set, SqsManagedSseEnabled is automatically
+        set to false. When KmsMasterKeyId is removed, SqsManagedSseEnabled reverts
+        to true.
+        """
+        kms_key = self.attributes.get(QueueAttributeName.KmsMasterKeyId, "")
+        if kms_key:
+            self.attributes[QueueAttributeName.SqsManagedSseEnabled] = "false"
+        else:
+            self.attributes[QueueAttributeName.SqsManagedSseEnabled] = "true"
 
     def update_delay_seconds(self, value: int):
         """

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -1279,6 +1279,10 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             else:
                 queue.attributes[k] = v
 
+        # Reconcile SSE attributes (KmsMasterKeyId and SqsManagedSseEnabled are mutually exclusive)
+        if QueueAttributeName.KmsMasterKeyId in attributes:
+            queue._reconcile_sse_attributes()
+
         # Special cases
         if queue.attributes.get(QueueAttributeName.Policy) == "":
             del queue.attributes[QueueAttributeName.Policy]

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -4651,7 +4651,6 @@ class TestSqsProvider:
         snapshot.match("sse_sqs_attributes", response)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(paths=["$..Attributes.SqsManagedSseEnabled"])
     def test_set_queue_attributes_default_values(self, sqs_create_queue, snapshot, aws_sqs_client):
         queue_url = sqs_create_queue()
         response = aws_sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])


### PR DESCRIPTION
## Motivation

Fixes #13539

On AWS, `KmsMasterKeyId` and `SqsManagedSseEnabled` are mutually exclusive encryption modes:
- When `KmsMasterKeyId` is set → `SqsManagedSseEnabled` becomes `"false"`
- When `KmsMasterKeyId` is removed → `SqsManagedSseEnabled` reverts to `"true"`

LocalStack was not reconciling these, so `SqsManagedSseEnabled` remained `"true"` even when KMS encryption was configured. This caused `terraform-provider-aws` SQS encryption tests to fail and produced incorrect snapshot diffs.

## Changes

- **`models.py`**: Added `_reconcile_sse_attributes()` method to `SqsQueue` that ensures mutual exclusivity between KMS and SQS-managed SSE. Called during queue creation when attributes include `KmsMasterKeyId`.
- **`provider.py`**: Call `_reconcile_sse_attributes()` in `set_queue_attributes` when `KmsMasterKeyId` is modified, handling both setting and removing KMS keys.
- **`test_sqs.py`**: Removed `skip_snapshot_verify` for `SqsManagedSseEnabled` on `test_set_queue_attributes_default_values` since the fix makes the snapshot match correctly.

## Tests

- Verified queue creation with `KmsMasterKeyId` → `SqsManagedSseEnabled` is `"false"`
- Verified queue creation without KMS → `SqsManagedSseEnabled` is `"true"` (default)
- Verified `SetQueueAttributes` with `KmsMasterKeyId` flips `SqsManagedSseEnabled` to `"false"`
- Verified removing `KmsMasterKeyId` restores `SqsManagedSseEnabled` to `"true"`
- Existing snapshot `test_set_queue_attributes_default_values` should now pass without skip

## Related

- #13539
- `terraform-provider-aws` test: `TestAccSQSQueue_encryption`