### PR TITLE
Migrate IAM policy simulator

### DIFF
--- a/localstack-core/localstack/services/iam/provider.py
+++ b/localstack-core/localstack/services/iam/provider.py
@@ -264,7 +264,7 @@ class IamProvider(IamApi, ServiceLifecycleHook):
 
     def __init__(self):
         apply_iam_patches()
-        self.policy_simulator = BasicIAMPolicySimulator()
+        self.policy_simulator = BasicIAMPolicySimulator(self)
         self._policy_lock = threading.Lock()
         self._role_lock = threading.Lock()
         self._group_lock = threading.Lock()


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
With the migration to LocalStack, the IAM basic policy simulation ceases to work.
This PR reintegrates it with the current model.

Currently the implementation uses some private methods from the provider - this will be refactored separately, once all of the bigger work is in!

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
* Modify to use the stores to look up policies / principals.

<!--
Summarise the changes proposed in the PR.
-->

## Tests
IAM policy simulator tests now pass

<!--
Optional: How are the proposed changes tested?
-->

## Related
Closes UNC-296

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
