### PR TITLE
chore: fix test flakes

### DIFF
--- a/tests/aws/services/events/test_events_schedule.py
+++ b/tests/aws/services/events/test_events_schedule.py
@@ -416,9 +416,11 @@ class TestScheduleCron:
             "DetailType": "core.update-account-command",
             "Detail": json.dumps({"command": ["update-account"]}),
         }
-        aws_client.events.put_events(Entries=[test_event])
+        for _ in range(3):
+            aws_client.events.put_events(Entries=[test_event])
 
         messages = aws_client.sqs.receive_message(
             QueueUrl=queue_url, WaitTimeSeconds=10 if is_aws_cloud() else 3
         )
-        assert not messages.get("Messages")
+        # we switch the assertion to take into account that the rule might trigger instantly
+        assert len(messages.get("Messages") or []) < 2

--- a/tests/aws/services/events/test_events_schedule.validation.json
+++ b/tests/aws/services/events/test_events_schedule.validation.json
@@ -69,12 +69,12 @@
     "last_validated_date": "2025-01-22T13:22:43+00:00"
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleCron::tests_scheduled_rule_does_not_trigger_on_put_events": {
-    "last_validated_date": "2025-06-04T19:23:59+00:00",
+    "last_validated_date": "2026-02-27T22:37:04+00:00",
     "durations_in_seconds": {
-      "setup": 0.56,
-      "call": 11.78,
-      "teardown": 1.18,
-      "total": 13.52
+      "setup": 0.01,
+      "call": 11.95,
+      "teardown": 0.9,
+      "total": 12.86
     }
   },
   "tests/aws/services/events/test_events_schedule.py::TestScheduleRate::test_put_rule_with_invalid_schedule_rate[ rate(10 minutes)]": {

--- a/tests/aws/services/sns/test_sns.py
+++ b/tests/aws/services/sns/test_sns.py
@@ -4763,7 +4763,8 @@ class TestSNSPlatformEndpoint:
 
         # assert that message has been received
         def check_message():
-            assert len(platform_endpoint_msgs[endpoint_arn]) > 0
+            for arn in endpoints_arn.values():
+                assert len(platform_endpoint_msgs[arn]) > 0
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Spotted 2 test flakes in this run: https://github.com/localstack/localstack/actions/runs/22470898797/job/65088451006

One SNS test can be hardened by checking that both endpoints received the message instead of one. 

The EventBridge one is a bit trickier, seems like the scheduled rule could trigger at the exact moment, so we'd end up with one message. This test was written to prevent a regression: every time we would send a message, we would trigger the rule. 
It has been written now in a way that we assert that sending multiple messages does not trigger it more than than the possible once it will trigger due to the rate. 

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- harden SNS test to verify that all endpoints received messages before doing assertion
- harden EventBridge test 

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
