### PR TITLE
fix: correct typo in Dockerfile comment (degredation → degradation)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN chmod 777 . && \
 
 # install the entrypoint script
 ADD bin/docker-entrypoint.sh /usr/local/bin/
-# add the shipped hosts file to prevent performance degredation in windows container mode on windows
+# add the shipped hosts file to prevent performance degradation in windows container mode on windows
 # (where hosts file is not mounted) See https://github.com/localstack/localstack/issues/5178
 ADD bin/hosts /etc/hosts
 


### PR DESCRIPTION
## Description
This PR fixes a spelling typo in the Dockerfile comment.

## Changes
- Fixed spelling: `degredation` → `degradation` in the comment explaining the hosts file addition for Windows container mode performance

## Related Issue
Fixes #13803

## Type of Change
- [x] Documentation/typo fix
- [x] No functional changes