### PR TITLE
CloudWatch: fix `test_put_metric_alarm` flakiness

### DIFF
--- a/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.snapshot.json
@@ -1875,576 +1875,6 @@
       }
     }
   },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm[query]": {
-    "recorded-date": "19-09-2025, 21:08:24",
-    "recorded-content": {
-      "describe-alarm": {
-        "CompositeAlarms": [],
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 10,
-            "StateReason": "Unchecked: Initial alarm creation",
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "INSUFFICIENT_DATA",
-            "Statistic": "Average",
-            "Threshold": 21.0,
-            "TreatMissingData": "ignore",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "alarm-triggered-sqs-msg": {
-        "AWSAccountId": "111111111111",
-        "AlarmActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-        "AlarmConfigurationUpdatedTimestamp": "date",
-        "AlarmDescription": "testing cloudwatch alarms",
-        "AlarmName": "<alarm-name:1>",
-        "InsufficientDataActions": [],
-        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-        "NewStateValue": "ALARM",
-        "OKActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "OldStateValue": "INSUFFICIENT_DATA",
-        "Region": "<region-name-full:1>",
-        "StateChangeTime": "date",
-        "Trigger": {
-          "ComparisonOperator": "GreaterThanThreshold",
-          "Dimensions": [
-            {
-              "name": "InstanceId",
-              "value": "abc"
-            }
-          ],
-          "EvaluateLowSampleCountPercentile": "",
-          "EvaluationPeriods": 1,
-          "MetricName": "my-metric1",
-          "Namespace": "<namespace:1>",
-          "Period": 10,
-          "Statistic": "AVERAGE",
-          "StatisticType": "Statistic",
-          "Threshold": 21.0,
-          "TreatMissingData": "ignore",
-          "Unit": "Seconds"
-        }
-      },
-      "describe-alarm-history": {
-        "AlarmHistoryItems": [
-          {
-            "AlarmName": "<alarm-name:1>",
-            "AlarmType": "MetricAlarm",
-            "HistoryData": {
-              "version": "1.0",
-              "oldState": {
-                "stateValue": "INSUFFICIENT_DATA",
-                "stateReason": "Unchecked: Initial alarm creation"
-              },
-              "newState": {
-                "stateValue": "ALARM",
-                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-                "stateReasonData": {
-                  "version": "1.0",
-                  "queryDate": "date",
-                  "startDate": "date",
-                  "unit": "Seconds",
-                  "statistic": "Average",
-                  "period": 10,
-                  "recentDatapoints": [
-                    21.5
-                  ],
-                  "threshold": 21.0,
-                  "evaluatedDatapoints": [
-                    {
-                      "timestamp": "date",
-                      "sampleCount": 2.0,
-                      "value": 21.5
-                    }
-                  ]
-                }
-              }
-            },
-            "HistoryItemType": "StateUpdate",
-            "HistorySummary": "Alarm updated from INSUFFICIENT_DATA to ALARM",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-alarms-for-metric": {
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 10,
-            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-            "StateReasonData": {
-              "version": "1.0",
-              "queryDate": "date",
-              "startDate": "date",
-              "unit": "Seconds",
-              "statistic": "Average",
-              "period": 10,
-              "recentDatapoints": [
-                21.5
-              ],
-              "threshold": 21.0,
-              "evaluatedDatapoints": [
-                {
-                  "timestamp": "date",
-                  "sampleCount": 2.0,
-                  "value": 21.5
-                }
-              ]
-            },
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "ALARM",
-            "Statistic": "Average",
-            "Threshold": 21.0,
-            "TreatMissingData": "ignore",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm[json]": {
-    "recorded-date": "19-09-2025, 21:08:43",
-    "recorded-content": {
-      "describe-alarm": {
-        "CompositeAlarms": [],
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 10,
-            "StateReason": "Unchecked: Initial alarm creation",
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "INSUFFICIENT_DATA",
-            "Statistic": "Average",
-            "Threshold": 21.0,
-            "TreatMissingData": "ignore",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "alarm-triggered-sqs-msg": {
-        "AWSAccountId": "111111111111",
-        "AlarmActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-        "AlarmConfigurationUpdatedTimestamp": "date",
-        "AlarmDescription": "testing cloudwatch alarms",
-        "AlarmName": "<alarm-name:1>",
-        "InsufficientDataActions": [],
-        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-        "NewStateValue": "ALARM",
-        "OKActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "OldStateValue": "INSUFFICIENT_DATA",
-        "Region": "<region-name-full:1>",
-        "StateChangeTime": "date",
-        "Trigger": {
-          "ComparisonOperator": "GreaterThanThreshold",
-          "Dimensions": [
-            {
-              "name": "InstanceId",
-              "value": "abc"
-            }
-          ],
-          "EvaluateLowSampleCountPercentile": "",
-          "EvaluationPeriods": 1,
-          "MetricName": "my-metric1",
-          "Namespace": "<namespace:1>",
-          "Period": 10,
-          "Statistic": "AVERAGE",
-          "StatisticType": "Statistic",
-          "Threshold": 21.0,
-          "TreatMissingData": "ignore",
-          "Unit": "Seconds"
-        }
-      },
-      "describe-alarm-history": {
-        "AlarmHistoryItems": [
-          {
-            "AlarmName": "<alarm-name:1>",
-            "AlarmType": "MetricAlarm",
-            "HistoryData": {
-              "version": "1.0",
-              "oldState": {
-                "stateValue": "INSUFFICIENT_DATA",
-                "stateReason": "Unchecked: Initial alarm creation"
-              },
-              "newState": {
-                "stateValue": "ALARM",
-                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-                "stateReasonData": {
-                  "version": "1.0",
-                  "queryDate": "date",
-                  "startDate": "date",
-                  "unit": "Seconds",
-                  "statistic": "Average",
-                  "period": 10,
-                  "recentDatapoints": [
-                    21.5
-                  ],
-                  "threshold": 21.0,
-                  "evaluatedDatapoints": [
-                    {
-                      "timestamp": "date",
-                      "sampleCount": 2.0,
-                      "value": 21.5
-                    }
-                  ]
-                }
-              }
-            },
-            "HistoryItemType": "StateUpdate",
-            "HistorySummary": "Alarm updated from INSUFFICIENT_DATA to ALARM",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-alarms-for-metric": {
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 10,
-            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-            "StateReasonData": {
-              "version": "1.0",
-              "queryDate": "date",
-              "startDate": "date",
-              "unit": "Seconds",
-              "statistic": "Average",
-              "period": 10,
-              "recentDatapoints": [
-                21.5
-              ],
-              "threshold": 21.0,
-              "evaluatedDatapoints": [
-                {
-                  "timestamp": "date",
-                  "sampleCount": 2.0,
-                  "value": 21.5
-                }
-              ]
-            },
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "ALARM",
-            "Statistic": "Average",
-            "Threshold": 21.0,
-            "TreatMissingData": "ignore",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm[smithy-rpc-v2-cbor]": {
-    "recorded-date": "19-09-2025, 21:09:02",
-    "recorded-content": {
-      "describe-alarm": {
-        "CompositeAlarms": [],
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 10,
-            "StateReason": "Unchecked: Initial alarm creation",
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "INSUFFICIENT_DATA",
-            "Statistic": "Average",
-            "Threshold": 21.0,
-            "TreatMissingData": "ignore",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "alarm-triggered-sqs-msg": {
-        "AWSAccountId": "111111111111",
-        "AlarmActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-        "AlarmConfigurationUpdatedTimestamp": "date",
-        "AlarmDescription": "testing cloudwatch alarms",
-        "AlarmName": "<alarm-name:1>",
-        "InsufficientDataActions": [],
-        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-        "NewStateValue": "ALARM",
-        "OKActions": [
-          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-        ],
-        "OldStateValue": "INSUFFICIENT_DATA",
-        "Region": "<region-name-full:1>",
-        "StateChangeTime": "date",
-        "Trigger": {
-          "ComparisonOperator": "GreaterThanThreshold",
-          "Dimensions": [
-            {
-              "name": "InstanceId",
-              "value": "abc"
-            }
-          ],
-          "EvaluateLowSampleCountPercentile": "",
-          "EvaluationPeriods": 1,
-          "MetricName": "my-metric1",
-          "Namespace": "<namespace:1>",
-          "Period": 10,
-          "Statistic": "AVERAGE",
-          "StatisticType": "Statistic",
-          "Threshold": 21.0,
-          "TreatMissingData": "ignore",
-          "Unit": "Seconds"
-        }
-      },
-      "describe-alarm-history": {
-        "AlarmHistoryItems": [
-          {
-            "AlarmName": "<alarm-name:1>",
-            "AlarmType": "MetricAlarm",
-            "HistoryData": {
-              "version": "1.0",
-              "oldState": {
-                "stateValue": "INSUFFICIENT_DATA",
-                "stateReason": "Unchecked: Initial alarm creation"
-              },
-              "newState": {
-                "stateValue": "ALARM",
-                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-                "stateReasonData": {
-                  "version": "1.0",
-                  "queryDate": "date",
-                  "startDate": "date",
-                  "unit": "Seconds",
-                  "statistic": "Average",
-                  "period": 10,
-                  "recentDatapoints": [
-                    21.5
-                  ],
-                  "threshold": 21.0,
-                  "evaluatedDatapoints": [
-                    {
-                      "timestamp": "date",
-                      "sampleCount": 2.0,
-                      "value": 21.5
-                    }
-                  ]
-                }
-              }
-            },
-            "HistoryItemType": "StateUpdate",
-            "HistorySummary": "Alarm updated from INSUFFICIENT_DATA to ALARM",
-            "Timestamp": "timestamp"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "describe-alarms-for-metric": {
-        "MetricAlarms": [
-          {
-            "ActionsEnabled": true,
-            "AlarmActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
-            "AlarmConfigurationUpdatedTimestamp": "timestamp",
-            "AlarmDescription": "testing cloudwatch alarms",
-            "AlarmName": "<alarm-name:1>",
-            "ComparisonOperator": "GreaterThanThreshold",
-            "Dimensions": [
-              {
-                "Name": "InstanceId",
-                "Value": "abc"
-              }
-            ],
-            "EvaluationPeriods": 1,
-            "InsufficientDataActions": [],
-            "MetricName": "my-metric1",
-            "Namespace": "<namespace:1>",
-            "OKActions": [
-              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
-            ],
-            "Period": 10,
-            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
-            "StateReasonData": {
-              "version": "1.0",
-              "queryDate": "date",
-              "startDate": "date",
-              "unit": "Seconds",
-              "statistic": "Average",
-              "period": 10,
-              "recentDatapoints": [
-                21.5
-              ],
-              "threshold": 21.0,
-              "evaluatedDatapoints": [
-                {
-                  "timestamp": "date",
-                  "sampleCount": 2.0,
-                  "value": 21.5
-                }
-              ]
-            },
-            "StateTransitionedTimestamp": "timestamp",
-            "StateUpdatedTimestamp": "timestamp",
-            "StateValue": "ALARM",
-            "Statistic": "Average",
-            "Threshold": 21.0,
-            "TreatMissingData": "ignore",
-            "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_breaching_alarm_actions[query]": {
     "recorded-date": "19-09-2025, 21:11:41",
     "recorded-content": {
@@ -3501,210 +2931,6 @@
             "Threshold": 2.0,
             "TreatMissingData": "ignore",
             "Unit": "Seconds"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created[query]": {
-    "recorded-date": "19-09-2025, 21:27:01",
-    "recorded-content": {
-      "get_metric_data": {
-        "Messages": [],
-        "MetricDataResults": [
-          {
-            "Id": "sent",
-            "Label": "NumberOfMessagesSent",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          },
-          {
-            "Id": "sent_size",
-            "Label": "SentMessageSize",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              5.0
-            ]
-          },
-          {
-            "Id": "empty_receives",
-            "Label": "NumberOfEmptyReceives",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_metric_data_2": {
-        "Messages": [],
-        "MetricDataResults": [
-          {
-            "Id": "num_msg_received",
-            "Label": "NumberOfMessagesReceived",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          },
-          {
-            "Id": "num_msg_deleted",
-            "Label": "NumberOfMessagesDeleted",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created[json]": {
-    "recorded-date": "19-09-2025, 21:29:00",
-    "recorded-content": {
-      "get_metric_data": {
-        "Messages": [],
-        "MetricDataResults": [
-          {
-            "Id": "sent",
-            "Label": "NumberOfMessagesSent",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          },
-          {
-            "Id": "sent_size",
-            "Label": "SentMessageSize",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              5.0
-            ]
-          },
-          {
-            "Id": "empty_receives",
-            "Label": "NumberOfEmptyReceives",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_metric_data_2": {
-        "Messages": [],
-        "MetricDataResults": [
-          {
-            "Id": "num_msg_received",
-            "Label": "NumberOfMessagesReceived",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          },
-          {
-            "Id": "num_msg_deleted",
-            "Label": "NumberOfMessagesDeleted",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created[smithy-rpc-v2-cbor]": {
-    "recorded-date": "19-09-2025, 21:31:00",
-    "recorded-content": {
-      "get_metric_data": {
-        "Messages": [],
-        "MetricDataResults": [
-          {
-            "Id": "sent",
-            "Label": "NumberOfMessagesSent",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          },
-          {
-            "Id": "sent_size",
-            "Label": "SentMessageSize",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              5.0
-            ]
-          },
-          {
-            "Id": "empty_receives",
-            "Label": "NumberOfEmptyReceives",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_metric_data_2": {
-        "Messages": [],
-        "MetricDataResults": [
-          {
-            "Id": "num_msg_received",
-            "Label": "NumberOfMessagesReceived",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
-          },
-          {
-            "Id": "num_msg_deleted",
-            "Label": "NumberOfMessagesDeleted",
-            "StatusCode": "Complete",
-            "Timestamps": "timestamp",
-            "Values": [
-              1.0
-            ]
           }
         ],
         "ResponseMetadata": {
@@ -7019,6 +6245,265 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm": {
+    "recorded-date": "26-02-2026, 10:14:11",
+    "recorded-content": {
+      "describe-alarm": {
+        "CompositeAlarms": [],
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [
+              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
+            ],
+            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmDescription": "testing cloudwatch alarms",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [
+              {
+                "Name": "InstanceId",
+                "Value": "abc"
+              }
+            ],
+            "EvaluationPeriods": 1,
+            "InsufficientDataActions": [],
+            "MetricName": "my-metric1",
+            "Namespace": "<namespace:1>",
+            "OKActions": [
+              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
+            ],
+            "Period": 10,
+            "StateReason": "Unchecked: Initial alarm creation",
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "INSUFFICIENT_DATA",
+            "Statistic": "Average",
+            "Threshold": 21.0,
+            "TreatMissingData": "ignore",
+            "Unit": "Seconds"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "alarm-triggered-sqs-msg": {
+        "AWSAccountId": "111111111111",
+        "ActionExecutedAfterMuteWindow": false,
+        "AlarmActions": [
+          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
+        ],
+        "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+        "AlarmConfigurationUpdatedTimestamp": "date",
+        "AlarmDescription": "testing cloudwatch alarms",
+        "AlarmName": "<alarm-name:1>",
+        "InsufficientDataActions": [],
+        "NewStateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
+        "NewStateValue": "ALARM",
+        "OKActions": [
+          "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
+        ],
+        "OldStateValue": "INSUFFICIENT_DATA",
+        "Region": "<region-name-full:1>",
+        "StateChangeTime": "date",
+        "Trigger": {
+          "ComparisonOperator": "GreaterThanThreshold",
+          "Dimensions": [
+            {
+              "name": "InstanceId",
+              "value": "abc"
+            }
+          ],
+          "EvaluateLowSampleCountPercentile": "",
+          "EvaluationPeriods": 1,
+          "MetricName": "my-metric1",
+          "Namespace": "<namespace:1>",
+          "Period": 10,
+          "Statistic": "AVERAGE",
+          "StatisticType": "Statistic",
+          "Threshold": 21.0,
+          "TreatMissingData": "ignore",
+          "Unit": "Seconds"
+        }
+      },
+      "describe-alarm-history": {
+        "AlarmHistoryItems": [
+          {
+            "AlarmName": "<alarm-name:1>",
+            "AlarmType": "MetricAlarm",
+            "HistoryData": {
+              "version": "1.0",
+              "oldState": {
+                "stateValue": "INSUFFICIENT_DATA",
+                "stateReason": "Unchecked: Initial alarm creation"
+              },
+              "newState": {
+                "stateValue": "ALARM",
+                "stateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
+                "stateReasonData": {
+                  "version": "1.0",
+                  "queryDate": "date",
+                  "startDate": "date",
+                  "unit": "Seconds",
+                  "statistic": "Average",
+                  "period": 10,
+                  "recentDatapoints": [
+                    21.5
+                  ],
+                  "threshold": 21.0,
+                  "evaluatedDatapoints": [
+                    {
+                      "timestamp": "date",
+                      "sampleCount": 2.0,
+                      "value": 21.5
+                    }
+                  ]
+                }
+              }
+            },
+            "HistoryItemType": "StateUpdate",
+            "HistorySummary": "Alarm updated from INSUFFICIENT_DATA to ALARM",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-alarms-for-metric": {
+        "MetricAlarms": [
+          {
+            "ActionsEnabled": true,
+            "AlarmActions": [
+              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
+            ],
+            "AlarmArn": "arn:<partition>:cloudwatch:<region>:111111111111:alarm:<alarm-name:1>",
+            "AlarmConfigurationUpdatedTimestamp": "timestamp",
+            "AlarmDescription": "testing cloudwatch alarms",
+            "AlarmName": "<alarm-name:1>",
+            "ComparisonOperator": "GreaterThanThreshold",
+            "Dimensions": [
+              {
+                "Name": "InstanceId",
+                "Value": "abc"
+              }
+            ],
+            "EvaluationPeriods": 1,
+            "InsufficientDataActions": [],
+            "MetricName": "my-metric1",
+            "Namespace": "<namespace:1>",
+            "OKActions": [
+              "arn:<partition>:sns:<region>:111111111111:<topic_arn>"
+            ],
+            "Period": 10,
+            "StateReason": "Threshold Crossed: 1 datapoint [21.5 (MM/DD/YY HH:MM:SS)] was greater than the threshold (21.0).",
+            "StateReasonData": {
+              "version": "1.0",
+              "queryDate": "date",
+              "startDate": "date",
+              "unit": "Seconds",
+              "statistic": "Average",
+              "period": 10,
+              "recentDatapoints": [
+                21.5
+              ],
+              "threshold": 21.0,
+              "evaluatedDatapoints": [
+                {
+                  "timestamp": "date",
+                  "sampleCount": 2.0,
+                  "value": 21.5
+                }
+              ]
+            },
+            "StateTransitionedTimestamp": "timestamp",
+            "StateUpdatedTimestamp": "timestamp",
+            "StateValue": "ALARM",
+            "Statistic": "Average",
+            "Threshold": 21.0,
+            "TreatMissingData": "ignore",
+            "Unit": "Seconds"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created": {
+    "recorded-date": "26-02-2026, 12:06:25",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "sent",
+            "Label": "NumberOfMessagesSent",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          },
+          {
+            "Id": "sent_size",
+            "Label": "SentMessageSize",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              5.0
+            ]
+          },
+          {
+            "Id": "empty_receives",
+            "Label": "NumberOfEmptyReceives",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_metric_data_2": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "num_msg_received",
+            "Label": "NumberOfMessagesReceived",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          },
+          {
+            "Id": "num_msg_deleted",
+            "Label": "NumberOfMessagesDeleted",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
+++ b/tests/aws/services/cloudwatch/test_cloudwatch.validation.json
@@ -110,31 +110,13 @@
       "total": 0.35
     }
   },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created[json]": {
-    "last_validated_date": "2025-09-19T21:29:01+00:00",
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created": {
+    "last_validated_date": "2026-02-26T12:06:25+00:00",
     "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 119.29,
-      "teardown": 0.17,
-      "total": 119.46
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created[query]": {
-    "last_validated_date": "2025-09-19T21:27:01+00:00",
-    "durations_in_seconds": {
-      "setup": 0.53,
-      "call": 100.09,
+      "setup": 0.5,
+      "call": 90.98,
       "teardown": 0.19,
-      "total": 100.81
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created[smithy-rpc-v2-cbor]": {
-    "last_validated_date": "2025-09-19T21:31:00+00:00",
-    "durations_in_seconds": {
-      "setup": 0.0,
-      "call": 119.3,
-      "teardown": 0.22,
-      "total": 119.52
+      "total": 91.67
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_breaching_alarm_actions[json]": {
@@ -1298,31 +1280,13 @@
       "total": 1.37
     }
   },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm[json]": {
-    "last_validated_date": "2025-09-19T21:08:43+00:00",
+  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm": {
+    "last_validated_date": "2026-02-26T10:14:12+00:00",
     "durations_in_seconds": {
-      "setup": 0.14,
-      "call": 17.57,
-      "teardown": 1.17,
-      "total": 18.88
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm[query]": {
-    "last_validated_date": "2025-09-19T21:08:24+00:00",
-    "durations_in_seconds": {
-      "setup": 0.96,
-      "call": 18.11,
-      "teardown": 1.08,
-      "total": 20.15
-    }
-  },
-  "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm[smithy-rpc-v2-cbor]": {
-    "last_validated_date": "2025-09-19T21:09:02+00:00",
-    "durations_in_seconds": {
-      "setup": 0.16,
-      "call": 17.47,
-      "teardown": 1.2,
-      "total": 18.83
+      "setup": 1.02,
+      "call": 54.49,
+      "teardown": 1.48,
+      "total": 56.99
     }
   },
   "tests/aws/services/cloudwatch/test_cloudwatch.py::TestCloudwatch::test_put_metric_alarm_escape_character[json]": {


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
We have been seeing `test_put_metric_alarm` being flaky for a long while now. This has been a bit exacerbated by the fact that we run 3 versions of the test for each protocol CloudWatch supports (query, json and cbor)

I tracked down the issue to be because the way we collected SQS messages, and a rare condition that could happen:

If you put the metrics at the same time the alarm scheduled task which fetch those metrics, you might end up with an alarm state that is "OK", because it only picked up half the metrics. This is fine, it somewhat means the alarm was executed before those metrics were put. When CloudWatch re-run the alarm scheduler task, this time it will properly trigger the alarm on the second time. But our SQS snapshot helper was only fetching the first message and not deleting it, so it would stay with the "OK" message notification and fail, even though the right ALARM message was there, as shown by the logs:

Here are the full failing log, [from this run](https://github.com/localstack/localstack/actions/runs/22425965416/job/64935185020):

This file contains the only relevant part, detailed under:
[sqs-cloudwatch.txt](https://github.com/user-attachments/files/25575590/sqs-cloudwatch.txt)


What the flow is:
-> PutMetrics with 2 metrics
-> Scheduler fetches the metrics, fetches only the first metric (executed at the same time, this is fine)
-> Alarm state is then OK
-> Publish OK notification
-> Helper calls SQS ReceiveMessage continuously
-> Scheduler fetches the metrics, triggers the Alarm
-> Alarm state is now ALARM
-> Publish ALARM notification
-> The helper is only fetching the first message, does not delete it, and never sees the ALARM notification
-> Test fails

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- update the cloudwatch snapshot helper to clean up SQS messages
- add some comments with one case I didn't see in the snapshots
- remove some parametrization for long running tests, those areas are already covered by other tests so no need to run all 3 protocols for them
<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
