### PR TITLE
install uv in pro pipeline

### DIFF
--- a/.github/workflows/tests-pro-integration.yml
+++ b/.github/workflows/tests-pro-integration.yml
@@ -205,12 +205,6 @@ jobs:
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
           path: localstack-pro
 
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: 'localstack/.python-version'
-
       - name: Set up Node 22.x
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

With the transition to `uv` in pro package, we broke the community against pro pipeline.

This pr fixes that by removing the python-setup and cache and updating the venv location.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
