### PR TITLE
Deprecate ACTIVATE_PRO environment variable

### DIFF
--- a/localstack-core/localstack/deprecations.py
+++ b/localstack-core/localstack/deprecations.py
@@ -319,6 +319,11 @@ DEPRECATIONS = [
         "By default, LocalStack routes Step Functions traffic to its internal runtime. "
         "Use this variable only if you need to redirect traffic to a different local Step Functions runtime.",
     ),
+    EnvVarDeprecation(
+        "ACTIVATE_PRO",
+        "4.14.0",
+        "This option has no effect anymore. Please remove this environment variable.",
+    ),
 ]
 
 

--- a/localstack-core/localstack/runtime/analytics.py
+++ b/localstack-core/localstack/runtime/analytics.py
@@ -11,7 +11,6 @@ LOG = logging.getLogger(__name__)
 # Config options for which both usage and values are reported in analytics.
 # Important: This list must only contain options whose values do not contain PII or sensitive data.
 TRACKED_ENV_VAR = [
-    "ACTIVATE_PRO",
     "ALLOW_NONSTANDARD_REGIONS",
     "BEDROCK_PREWARM",
     "CFN_IGNORE_UNSUPPORTED_TYPE_CREATE",

--- a/tests/bootstrap/test_container_configurators.py
+++ b/tests/bootstrap/test_container_configurators.py
@@ -118,7 +118,6 @@ def test_default_localstack_container_configurator(
     monkeypatch.setenv("DEBUG", "1")
     monkeypatch.setenv("LOCALSTACK_AUTH_TOKEN", "")
     monkeypatch.setenv("LOCALSTACK_API_KEY", "")
-    monkeypatch.setenv("ACTIVATE_PRO", "0")
     monkeypatch.setattr(config, "DEBUG", True)
     monkeypatch.setattr(config, "VOLUME_DIR", str(volume))
     monkeypatch.setattr(config, "DOCKER_FLAGS", "-p 23456:4566 -e MY_TEST_VAR=foobar")


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

This PR deprecates the `ACTIVATE_PRO` environment variable, which is currently used in the Pro repository to determine whether to start the Community or Pro version of LocalStack.

## Changes

- Remove from tracked env variables
- Add to the list of deprecated env variables

## Related

FLC-383
