### PR TITLE
IAM: Migrate server and signing certificates

### DIFF
--- a/tests/aws/services/iam/test_iam_server_certificates.py
+++ b/tests/aws/services/iam/test_iam_server_certificates.py
@@ -15,9 +15,6 @@ from localstack.utils.strings import short_uid
 
 LOG = logging.getLogger(__name__)
 
-# TODO remove after new IAM implementation of server certificates
-pytestmark = pytest.mark.skip
-
 
 def create_certificate_with_chain() -> tuple[str, str, str]:
     root_cert, root_key = root_certificate()

--- a/tests/aws/services/iam/test_iam_signing_certificates.py
+++ b/tests/aws/services/iam/test_iam_signing_certificates.py
@@ -14,9 +14,6 @@ from localstack.utils.strings import short_uid
 
 LOG = logging.getLogger(__name__)
 
-# TODO remove after new IAM implementation of signing certificates
-pytestmark = pytest.mark.skip
-
 
 def create_certificate() -> str:
     """


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
Next, we are migrating the IAM server and signing certificates.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
### Server Certificates (8 operations)

| Operation | Description |
|-----------|-------------|
| `UploadServerCertificate` | Creates a server certificate with path, chain, and tags. Parses X.509 to extract expiration date. |
| `GetServerCertificate` | Retrieves certificate by name (returns body, chain, tags - never private key) |
| `ListServerCertificates` | Lists certificates with path_prefix filter and pagination |
| `DeleteServerCertificate` | Deletes certificate by name |
| `UpdateServerCertificate` | Updates certificate path and/or name |
| `TagServerCertificate` | Adds tags to certificate (case-insensitive merge) |
| `UntagServerCertificate` | Removes tags from certificate |
| `ListServerCertificateTags` | Lists certificate tags with pagination |

### Signing Certificates (4 operations)

| Operation | Description |
|-----------|-------------|
| `UploadSigningCertificate` | Uploads X.509 certificate for user, validates format, enforces quota of 2 per user |
| `ListSigningCertificates` | Lists certificates for user with pagination |
| `UpdateSigningCertificate` | Updates certificate status (Active/Inactive) |
| `DeleteSigningCertificate` | Deletes certificate by ID |

### Entity Storage

**Server Certificates:**
- Created `ServerCertificateEntity` dataclass wrapping the API's `ServerCertificateMetadata`
- Private key is stored but never returned in API responses (AWS behavior)
- Stored in `IamStore.SERVER_CERTIFICATES` dict keyed by certificate name
- Uses `CrossRegionAttribute` since IAM is a global service

**Signing Certificates:**
- Uses the API's `SigningCertificate` TypedDict directly (no wrapper needed)
- Stored in `UserEntity.signing_certificates` dict keyed by certificate ID
- Maximum 2 certificates per user (enforced via `LimitExceededException`)


<!--
Summarise the changes proposed in the PR.
-->

## Tests
All 7 tests pass with snapshot parity:
- `test_server_certificate_lifecycle[None]` ✅
- `test_server_certificate_lifecycle[/]` ✅
- `test_server_certificate_lifecycle[/test-path/]` ✅
- `test_server_certificate_with_chain` ✅
- `test_server_certificate_errors` ✅
- `test_signing_certificate_lifecycle` ✅
- `test_signing_certificate_errors` ✅

<!--
Optional: How are the proposed changes tested?
-->

## Related
Closes UNC-292

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
