### PR TITLE
Fix: Clean Up from RGTA Migration

### DIFF
--- a/localstack-core/localstack/services/kms/utils.py
+++ b/localstack-core/localstack/services/kms/utils.py
@@ -102,13 +102,11 @@ def get_custom_key_material(request: CreateKeyRequest | None) -> bytes | None:
     if not request:
         return None
 
-    custom_key_material = None
     tags = request.get("Tags", [])
     for tag in tags:
         if tag["TagKey"] == TAG_KEY_CUSTOM_KEY_MATERIAL:
-            custom_key_material = base64.b64decode(tag["TagValue"])
-
-    return custom_key_material
+            return base64.b64decode(tag["TagValue"])
+    return None
 
 
 def get_custom_key_id(request: CreateKeyRequest | None) -> bytes | None:
@@ -121,13 +119,11 @@ def get_custom_key_id(request: CreateKeyRequest | None) -> bytes | None:
     if not request:
         return None
 
-    custom_key_id = None
     tags = request.get("Tags", [])
     for tag in tags:
         if tag["TagKey"] == TAG_KEY_CUSTOM_ID:
-            custom_key_id = tag["TagValue"]
-
-    return custom_key_id
+            return tag["TagValue"]
+    return None
 
 
 def execute_dry_run_capable[T](func: Callable[..., T], dry_run: bool, *args, **kwargs) -> T:

--- a/localstack-core/localstack/services/route53/provider.py
+++ b/localstack-core/localstack/services/route53/provider.py
@@ -27,20 +27,15 @@ from localstack.aws.api.route53 import (
 from localstack.aws.connect import connect_to
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.services.route53.models import Route53Store, route53_stores
+from localstack.services.route53.models import route53_stores
 from localstack.state import StateVisitor
 
 
 class Route53Provider(Route53Api, ServiceLifecycleHook):
     def accept_state_visitor(self, visitor: StateVisitor):
-        from localstack.services.route53.models import route53_stores
 
         visitor.visit(route53_backends)
         visitor.visit(route53_stores)
-
-    @staticmethod
-    def get_route53_store(account_id: str, region: str) -> Route53Store:
-        return route53_stores[account_id][region]
 
     # No tag deletion logic to handle in Community. Overwritten in Pro implementation.
     def remove_resource_tags(

--- a/localstack-core/localstack/utils/tagging.py
+++ b/localstack-core/localstack/utils/tagging.py
@@ -75,7 +75,7 @@ class Tags:
     _tags if the resource has been deleted.
 
     This distinction is important to maintain parity with the Resource Groups Tagging API (RGTA) which will tap into
-    supported service's `Tags` dataclass within it's store.
+    supported service's `Tags` dataclass within its store.
     """
 
     _tags: dict[ResourceARN, TagMap] = field(default_factory=dict)


### PR DESCRIPTION
## Motivation + Changes
- Fixes the comments addressed in this [PR](https://github.com/localstack/localstack/pull/13821). This includes moving the `get_route53_store` util to Pro since it's not used in Community, updating the docstring for the `Tags` collection and updating the KMS `get_custom_key_material` and `get_custom_key_id` to return early.