### PR TITLE
Set correct JLI path for JRE versions 12+

### DIFF
--- a/localstack-core/localstack/packages/java.py
+++ b/localstack-core/localstack/packages/java.py
@@ -46,6 +46,11 @@ class JavaInstallerMixin:
         """
         if java_home := self.get_java_home():
             if is_mac_os():
+                # location in JRE versions 12+, see https://bugs.openjdk.org/browse/JDK-8210931
+                jli_path = os.path.join(java_home, "lib", "libjli.dylib")
+                if os.path.isfile(jli_path):
+                    return jli_path
+                # location in JRE versions 11-
                 return os.path.join(java_home, "lib", "jli", "libjli.dylib")
             return os.path.join(java_home, "lib", "server", "libjvm.so")
         return None


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

JLI path has changed since version 12: https://bugs.openjdk.org/browse/JDK-8210931

This manifests in errors when running e.g. StepFunctions' JSONata tests in host mode:

```
localstack.services.stepfunctions.asl.component.eval_component : 
Exception=FileNotFoundError, Details=[2, 'JVM DLL not found: 
/$REDACTED$/localstack/localstack-core/.filesystem/var/lib/localstack/lib/java/21/Contents/Home/lib/jli/libjli.dylib']
at '(StringJSONata| {'literal_value': '$variable := 1', 'expression': '$variable := 1'}'
```

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

Mixin class doesn't have access to JRE version, therefore using a file check to determine location - checking the new location before defaulting to the old one.

<!--
Summarise the changes proposed in the PR.
-->

## Tests

Tested the fix by running StepFunctions tests on macOS in host mode.

<!--
Optional: How are the proposed changes tested?
-->