### PR TITLE
S3: fix tagging with cross region calls

### DIFF
--- a/localstack-core/localstack/services/s3/provider.py
+++ b/localstack-core/localstack/services/s3/provider.py
@@ -3370,9 +3370,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         **kwargs,
     ) -> GetObjectTaggingOutput:
         store, s3_bucket = self._get_cross_account_bucket(context, bucket)
-        print(f"{store._region_name=} {store._account_id=}")
-        print(f"{store.tags._tags=}")
-
         try:
             s3_object = s3_bucket.get_object(key=key, version_id=version_id)
         except NoSuchKey as e:
@@ -4608,11 +4605,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # in case we are overriding an object, delete the tags entry
         key_id = get_unique_key_id(bucket, object_key, version_id)
         store.tags.delete_all_tags(key_id)
-        print(f"{tagging=}")
         if tagging:
-            print(f"{store._region_name=} {store._account_id=}")
             store.tags.update_tags(key_id, tagging)
-            print(f"{store.tags._tags=}")
 
         response = PostResponse()
         # hacky way to set the etag in the headers as well: two locations for one value


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Following #13821, we switch S3 tags to be a local attribute instead of a cross account one, which is the right behavior, tagging should be scoped per region, as testing with RGTA showed. 

However, our S3 code was not fully ready for this change: when fetching the bucket and the store associated with it, we did not take the region into account, and would we return only a store that had the same account as the bucket. This wasn't an issue before because all attributes were cross-region. Now that tagging is local, this started to become an issue, as if you sent a request from `us-east-1`, you wouldn't be able to see the tags if the bucket came from `eu-west-1` for example. 

The fix is in the `_get_cross_account_bucket` change.

The rest is just refactoring following the RGTA architectural change, to use the new clean `Tags` API directly 👍 

All the `_bucket` tagging utility functions that were there already had the right behavior and were re-fetching the right store, but we should have the right store from the beginning available in the provider operation 👍 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- fix `_get_cross_account_bucket` to return the right regional store with the bucket
- refactor to remove one line functions 

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
