### PR TITLE
Migrate IAM OIDC Tests to LocalStack

### DIFF
--- a/tests/aws/services/iam/test_iam_oidc.snapshot.json
+++ b/tests/aws/services/iam/test_iam_oidc.snapshot.json
@@ -106,12 +106,34 @@
     }
   },
   "tests/aws/services/iam/test_iam_oidc.py::TestOIDCProviderOperations::test_delete_open_id_connect_provider": {
-    "recorded-date": "18-02-2026, 19:01:12",
+    "recorded-date": "18-02-2026, 20:24:58",
     "recorded-content": {
       "delete-response": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "get-not-found-error": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "OpenIDConnect Provider not found for arn arn:<partition>:iam::111111111111:oidc-provider/<domain>",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "deletion-not-found-error": {
+        "Error": {
+          "Code": "NoSuchEntity",
+          "Message": "OpenId connect Provider arn:<partition>:iam::111111111111:oidc-provider/<domain> cannot be found.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/aws/services/iam/test_iam_oidc.validation.json
+++ b/tests/aws/services/iam/test_iam_oidc.validation.json
@@ -81,12 +81,12 @@
     }
   },
   "tests/aws/services/iam/test_iam_oidc.py::TestOIDCProviderOperations::test_delete_open_id_connect_provider": {
-    "last_validated_date": "2026-02-18T19:01:12+00:00",
+    "last_validated_date": "2026-02-18T20:24:58+00:00",
     "durations_in_seconds": {
       "setup": 0.37,
-      "call": 0.7,
+      "call": 0.68,
       "teardown": 0.0,
-      "total": 1.07
+      "total": 1.05
     }
   },
   "tests/aws/services/iam/test_iam_oidc.py::TestOIDCProviderOperations::test_get_open_id_connect_provider": {


### PR DESCRIPTION
## Motivation
This PR migrates the tests about IAM OIDC from moto to LocalStack

## Changes
### Moto Tests to LocalStack Tests

| # | Moto Test Function | LocalStack Test Class/Method | Status |
|---|-------------------|------------------------------|--------|
| 1 | `test_create_open_id_connect_provider` | `TestOIDCProviderCreate.test_create_open_id_connect_provider` | Migrated (partial - query string test removed) |
| 2 | `test_create_open_id_connect_provider_with_tags` | - | **Removed** (duplicate of tagging tests) |
| 3 | `test_create_open_id_connect_provider_invalid_url` | `TestOIDCProviderCreateErrors.test_create_open_id_connect_provider_invalid_url` | Migrated |
| 4 | `test_create_open_id_connect_provider_errors` | `TestOIDCProviderCreateErrors.test_create_open_id_connect_provider_duplicate_error` | Migrated (renamed) |
| 5 | `test_create_open_id_connect_provider_too_many_entries` | `TestOIDCProviderCreateErrors.test_create_open_id_connect_provider_too_many_thumbprints` | Migrated (renamed) |
| 6 | `test_create_open_id_connect_provider_quota_error` | `TestOIDCProviderCreateErrors.test_create_open_id_connect_provider_quota_error` | Migrated |
| 7 | `test_create_open_id_connect_provider_multiple_errors` | `TestOIDCProviderCreateErrors.test_create_open_id_connect_provider_validation_errors` | Migrated (renamed) |
| 8 | `test_delete_open_id_connect_provider` | `TestOIDCProviderOperations.test_delete_open_id_connect_provider` | Migrated |
| 9 | (part of #8 in moto) | - | **Removed** (idempotent delete - AWS raises error) |
| 10 | `test_get_open_id_connect_provider` | `TestOIDCProviderOperations.test_get_open_id_connect_provider` | Migrated |
| 11 | `test_get_open_id_connect_provider_errors` | `TestOIDCProviderOperations.test_get_open_id_connect_provider_not_found` | Migrated (renamed) |
| 12 | `test_update_open_id_connect_provider` | `TestOIDCProviderOperations.test_update_open_id_connect_provider_thumbprint` | Migrated |
| 13 | `test_list_open_id_connect_providers` | `TestOIDCProviderList.test_list_open_id_connect_providers` | Migrated |
| 14 | `test_tag_open_id_connect_provider` | `TestOIDCProviderTags.test_tag_open_id_connect_provider` | Migrated |
| 15 | `test_untag_open_id_connect_provider` | `TestOIDCProviderTags.test_untag_open_id_connect_provider` | Migrated |
| 16 | `test_list_open_id_connect_provider_tags` | `TestOIDCProviderTags.test_list_open_id_connect_provider_tags` | Migrated |
| 17 | `test_list_open_id_connect_provider_tags__paginated` | - | **Removed** (AWS tag limit is 50, not 150) |
| 18 | `test_list_open_id_connect_provider_tags__maxitems` | `TestOIDCProviderTags.test_list_open_id_connect_provider_tags_max_items` | Migrated |

---

### Tests Removed and Reasons

| Test | Reason for Removal |
|------|-------------------|
| `test_create_open_id_connect_provider` (query string part) | AWS raises an error when URL contains query string parameters |
| `test_create_open_id_connect_provider_with_tags` | Duplicate functionality - already covered by `TestOIDCProviderTags.test_tag_open_id_connect_provider` |
| `test_delete_open_id_connect_provider_idempotent` | AWS raises `NoSuchEntity` error when deleting a non-existent provider (not idempotent like moto) |
| `test_list_open_id_connect_provider_tags_paginated` | AWS limits OIDC provider tags to 50 (not 150 as moto allows) |