### PR TITLE
fix: development environment setup link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ For pull requests (PRs), please stick to the following guidelines:
 * Fork localstack on your GitHub user account, make code changes there, and then create a PR against main localstack repository.
 * Add tests for any new features or bug fixes. Ideally, each PR increases the test coverage. Please read our [integration testing](testing/integration-tests/README.md) and [parity testing](testing/parity-testing/README.md) guides on how to write tests for AWS services.
 * Follow the existing code style. Run `make format` and `make lint` before checking in your code.
-  * Refer to [Development Environment Setup](development-environment-setup/README.md) if your local testing environment is not yet properly set up.
+  * Refer to [Development Environment Setup](/docs/development-environment-setup/README.md) if your local testing environment is not yet properly set up.
 * Document newly introduced methods and classes with pydoc, and add inline comments to code that is not self-documenting.
 * Separate unrelated changes into multiple PRs.
 * When creating a PR, classify the size of your change with setting a semver label:


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->
## Motivation
In the [Contributing Tab](https://github.com/localstack/localstack?tab=contributing-ov-file)
The second `Development Environment Setup` link does not work because it's relative.
The link at line 8 works.
## Changes

Fix the link to be absolute.

## Tests
NA

## Related
Resolves #13815


## Notes
I can't add the necessary labels myself:
- docs: skip
- notes: skip
- semver: patch
