### PR TITLE
Logs: fix snapshot region from tests

### DIFF
--- a/tests/aws/services/logs/test_logs_destinations.py
+++ b/tests/aws/services/logs/test_logs_destinations.py
@@ -15,7 +15,7 @@ ACCESS_POLICY_DOC = json.dumps(
         "Statement": [
             {
                 "Effect": "Allow",
-                "Principal": {"AWS": "logs.us-east-1.amazonaws.com"},
+                "Principal": {"AWS": "logs.amazonaws.com"},
                 "Action": "logs:PutSubscriptionFilter",
                 "Resource": "destination_arn",
             }

--- a/tests/aws/services/logs/test_logs_destinations.snapshot.json
+++ b/tests/aws/services/logs/test_logs_destinations.snapshot.json
@@ -85,7 +85,7 @@
     }
   },
   "tests/aws/services/logs/test_logs_destinations.py::TestDestinations::test_put_destination_policy": {
-    "recorded-date": "05-02-2026, 15:23:25",
+    "recorded-date": "18-02-2026, 19:55:08",
     "recorded-content": {
       "put-destination-policy": {
         "ResponseMetadata": {
@@ -102,7 +102,7 @@
                 {
                   "Effect": "Allow",
                   "Principal": {
-                    "AWS": "logs.<region>.amazonaws.com"
+                    "AWS": "logs.amazonaws.com"
                   },
                   "Action": "logs:PutSubscriptionFilter",
                   "Resource": "arn:<partition>:kinesis:<region>:111111111111:stream/<stream-name>"

--- a/tests/aws/services/logs/test_logs_destinations.validation.json
+++ b/tests/aws/services/logs/test_logs_destinations.validation.json
@@ -36,12 +36,12 @@
     }
   },
   "tests/aws/services/logs/test_logs_destinations.py::TestDestinations::test_put_destination_policy": {
-    "last_validated_date": "2026-02-05T15:23:25+00:00",
+    "last_validated_date": "2026-02-18T19:55:08+00:00",
     "durations_in_seconds": {
-      "setup": 6.18,
-      "call": 10.12,
-      "teardown": 0.81,
-      "total": 17.11
+      "setup": 6.6,
+      "call": 10.21,
+      "teardown": 0.76,
+      "total": 17.57
     }
   },
   "tests/aws/services/logs/test_logs_destinations.py::TestDestinations::test_update_destination": {


### PR DESCRIPTION
## Motivation
The MultiRegion/MultiAccount pipeline was failing because a test policy had a hardcoded us-east-1 principal. When running with multi-region enabled and a different region configured, the snapshot's automatic transformation only substitutes the active region — leaving the hardcoded one unmatched and breaking the test.

## Changes
- Use a global service principal instead of a regional 

## Notes
