### PR TITLE
Add deprecation warning for ACTIVATE_PRO

### DIFF
--- a/localstack-core/localstack/deprecations.py
+++ b/localstack-core/localstack/deprecations.py
@@ -322,7 +322,8 @@ DEPRECATIONS = [
     EnvVarDeprecation(
         "ACTIVATE_PRO",
         "4.14.0",
-        "This option has no effect anymore. Please remove this environment variable.",
+        "Starting in March 2026, LocalStack will require an auth token. "
+        "Go to this page for more infos: https://localstack.cloud/2026-updates",
     ),
 ]
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

This PR adds deprecation warning for the `ACTIVATE_PRO` environment variable, which is currently used in the Pro repository to determine whether to start the Community or Pro version of LocalStack.

## Changes

- Added deprecation warning for `ACTIVATE_PRO`

Closes FLC-424