### PR TITLE
remove k8s_always_run marker

### DIFF
--- a/localstack-core/localstack/testing/pytest/marking.py
+++ b/localstack-core/localstack/testing/pytest/marking.py
@@ -76,8 +76,6 @@ class Markers:
     """The test requires docker or a compatible container engine - will not work on kubernetes"""
     lambda_runtime_update = pytest.mark.lambda_runtime_update
     """Tests to execute when updating snapshots for a new Lambda runtime"""
-    k8s_always_run = pytest.mark.k8s_always_run
-    """This tests will always run against k8s environment"""
     skip_k8s = pytest.mark.skip_k8s
     """This test will be skipped in k8s environment"""
 
@@ -230,8 +228,4 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "requires_in_process: mark the test as requiring the test to run inside the same process as LocalStack - will not work if tests are run against a running LS container.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "k8s_always_run: mark the test to always run in k8s environment. This allows us to run tests that would otherwise be skipped, such as localstack_only tests.",
     )


### PR DESCRIPTION
## Motivation

The marker `k8s_always_run` was introduced to mark some non-validated tests as tests that always require running in kubernetes test pipelines. This is not needed anymore.

## Changes

Remove the marker definition.

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
