### PR TITLE
fix: add --no-install-recommends to builder stage apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
         # Install dependencies to add additional repos
         # g++ is a workaround to fix the JPype1 compile error on ARM Linux "gcc: fatal error: cannot execute ‘cc1plus’"
-        apt-get install -y gcc g++
+        apt-get install -y --no-install-recommends gcc g++
 
 # upgrade python build tools
 RUN --mount=type=cache,target=/root/.cache \


### PR DESCRIPTION
## Motivation
The `builder` stage `apt-get install` was missing the `--no-install-recommends` 
flag, unlike the `base` stage, which uses it consistently. This causes unnecessary 
recommended packages to be pulled in, increasing the build layer size.

Closes #13802

## Changes
Added `--no-install-recommends` to the `apt-get install` command in the 
`builder` stage of the Dockerfile.

## Tests
No functional change — this is a Dockerfile optimisation. No tests required.

## Related
#13802