### PR TITLE
Migrate IAM access keys

### DIFF
--- a/tests/aws/services/iam/test_iam.py
+++ b/tests/aws/services/iam/test_iam.py
@@ -589,14 +589,6 @@ class TestIAMIntegrations:
                 aws_client.iam.delete_service_linked_role(RoleName=role_name)
 
     @markers.aws.validated
-    @markers.snapshot.skip_snapshot_verify(
-        paths=[
-            "$..Policy.IsAttachable",
-            "$..Policy.PermissionsBoundaryUsageCount",
-            "$..Policy.Tags",
-            "$..Policy.Description",
-        ]
-    )
     def test_user_attach_policy(self, snapshot, aws_client, create_user, create_policy):
         snapshot.add_transformer(snapshot.transform.iam_api())
 

--- a/tests/aws/services/iam/test_iam.snapshot.json
+++ b/tests/aws/services/iam/test_iam.snapshot.json
@@ -16,7 +16,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_user_attach_policy": {
-    "recorded-date": "06-03-2025, 12:25:06",
+    "recorded-date": "24-02-2026, 15:23:21",
     "recorded-content": {
       "create_policy_response": {
         "Policy": {
@@ -39,7 +39,7 @@
       "non_existent_malformed_policy_arn": {
         "Error": {
           "Code": "ValidationError",
-          "Message": "Invalid ARN:  Could not be parsed!",
+          "Message": "ARN longpolicynamebutnoarn is not valid.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -50,7 +50,7 @@
       "existing_policy_name_provided": {
         "Error": {
           "Code": "ValidationError",
-          "Message": "Invalid ARN:  Could not be parsed!",
+          "Message": "ARN <policy-name:1> is not valid.",
           "Type": "Sender"
         },
         "ResponseMetadata": {
@@ -647,7 +647,7 @@
     }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_delete_user_after_service_credential_created": {
-    "recorded-date": "06-03-2025, 16:58:41",
+    "recorded-date": "24-02-2026, 15:27:02",
     "recorded-content": {
       "create-user-response": {
         "User": {

--- a/tests/aws/services/iam/test_iam.validation.json
+++ b/tests/aws/services/iam/test_iam.validation.json
@@ -66,7 +66,13 @@
     "last_validated_date": "2025-04-21T20:07:38+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMIntegrations::test_user_attach_policy": {
-    "last_validated_date": "2025-03-06T12:25:05+00:00"
+    "last_validated_date": "2026-02-24T15:23:21+00:00",
+    "durations_in_seconds": {
+      "setup": 0.8,
+      "call": 2.12,
+      "teardown": 1.26,
+      "total": 4.18
+    }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMPolicyEncoding::test_put_group_policy_encoding": {
     "last_validated_date": "2025-03-06T12:25:10+00:00"
@@ -519,7 +525,13 @@
     "last_validated_date": "2025-03-06T16:58:36+00:00"
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_delete_user_after_service_credential_created": {
-    "last_validated_date": "2025-03-06T16:58:40+00:00"
+    "last_validated_date": "2026-02-24T15:27:02+00:00",
+    "durations_in_seconds": {
+      "setup": 0.7,
+      "call": 1.14,
+      "teardown": 0.88,
+      "total": 2.72
+    }
   },
   "tests/aws/services/iam/test_iam.py::TestIAMServiceSpecificCredentials::test_id_match_user_mismatch": {
     "last_validated_date": "2025-03-06T16:58:42+00:00"

--- a/tests/aws/services/iam/test_iam_users.py
+++ b/tests/aws/services/iam/test_iam_users.py
@@ -279,7 +279,6 @@ class TestUserLoginProfile:
         snapshot.match("delete-login-profile-unknown-user-error", exc.value.response)
 
 
-@pytest.mark.skip(reason="Access keys not yet migrated to native IAM implementation")
 class TestUserAccessKeys:
     """Tests for user access key operations."""
 
@@ -362,6 +361,7 @@ class TestUserAccessKeys:
         snapshot.match("create-third-access-key-error", exc.value.response)
 
     @markers.aws.validated
+    @pytest.mark.skip(reason="LastUsedDate tracking requires integration with auth layer")
     def test_access_key_last_used(
         self, create_user, aws_client, snapshot, aws_client_factory, region_name
     ):
@@ -407,6 +407,8 @@ class TestUserAccessKeys:
     def test_access_key_errors(self, create_user, aws_client, snapshot):
         """Test error cases for access key operations."""
         snapshot.add_transformer(snapshot.transform.key_value("AccessKeyId"))
+        caller_principal = aws_client.sts.get_caller_identity()["Arn"]
+        snapshot.add_transformer(snapshot.transform.regex(caller_principal, "<caller>"))
         user_name = f"user-{short_uid()}"
         create_user(UserName=user_name)
 
@@ -648,7 +650,6 @@ class TestUserTags:
         snapshot.match("list-tags-nonexistent-user-error", exc.value.response)
 
 
-@pytest.mark.skip(reason="Groups not yet migrated to native IAM implementation")
 class TestUserGroups:
     """Tests for user-group membership operations."""
 

--- a/tests/aws/services/iam/test_iam_users.snapshot.json
+++ b/tests/aws/services/iam/test_iam_users.snapshot.json
@@ -669,7 +669,7 @@
     }
   },
   "tests/aws/services/iam/test_iam_users.py::TestUserAccessKeys::test_access_key_errors": {
-    "recorded-date": "11-02-2026, 10:59:27",
+    "recorded-date": "24-02-2026, 14:43:43",
     "recorded-content": {
       "create-access-key-unknown-user-error": {
         "Error": {
@@ -696,7 +696,7 @@
       "get-last-used-nonexistent-key-error": {
         "Error": {
           "Code": "AccessDenied",
-          "Message": "User: arn:<partition>:sts::111111111111:assumed-role/AWSReservedSSO_AWSAdministratorAccess_2af0fc60fb59da5a/daniel.fangl@localstack.cloud is not authorized to perform iam:GetAccessKeyLastUsed on resource: access key AKIAIOSFODNN7EXAMPLE",
+          "Message": "User: <caller> is not authorized to perform iam:GetAccessKeyLastUsed on resource: access key AKIAIOSFODNN7EXAMPLE",
           "Type": "Sender"
         },
         "ResponseMetadata": {

--- a/tests/aws/services/iam/test_iam_users.validation.json
+++ b/tests/aws/services/iam/test_iam_users.validation.json
@@ -9,12 +9,12 @@
     }
   },
   "tests/aws/services/iam/test_iam_users.py::TestUserAccessKeys::test_access_key_errors": {
-    "last_validated_date": "2026-02-11T10:59:27+00:00",
+    "last_validated_date": "2026-02-24T14:43:43+00:00",
     "durations_in_seconds": {
-      "setup": 0.8,
-      "call": 1.41,
-      "teardown": 1.21,
-      "total": 3.42
+      "setup": 1.25,
+      "call": 1.51,
+      "teardown": 1.33,
+      "total": 4.09
     }
   },
   "tests/aws/services/iam/test_iam_users.py::TestUserAccessKeys::test_access_key_last_used": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
We need to migrate IAM user access keys from moto to LocalStack.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
### Operations Implemented

| Operation | Description |
|-----------|-------------|
| `create_access_key` | Create a new access key for a user (max 2 per user) |
| `delete_access_key` | Delete an access key |
| `list_access_keys` | List access keys for a user (with pagination) |
| `update_access_key` | Update access key status (Active/Inactive) |
| `get_access_key_last_used` | Get last used information for an access key |


### New Entity: `AccessKeyEntity`

```python
@dataclasses.dataclass
class AccessKeyEntity:
    """Wrapper for AccessKey with last used tracking."""
    access_key: AccessKey  # UserName, AccessKeyId, Status, SecretAccessKey, CreateDate
    last_used: AccessKeyLastUsed | None = None
```

### Extended `UserEntity`

Added `access_keys` field as a dict for efficient lookup by access key ID:

```python
access_keys: dict[str, AccessKeyEntity] = field(default_factory=dict)  # access_key_id -> entity
```

### Extended `IamStore`

Added `ACCESS_KEY_INDEX` for efficient cross-user access key lookups:

```python
ACCESS_KEY_INDEX: dict[str, str] = CrossRegionAttribute(default=dict)  # access_key_id -> user_name
```

## Design Decisions

### 1. Access Key ID Generation

- Uses `generate_iam_identifier()` from `utils.py` (same as role/user IDs)
- Prefix determined by `config.PARITY_AWS_ACCESS_KEY_ID`:
  - `AKIA` for AWS parity mode
  - `LKIA` for LocalStack default
- Total length: 20 characters

### 2. Secret Access Key Generation

- 40-character random string
- Character set: `string.ascii_letters + string.digits + "+/"`

### 3. User Name Derivation (Self-Referential Operations)

When `user_name` is not provided, the implementation:
1. First tries to look up the access key ID from the request's Authorization header in `ACCESS_KEY_INDEX`
2. If found, returns the associated user name directly
3. If not found, raises `ValidationError("Must specify userName when calling with non-User credentials")`

This approach allows users to manage their own access keys without specifying their username.

### 4. Access Key Limit

- Maximum 2 access keys per user (AWS behavior)
- Enforced via `LIMIT_ACCESS_KEYS_PER_USER = 2` constant
- Raises `LimitExceededException` when exceeded

### 5. Delete User Validation

Updated `delete_user` to check for access keys before deletion:
- Raises `DeleteConflictException("Cannot delete entity, must delete access keys first.")` if user has access keys

### 6. Error Handling

- `get_access_key_last_used` with nonexistent key returns `AccessDenied` (not `NoSuchEntity`) to prevent enumeration attacks - this matches AWS behavior

### Thread Safety

All access key operations use the existing `self._user_lock` for thread safety.


## Known Limitations

1. **LastUsedDate Tracking**: The `last_used` field is not populated because tracking when access keys are actually used requires integration with the authentication/STS layer. This is marked for future work.


<!--
Summarise the changes proposed in the PR.
-->

## Tests

| Test | Status | Notes |
|------|--------|-------|
| `test_access_key_lifecycle` | Passing | Create, list, delete |
| `test_access_key_update_status` | Passing | Status changes |
| `test_access_key_limit` | Passing | 2-key limit enforcement |
| `test_access_key_last_used` | Skipped | Requires auth layer integration |
| `test_access_key_errors` | Passing | Error handling |
| `test_access_key_deletion_without_username` | Passing | Self-deletion |

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
