### PR TITLE
typing: update Events and STS typing

### DIFF
--- a/localstack-core/localstack/services/events/event_bus.py
+++ b/localstack-core/localstack/services/events/event_bus.py
@@ -1,6 +1,6 @@
 import json
 from datetime import UTC, datetime
-from typing import Self
+from typing import Any, Self
 
 from localstack.aws.api.events import (
     Action,
@@ -12,7 +12,7 @@ from localstack.aws.api.events import (
     StatementId,
     TagList,
 )
-from localstack.services.events.models import EventBus, ResourcePolicy, RuleDict, Statement
+from localstack.services.events.models import EventBus, ResourcePolicy, RuleDict
 from localstack.utils.aws.arns import get_partition
 
 
@@ -111,21 +111,20 @@ class EventBusService:
         principal: Principal,
         resource_arn: Arn,
         condition: Condition,
-    ) -> Statement:
+    ) -> dict[str, Any]:
         # TODO: cover via test
         # if condition and principal != "*":
         #     raise ValueError("Condition can only be set when principal is '*'")
         if principal != "*":
             principal = {"AWS": f"arn:{get_partition(self.event_bus.region)}:iam::{principal}:root"}
-        statement = Statement(
-            Sid=statement_id,
-            Effect="Allow",
-            Principal=principal,
-            Action=action,
-            Resource=resource_arn,
-            Condition=condition,
-        )
-        return statement
+        return {
+            "Sid": statement_id,
+            "Effect": "Allow",
+            "Principal": principal,
+            "Action": action,
+            "Resource": resource_arn,
+            "Condition": condition,
+        }
 
 
 EventBusServiceDict = dict[Arn, EventBusService]

--- a/localstack-core/localstack/services/events/models.py
+++ b/localstack-core/localstack/services/events/models.py
@@ -107,18 +107,9 @@ class ResourceType(Enum):
     RULE = "rule"
 
 
-class Statement(TypedDict):
-    Sid: str | None
-    Effect: str
-    Principal: str | dict[str, str] | None
-    Action: str | list[str]
-    Resource: str | list[str]
-    Condition: dict[str, Any] | None
-
-
 class ResourcePolicy(TypedDict):
     Version: str
-    Statement: list[Statement]
+    Statement: list[dict[str, Any]]
 
 
 @dataclass

--- a/localstack-core/localstack/services/sts/models.py
+++ b/localstack-core/localstack/services/sts/models.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from localstack.aws.api.sts import Tag
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
@@ -10,7 +10,7 @@ class SessionConfig(TypedDict):
     # list of lowercase transitive tag keys
     transitive_tags: list[str]
     # other stored context variables
-    iam_context: dict[str, str | list[str]]
+    iam_context: dict[str, Any]
 
 
 class STSStore(BaseStore):


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
When working on the new serialization framework, some type hints were not supported. Unions of mutable types like sequences (list, set) and other types are not supported. 

For such basic types, it is easier to make them as `dict[str, Any]`, even if it makes less readable/usable, the framework can handle that. Sorry! 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- update type hints to not have mutable container unions

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
