### PR TITLE
Test and fix provisioned concurrency error handling

### DIFF
--- a/localstack-core/localstack/services/lambda_/invocation/assignment.py
+++ b/localstack-core/localstack/services/lambda_/invocation/assignment.py
@@ -148,7 +148,7 @@ class AssignmentService(OtherServiceEndpoint):
         # current_provisioned_environments_count = len(current_provisioned_environments)
         # diff = target_provisioned_environments - current_provisioned_environments_count
 
-        # TODO: handle case where no provisioned environment is available during scaling
+        # TODO: handle case where no provisioned environment is available during scaling. Does AWS serve on-demand?
         # Most simple scaling implementation for now:
         futures = []
         # 1) Re-create new target

--- a/tests/aws/services/lambda_/functions/lambda_invocation_type_failure.py
+++ b/tests/aws/services/lambda_/functions/lambda_invocation_type_failure.py
@@ -1,0 +1,14 @@
+import os
+import time
+
+init_type = os.environ["AWS_LAMBDA_INITIALIZATION_TYPE"]
+
+if init_type == "provisioned-concurrency":
+    raise Exception("Intentional failure upon provisioned concurrency initialization")
+
+
+def handler(event, context):
+    if event.get("wait"):
+        time.sleep(event["wait"])
+    print(f"{init_type=}")
+    return init_type

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -4617,5 +4617,44 @@
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaURL::test_lambda_url_non_existing_url": {
     "recorded-date": "24-11-2025, 23:11:02",
     "recorded-content": {}
+  },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency_init_failure": {
+    "recorded-date": "17-02-2026, 09:40:04",
+    "recorded-content": {
+      "put_provisioned": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "IN_PROGRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "get_provisioned_prewait": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "IN_PROGRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_provisioned_postwait": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "FAILED",
+        "StatusReason": "FUNCTION_ERROR_INIT_FAILURE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -230,6 +230,15 @@
       "total": 131.15
     }
   },
+  "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency_init_failure": {
+    "last_validated_date": "2026-02-17T09:40:06+00:00",
+    "durations_in_seconds": {
+      "setup": 12.05,
+      "call": 323.08,
+      "teardown": 2.23,
+      "total": 337.36
+    }
+  },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaConcurrency::test_provisioned_concurrency_on_alias": {
     "last_validated_date": "2025-11-24T23:21:03+00:00",
     "durations_in_seconds": {


### PR DESCRIPTION
## Motivation

Lambda provisioned concurrency always succeeds, even when facing initialization errors. Additionally, Lambda schedules invokes to failed provisioned concurrency environments.

## Changes

* Add an aws-validated test case for handling init failures of provisioned concurrency environments
* Only yield a provisioned concurrency lease if there is ready provisioned concurrency (currently not during updates)
* Check and raise init errors while scaling provisioned concurrency

## Related

Related to DRG-455 (which links to relevant support sample)
