### PR TITLE
fix: use standard npm install command to upgrade npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "$LATEST_VERSION_FILENAME.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   # upgrade npm to the latest version
-  && npm upgrade -g npm \
+  && npm install -g npm@latest \
   # smoke tests
   && node --version \
   && npm --version \


### PR DESCRIPTION
Reference Fixes #13804  explain that npm install -g npm@latest is the officially recommended way to update npm globally, while npm upgrade -g npm is unconventional
Suggested label: semver: patch