### PR TITLE
Lambda: add more context to alias failure reason

### DIFF
--- a/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
+++ b/localstack-core/localstack/services/lambda_/resource_providers/lambda_alias.py
@@ -116,7 +116,7 @@ class LambdaAliasProvider(ResourceProvider[LambdaAliasProperties]):
                 return ProgressEvent(
                     status=OperationStatus.FAILED,
                     resource_model=model,
-                    message="",
+                    message=result.get("StatusReason", "Unknown"),
                     error_code="VersionStateFailure",  # TODO: not parity tested
                 )
 


### PR DESCRIPTION
# Motivation

It was found that if a stack is deployed with SAM and a resource fails to deploy, _AND_ that resource does not return a failure message then SAM incorrectly exists with status code 0. I found this out while debugging this strange behaviour for lambda managed instances where the `AWS::Lambda::Alias` does not set a failure reason. The alias with managed instances tries to create the function and the sample I was investigating had a deliberate error causing the deployment to fail.

<img width="1723" height="338" alt="image" src="https://github.com/user-attachments/assets/5b9c94f7-c25e-469b-95e9-c23eb5131700" />


# Changes

- add a `message` to the returned event to ensure SAM treats the stack deploy as failed

# Result

<img width="1925" height="313" alt="image" src="https://github.com/user-attachments/assets/120ebd89-b8d5-4e4c-8a12-81565913c83a" />

