### PR TITLE
Stores: Separate cross region and cross account data by partition

### DIFF
--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -148,6 +148,33 @@ class TestStores:
             == id(backend2_eu._universal)
         )
 
+    def test_store_partition_namespacing(self, sample_stores):
+        account1 = "696969696969"
+        account2 = "424242424242"
+        aws_region = "eu-central-1"
+        gov_region = "us-gov-west-1"
+
+        #
+        # For Account 1
+        #
+        # Get backends for same account but different partitions
+        backend1_aws = sample_stores[account1][aws_region]
+        backend1_gov = sample_stores[account1][gov_region]
+        #
+        # For Account 2
+        #
+        # Get backends for same account but different partitions
+        backend2_aws = sample_stores[account2][aws_region]
+        backend2_gov = sample_stores[account2][gov_region]
+
+        backend1_aws.CROSS_REGION_ATTR.extend([1, 2, 3])
+        assert backend1_gov.CROSS_REGION_ATTR == []
+
+        backend1_aws.CROSS_ACCOUNT_ATTR.extend([4, 5, 6])
+        assert backend2_aws.CROSS_ACCOUNT_ATTR == [4, 5, 6]
+        assert backend1_gov.CROSS_ACCOUNT_ATTR == []
+        assert backend2_gov.CROSS_ACCOUNT_ATTR == []
+
     def test_valid_regions(self):
         stores = AccountRegionBundle("sns", SampleStore)
         account1 = "696969696969"


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
> [!WARNING]  
> Merging this PR will likely break persistence across most services utilizing cross account or cross region attributes.

AWS partitions are completely separate - this means all attributes in our stores shared across regions or even accounts still need to be separated by partition.
This PR handles this separation on the store level - by partitioning the account/region global data by AWS partition.

There might be some further issues, for example S3 does not separate the on-disk data by partition. While the stores would be separate, objects with identical names can overwrite each other. cc @bentsku 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Separate account / region shared store data by AWS partition

<!--
Summarise the changes proposed in the PR.
-->

## Tests
* Added unit test, but it would require testing of all pipelines.

<!--
Optional: How are the proposed changes tested?
-->

## Related


<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
