### PR TITLE
Fix failing snapshot test due to Lambda Python image changes

### DIFF
--- a/tests/aws/services/lambda_/functions/lambda_process_inspection.py
+++ b/tests/aws/services/lambda_/functions/lambda_process_inspection.py
@@ -3,6 +3,7 @@ import os
 
 def handler(event, context):
     return {"environment": dict(os.environ)}
+    # TODO: rework init env snapshotting test case because /proc/1 introspection does not work anymore at AWS
     # pid = event.get("pid")
     # with open(f"/proc/{pid}/environ", mode="rt") as f:
     #     environment = f.read()

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -796,6 +796,8 @@ class TestLambdaBehavior:
             "$..Payload.environment.AWS_LAMBDA_FUNCTION_TIMEOUT",
             "$..Payload.environment.EDGE_PORT",
             "$..Payload.environment.LOCALSTACK_HOSTNAME",
+            # Missing in Python Lambda images (3.12, 3.13, 3.14) since around 2026-02-18
+            "$..Payload.environment.LC_CTYPE",
         ]
     )
     @markers.requires_in_process
@@ -823,8 +825,9 @@ class TestLambdaBehavior:
         )
         create_result = create_lambda_function(
             func_name=func_name,
+            # TODO: rework init env snapshotting test case because /proc/1 introspection does not work anymore at AWS
             handler_file=TEST_LAMBDA_PROCESS_INSPECTION,
-            runtime=Runtime.python3_12,
+            runtime=Runtime.python3_14,
             client=aws_client.lambda_,
         )
         snapshot.match("create-result", create_result)

--- a/tests/aws/services/lambda_/test_lambda.snapshot.json
+++ b/tests/aws/services/lambda_/test_lambda.snapshot.json
@@ -3641,7 +3641,7 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_init_environment": {
-    "recorded-date": "25-11-2025, 22:02:31",
+    "recorded-date": "18-02-2026, 11:19:29",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -3670,7 +3670,7 @@
           "PackageType": "Zip",
           "RevisionId": "<uuid:1>",
           "Role": "arn:<partition>:iam::111111111111:role/<resource:1>",
-          "Runtime": "python3.12",
+          "Runtime": "python3.14",
           "RuntimeVersionConfig": {
             "RuntimeVersionArn": "arn:<partition>:lambda:<region>::runtime:<resource:2>"
           },
@@ -3697,7 +3697,7 @@
         "Payload": {
           "environment": {
             "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
-            "AWS_EXECUTION_ENV": "AWS_Lambda_python3.12",
+            "AWS_EXECUTION_ENV": "AWS_Lambda_python3.14",
             "AWS_DEFAULT_REGION": "<region>",
             "AWS_LAMBDA_LOG_STREAM_NAME": "<log-stream-name:1>",
             "AWS_REGION": "<region>",

--- a/tests/aws/services/lambda_/test_lambda.validation.json
+++ b/tests/aws/services/lambda_/test_lambda.validation.json
@@ -108,12 +108,12 @@
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_init_environment": {
-    "last_validated_date": "2025-11-25T22:02:31+00:00",
+    "last_validated_date": "2026-02-18T11:19:29+00:00",
     "durations_in_seconds": {
-      "setup": 11.17,
-      "call": 2.27,
-      "teardown": 6.54,
-      "total": 19.98
+      "setup": 12.32,
+      "call": 3.18,
+      "teardown": 1.93,
+      "total": 17.43
     }
   },
   "tests/aws/services/lambda_/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_no_timeout": {

--- a/tests/aws/services/lambda_/test_lambda_common.py
+++ b/tests/aws/services/lambda_/test_lambda_common.py
@@ -132,7 +132,7 @@ class TestLambdaRuntimesCommon:
             "$..environment.AWS_EXECUTION_ENV",  # Only rust runtime
             "$..environment.LD_LIBRARY_PATH",  # Only rust runtime (additional /var/lang/bin)
             "$..environment.PATH",  # Only rust runtime (additional /var/lang/bin)
-            "$..environment.LC_CTYPE",  # Only python3.11 (part of a broken image rollout, likely rolled back)
+            "$..environment.LC_CTYPE",  # Only missing in Python 3.12, 3.13, and 3.14
             "$..environment.RUBYLIB",  # Changed around 2025-06-17
             # Newer Nodejs images explicitly disable a temporary performance workaround for Nodejs 20 on certain hosts:
             # https://nodejs.org/api/cli.html#uv_use_io_uringvalue


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

CI is broken due to an image to a Lambda Python image removing the `LC_CTYPE` environment variable for Python runtimes.

## Changes

* Add snapshot skip
* Update Lambda to latest supported runtime