### PR TITLE
IAM: Migrate Groups

### DIFF
--- a/tests/aws/services/iam/test_iam_groups.py
+++ b/tests/aws/services/iam/test_iam_groups.py
@@ -162,7 +162,6 @@ class TestIAMGroupsCRUD:
     @markers.snapshot.skip_snapshot_verify(
         paths=["$..Error.message", "$..Error.Type", "$..ResponseMetadata.HTTPStatusCode"]
     )
-    @pytest.mark.skip("TODO - FAILS against pro. needs investigation")
     def test_update_group_not_found(self, aws_client, snapshot):
         """Test error handling when updating non-existent group."""
         snapshot.add_transformer(snapshot.transform.iam_api())
@@ -172,13 +171,12 @@ class TestIAMGroupsCRUD:
         snapshot.match("update-nonexistent-group", ex.value.response)
 
     @markers.aws.validated
-    @pytest.mark.skip("TODO - Exception not raised")
     def test_update_group_duplicate_name(self, create_group, aws_client, snapshot):
         """Test error handling when updating to existing group name."""
         group_name_1 = f"group-{short_uid()}"
         group_name_2 = f"group-{short_uid()}"
         snapshot.add_transformer(snapshot.transform.iam_api())
-        snapshot.add_transformer(snapshot.transform.key_value("GroupName"))
+        snapshot.add_transformer(snapshot.transform.regex(group_name_2, "<group-name-2>"))
 
         create_group(GroupName=group_name_1)
         create_group(GroupName=group_name_2)

--- a/tests/aws/services/iam/test_iam_groups.snapshot.json
+++ b/tests/aws/services/iam/test_iam_groups.snapshot.json
@@ -198,7 +198,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_duplicate_name": {
-    "recorded-date": "12-02-2026, 18:45:25",
+    "recorded-date": "20-02-2026, 15:46:30",
     "recorded-content": {
       "update-duplicate-name": {
         "Error": {

--- a/tests/aws/services/iam/test_iam_groups.validation.json
+++ b/tests/aws/services/iam/test_iam_groups.validation.json
@@ -54,12 +54,12 @@
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_duplicate_name": {
-    "last_validated_date": "2026-02-12T18:45:26+00:00",
+    "last_validated_date": "2026-02-20T15:46:31+00:00",
     "durations_in_seconds": {
-      "setup": 0.44,
-      "call": 0.79,
-      "teardown": 1.11,
-      "total": 2.34
+      "setup": 0.38,
+      "call": 0.61,
+      "teardown": 0.96,
+      "total": 1.95
     }
   },
   "tests/aws/services/iam/test_iam_groups.py::TestIAMGroupsCRUD::test_update_group_name": {


### PR DESCRIPTION
## Motivation
With this PR. We are migrating the Groups resource type from the Moto lib to LocalStack

## Changes
  1. localstack-core/localstack/services/iam/models.py                                                   
  - Added GroupEntity dataclass to wrap IAM Group with inline policies, managed policy tracking, and     
  membership                                                                                             
  - Added GROUPS storage (dict[str, GroupEntity]) to IamStore with CrossRegionAttribute                  
                                                                                                         
  2. localstack-core/localstack/services/iam/provider.py                                                 
  - Added _group_lock: threading.Lock for thread-safe group operations                                   
  - Added helper methods: _get_group_entity, _generate_group_id, _build_group_arn                        
  - Implemented 15 group operations:                                                                     
    - CRUD: create_group, get_group, list_groups, delete_group, update_group                             
    - Membership: add_user_to_group, remove_user_from_group, list_groups_for_user                        
    - Inline policies: put_group_policy, get_group_policy, list_group_policies, delete_group_policy      
    - Managed policies: attach_group_policy, detach_group_policy, list_attached_group_policies   
    
## Tests
 - All tests must pass.

## TODO
- [x] remove moto dependency in operations related to user management withing groups when #13806 is merged.