### PR TITLE
feature request: Upgrade go lang image to 1.26 #13808

### DIFF
--- a/tests/aws/services/lambda_/functions/common/endpointinjection_extra/provided/Makefile
+++ b/tests/aws/services/lambda_/functions/common/endpointinjection_extra/provided/Makefile
@@ -14,7 +14,7 @@ endif
 
 # https://hub.docker.com/_/golang/tags
 # Golang EOL overview: https://endoflife.date/go
-DOCKER_GOLANG_IMAGE ?= golang:1.19.6
+DOCKER_GOLANG_IMAGE ?= golang:1.26.0
 
 build:
 	mkdir -p build && \

--- a/tests/aws/services/lambda_/functions/common/uncaughtexception_extra/provided/Makefile
+++ b/tests/aws/services/lambda_/functions/common/uncaughtexception_extra/provided/Makefile
@@ -14,7 +14,7 @@ endif
 
 # https://hub.docker.com/_/golang/tags
 # Golang EOL overview: https://endoflife.date/go
-DOCKER_GOLANG_IMAGE ?= golang:1.19.6
+DOCKER_GOLANG_IMAGE ?= golang:1.26.0
 
 build:
 	mkdir -p build && \


### PR DESCRIPTION
## Motivation

The currently used Go lang image contains several CVEs and was marked as deprecated.

## Changes

Changed version of the Go lang image from 1.19.6 to 1.26.0

## Tests

## Related
