### PR TITLE
SNS: update store typing

### DIFF
--- a/localstack-core/localstack/services/sns/models.py
+++ b/localstack-core/localstack/services/sns/models.py
@@ -173,7 +173,9 @@ class SnsStore(BaseStore):
     subscriptions: dict[str, SnsSubscription] = LocalAttribute(default=dict)
 
     # filter policy are stored as JSON string in subscriptions, store the decoded result Dict
-    subscription_filter_policy: dict[subscriptionARN, dict[str, Any]] = LocalAttribute(default=dict)
+    subscription_filter_policy: dict[subscriptionARN, dict[str, Any] | None] = LocalAttribute(
+        default=dict
+    )
 
     # maps confirmation token to subscription ARN
     subscription_tokens: dict[str, str] = LocalAttribute(default=dict)
@@ -185,15 +187,13 @@ class SnsStore(BaseStore):
     platform_endpoints: dict[str, PlatformEndpoint] = LocalAttribute(default=dict)
 
     # cache of topic ARN to platform endpoint messages (used primarily for testing)
-    platform_endpoint_messages: dict[str, list[dict[str, str | MessageAttributeMap | None]]] = (
-        LocalAttribute(default=dict)
-    )
+    platform_endpoint_messages: dict[str, list[dict[str, Any]]] = LocalAttribute(default=dict)
 
     # topic/subscription independent default values for sending sms messages
     sms_attributes: dict[str, str] = LocalAttribute(default=dict)
 
     # list of sent SMS messages
-    sms_messages: list[dict[str, str | MessageAttributeMap | None]] = LocalAttribute(default=list)
+    sms_messages: list[dict[str, Any]] = LocalAttribute(default=list)
 
     tags: Tags = CrossRegionAttribute(default=Tags)
 


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Due to new rules in our serialization framework, we now cannot do Union of sequence/dict types with other types, due to the nature of Python not allowing the resolve their full type at runtime. 

Due to some changes upstream, they broke serialization for SNS, so we need to get this change quickly 👍 

In order to bypass this for types like that, we will serialize them to JSON instead via `dict[str, Any]`. 

For `subscription_filter_policy`, previously the framework would silently swallow the fact that the `dict[str, Any]` was set to `None`. We now explicitly fail in this case, so we need to indicate that the value can also be `None`. 

Example: 
```python

value: dict[str, dict[str, Any]] = {}

# this works
value["test"] = {"test1": "test2"}
# this doesn't anymore
value["test2"] = None
# the proper type hint will be:
value: dict[str, dict[str, Any] | None] = {}
```


<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
- update typing for SNS store
<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
