### PR TITLE
Allow specifying API call visibility with the trace_visibility() method on connect_to().

### DIFF
--- a/localstack-core/localstack/aws/connect.py
+++ b/localstack-core/localstack/aws/connect.py
@@ -5,6 +5,7 @@ This module provides the interface to perform cross-service communication betwee
 LocalStack providers.
 """
 
+import copy
 import json
 import logging
 import os
@@ -12,6 +13,7 @@ import re
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from enum import Enum
 from functools import lru_cache, partial
 from random import choice
 from socket import socket
@@ -154,6 +156,9 @@ class InternalRequestParameters(TypedDict):
     service_principal: str | None
     """Service principal making this call"""
 
+    trace_visibility: str | None
+    """Visibility of this call, for tracing purposes"""
+
 
 def dump_dto(data: InternalRequestParameters) -> str:
     # To produce a compact JSON representation of DTO, remove spaces from separators
@@ -166,6 +171,21 @@ def load_dto(data: str) -> InternalRequestParameters:
 
 
 T = TypeVar("T")
+
+
+class TraceVisibility(Enum):
+    """
+    Provides an indication of how visible this API operation should be to the user.
+    """
+
+    # Call is part of LocalStack's internal implementation. Not interesting to users.
+    LOCALSTACK = "localstack"
+
+    # Call is part of an advanced feature of AWS's mechanism (e.g. Lambda ESM)
+    AWS = "aws"
+
+    # Call is an application-level operation. Always interesting to users.
+    APPLICATION = "application"
 
 
 class MetadataRequestInjector(Generic[T]):
@@ -198,13 +218,25 @@ class MetadataRequestInjector(Generic[T]):
         :param service_principal: Service principal on which behalf the calls of this client shall be made
         :return: A new version of the MetadataRequestInjector
         """
-        if self._params is not None:
+        if self._params is not None and (
+            "_SourceArn" in self._params or "_ServicePrincipal" in self._params
+        ):
             raise TypeError("Request_data cannot be called on it's own return value")
         params = {}
         if source_arn:
             params["_SourceArn"] = source_arn
         if service_principal:
             params["_ServicePrincipal"] = service_principal
+        return MetadataRequestInjector(client=self._client, params=params)
+
+    def trace_visibility(self, visibility: TraceVisibility) -> T:
+        """
+        Returns a new client instance preset with the given trace visibility.
+
+        For example: lambda_client.trace_visibility(TraceVisibility.LOCALSTACK).invoke(...)
+        """
+        params = copy.deepcopy(self._params) if self._params is not None else {}
+        params["_TraceVisibility"] = visibility.value
         return MetadataRequestInjector(client=self._client, params=params)
 
 

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -11,6 +11,7 @@ from localstack.aws.connect import (
     ExternalAwsClientFactory,
     ExternalClientFactory,
     InternalClientFactory,
+    TraceVisibility,
     attribute_name_to_service_name,
 )
 from localstack.aws.gateway import Gateway
@@ -416,6 +417,33 @@ class TestClientFactory:
             source_arn=expected_result["source_arn"],
             service_principal=expected_result["service_principal"],
         ).list_functions()
+
+        assert test_params == expected_result
+
+    def test_call_trace_visibility(self, create_dummy_request_parameter_gateway):
+        """Test that trace visibility is correctly passed"""
+        factory = InternalClientFactory()
+        test_params = {}
+
+        def echo_request_handler(_: HandlerChain, context: RequestContext, response: Response):
+            if context.internal_request_params:
+                test_params.update(context.internal_request_params)
+            response.status_code = 200
+
+        endpoint_url = create_dummy_request_parameter_gateway([echo_request_handler])
+        clients = factory(
+            endpoint_url=endpoint_url,
+        )
+
+        expected_result = {
+            "service_principal": "apigateway",
+            "source_arn": "arn:aws:apigateway:us-east-1::/apis/a1a1a1a1",
+            "trace_visibility": "aws",
+        }
+        clients.lambda_.request_metadata(
+            source_arn=expected_result["source_arn"],
+            service_principal=expected_result["service_principal"],
+        ).trace_visibility(TraceVisibility.AWS).list_functions()
 
         assert test_params == expected_result
 


### PR DESCRIPTION
## Motivation

We need to distinguish between internal API calls that are user visible, from those that happen because a service is relying on another service for its internal operations. For example, a `GetPolicy` API call might be invoked implicitly by the IAM service, rather than by user code. In this case, we want to flag the API call as being implicit to LocalStack, rather than explicit in the user's code.

## Changes

* Add the `trace_visibility()` method that can be chained to `connect_to()` in order to specify the visibility.
* Include the `trace_visibility` field inside the `x-localstack-data` HTTP header.

## Tests

* Added unit test to validate that `trace_visibility` is correctly passed.
* Visually reviewed the LocalStack logs to ensure the flag is being set correctly.

## Related

* Part of [DRG-562](https://linear.app/localstack/issue/DRG-562/implement-header-based-approach-of-declaring-span-visibility)

